### PR TITLE
Add reminder to run devenv sync via git commit hook that added via `devenv sync`

### DIFF
--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+red="$(tput setaf 1)"
+yellow="$(tput setaf 3)"
+bold="$(tput bold)"
+reset="$(tput sgr0)"
+
+files_changed_upstream="$(mktemp)"
+# shellcheck disable=SC2064
+trap "rm -f $files_changed_upstream" EXIT
+
+git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD >"$files_changed_upstream"
+
+grep_pattern="requirements-dev-frozen.txt|migrations"
+if [[ "$SENTRY_DEVENV_SKIP_FRONTEND" != "1" ]]; then
+  grep_pattern+="|pnpm-lock.yaml"
+fi
+
+if grep -E --quiet "$grep_pattern" "$files_changed_upstream"; then
+  cat <<EOF
+
+[${red}${bold}!!!${reset}] ${red} It looks like some dependencies have changed. Run devenv sync to resync your environment.${reset}
+
+EOF
+
+  if [[ "$SENTRY_POST_MERGE_AUTO_UPDATE" ]]; then
+    if [ -f .venv/bin/devenv ]; then
+        DEVENV=.venv/bin/devenv
+    else
+        DEVENV=devenv
+    fi
+    echo "${yellow}Automatically running devenv sync because SENTRY_POST_MERGE_AUTO_UPDATE is set.${reset}"
+    if ! command -v "$DEVENV" >/dev/null 2>&1; then
+        echo "devenv not found! install: https://github.com/getsentry/devenv#install"
+        exit 1
+    fi
+    "$DEVENV" sync
+  else
+    echo "${yellow}If you want devenv sync to be executed automatically after pulling code, you can export the SENTRY_POST_MERGE_AUTO_UPDATE variable.${reset}"
+  fi
+fi

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -12,9 +12,6 @@ trap "rm -f $files_changed_upstream" EXIT
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD >"$files_changed_upstream"
 
 grep_pattern="requirements-dev-frozen.txt|migrations"
-if [[ "$SENTRY_DEVENV_SKIP_FRONTEND" != "1" ]]; then
-  grep_pattern+="|pnpm-lock.yaml"
-fi
 
 if grep -E --quiet "$grep_pattern" "$files_changed_upstream"; then
   cat <<EOF

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,4 +1,4 @@
-from devenv.lib import config, venv
+from devenv.lib import config, venv, fs
 
 def main(context: dict[str, str]) -> int:
     reporoot = context["reporoot"]
@@ -11,5 +11,6 @@ def main(context: dict[str, str]) -> int:
     print(f"syncing venv with {requirements}...")
     venv.sync(reporoot, venv_dir, requirements, editable_paths, bins)
 
-    return 0
+    fs.ensure_symlink("../../config/hooks/post-merge", f"{reporoot}/.git/hooks/post-merge")
 
+    return 0


### PR DESCRIPTION
`config/hooks/post-merge` is copied from the `sentry` as is the line I
added to `devenc/sync.py`
