### PR TITLE
Add bundletool utils and split APKs from AAB in prep for treemap gen

### DIFF
--- a/src/launchpad/artifacts/__init__.py
+++ b/src/launchpad/artifacts/__init__.py
@@ -1,7 +1,9 @@
+from .android.aab import AAB
 from .android.apk import APK
 from .android.manifest.axml import AxmlUtils, BinaryXmlParser
 from .android.manifest.manifest import AndroidManifest
 from .android.resources.binary import BinaryResourceTable
+from .android.zipped_aab import ZippedAAB
 from .android.zipped_apk import ZippedAPK
 from .artifact import AndroidArtifact, Artifact, IOSArtifact
 from .artifact_factory import ArtifactFactory
@@ -9,6 +11,7 @@ from .ios.zipped_xcarchive import ZippedXCArchive
 from .providers.zip_provider import ZipProvider
 
 __all__ = [
+    "AAB",
     "APK",
     "ArtifactFactory",
     "Artifact",
@@ -20,5 +23,6 @@ __all__ = [
     "IOSArtifact",
     "ZipProvider",
     "ZippedAPK",
+    "ZippedAAB",
     "ZippedXCArchive",
 ]

--- a/src/launchpad/artifacts/android/aab.py
+++ b/src/launchpad/artifacts/android/aab.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-import logging
+from launchpad.utils.android.bundletool import Bundletool, DeviceSpec
+from launchpad.utils.file_utils import cleanup_directory, create_temp_directory
+from launchpad.utils.logging import get_logger
 
 from ..artifact import AndroidArtifact
 from ..providers.zip_provider import ZipProvider
+from .apk import APK
 from .manifest.manifest import AndroidManifest
 from .manifest.proto_xml import ProtoXmlUtils
 from .resources.proto import ProtobufResourceTable
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class AAB(AndroidArtifact):
@@ -20,12 +23,15 @@ class AAB(AndroidArtifact):
         """Initialize APK with raw bytes content.
 
         Args:
-            content: Raw bytes of the APK file
+            content: Raw bytes of the AAB file
         """
         super().__init__(content)
+        self._path = create_temp_directory("aab-") / "bundle.aab"
+        self._path.write_bytes(content)
         self._zip_provider = ZipProvider(content)
         self._manifest: AndroidManifest | None = None
         self._resource_table: ProtobufResourceTable | None = None
+        self._primary_apks: list[APK] | None = None
 
     def get_manifest(self) -> AndroidManifest:
         """Get the Android manifest information.
@@ -78,3 +84,27 @@ class AAB(AndroidArtifact):
         arsc_buffer = zip_file.read(arsc_file)
         self._resource_table = ProtobufResourceTable(arsc_buffer)
         return [self._resource_table]
+
+    def get_primary_apks(self, device_spec: DeviceSpec = DeviceSpec()) -> list[APK]:
+        """Split the AAB into APKS.
+
+        Args:
+            device_spec: Device specification for APK splitting
+        """
+        if self._primary_apks is not None:
+            return self._primary_apks
+
+        apks_dir = create_temp_directory("apks-")
+        try:
+            bundletool = Bundletool()
+            bundletool.build_apks(bundle_path=self._path, output_dir=apks_dir, device_spec=device_spec)
+
+            apks = []
+            for apk_path in apks_dir.glob("*.apk"):
+                with open(apk_path, "rb") as apk_file:
+                    apks.append(APK(apk_file.read()))
+
+            self._primary_apks = apks
+            return apks
+        finally:
+            cleanup_directory(apks_dir)

--- a/src/launchpad/artifacts/android/zipped_aab.py
+++ b/src/launchpad/artifacts/android/zipped_aab.py
@@ -1,6 +1,7 @@
 from ..artifact import AndroidArtifact
 from ..providers.zip_provider import ZipProvider
 from .aab import AAB
+from .apk import APK
 from .manifest.manifest import AndroidManifest
 
 
@@ -24,3 +25,6 @@ class ZippedAAB(AndroidArtifact):
                 return self._aab
 
         raise FileNotFoundError(f"No AAB found in {self._extract_dir}")
+
+    def get_primary_apks(self) -> list[APK]:
+        return self.get_aab().get_primary_apks()

--- a/src/launchpad/utils/__init__.py
+++ b/src/launchpad/utils/__init__.py
@@ -1,9 +1,12 @@
 """Utility modules for app size analyzer."""
 
+from .android.bundletool import Bundletool, DeviceSpec
 from .file_utils import calculate_file_hash, cleanup_directory, create_temp_directory, get_file_size
 from .logging import setup_logging
 
 __all__ = [
+    "Bundletool",
+    "DeviceSpec",
     "calculate_file_hash",
     "cleanup_directory",
     "create_temp_directory",

--- a/src/launchpad/utils/android/bundletool.py
+++ b/src/launchpad/utils/android/bundletool.py
@@ -41,6 +41,7 @@ class Bundletool:
         """
         if bundletool_path is None:
             try:
+                # TODO: Ensure packaged in docker image when productionizing
                 result = subprocess.run(
                     ["which", "bundletool"],
                     capture_output=True,
@@ -117,24 +118,20 @@ class Bundletool:
         build_apks_command = ["build-apks", f"--bundle={bundle_path}", f"--output={temp_apks_path}"]
 
         # Create a temporary file for the device spec JSON
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as temp_file:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as temp_file:
             json.dump(device_spec.model_dump(by_alias=True), temp_file)
             temp_device_spec_path = temp_file.name
 
-        try:
-            self._run_command(build_apks_command)
+        self._run_command(build_apks_command)
 
-            # Extract APKs for the specified device
-            extract_command = [
-                "extract-apks",
-                f"--apks={temp_apks_path}",
-                f"--output-dir={output_dir}",
-                f"--device-spec={temp_device_spec_path}",
-            ]
-            self._run_command(extract_command)
-        finally:
-            # Clean up the temporary file
-            Path(temp_device_spec_path).unlink(missing_ok=True)
+        # Extract APKs for the specified device
+        extract_command = [
+            "extract-apks",
+            f"--apks={temp_apks_path}",
+            f"--output-dir={output_dir}",
+            f"--device-spec={temp_device_spec_path}",
+        ]
+        self._run_command(extract_command)
 
 
 class DeviceSpec(BaseModel):

--- a/src/launchpad/utils/android/bundletool.py
+++ b/src/launchpad/utils/android/bundletool.py
@@ -1,0 +1,183 @@
+"""Android bundletool wrapper utilities."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Sequence
+
+from pydantic import BaseModel, Field
+
+from ..file_utils import create_temp_directory
+from ..logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class BundletoolError(Exception):
+    """Raised when bundletool command fails."""
+
+    def __init__(self, message: str, returncode: int, stdout: str, stderr: str) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class Bundletool:
+    """Wrapper around Android's bundletool CLI utility."""
+
+    def __init__(self, bundletool_path: str | Path | None = None) -> None:
+        """Initialize bundletool wrapper.
+
+        Args:
+            bundletool_path: Optional path to bundletool executable file. If not provided,
+                will attempt to find bundletool in PATH.
+
+        Raises:
+            FileNotFoundError: If bundletool cannot be found at specified path or in PATH
+        """
+        if bundletool_path is None:
+            try:
+                result = subprocess.run(
+                    ["which", "bundletool"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                bundletool_path = result.stdout.strip()
+            except subprocess.CalledProcessError as e:
+                raise FileNotFoundError("bundletool not found in PATH. Install with `brew install bundletool`") from e
+
+        self.bundletool_path = Path(bundletool_path)
+        if not self.bundletool_path.exists():
+            raise FileNotFoundError(f"bundletool not found at {bundletool_path}")
+
+    def _run_command(self, command: list[str], **kwargs: Any) -> tuple[int, str, str]:
+        """Run a bundletool command.
+
+        Args:
+            command: List of command arguments to pass to bundletool
+            **kwargs: Additional arguments to pass to subprocess.run
+
+        Returns:
+            Tuple of (returncode, stdout, stderr)
+
+        Raises:
+            BundletoolError: If command fails
+        """
+        cmd = [str(self.bundletool_path)] + command
+        logger.debug("Running bundletool command: %s", " ".join(cmd))
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                **kwargs,
+            )
+        except subprocess.SubprocessError as e:
+            raise BundletoolError(
+                f"Failed to run bundletool command: {e}",
+                -1,
+                "",
+                str(e),
+            ) from e
+
+        if result.returncode != 0:
+            raise BundletoolError(
+                f"bundletool command failed with return code {result.returncode}",
+                result.returncode,
+                result.stdout,
+                result.stderr,
+            )
+
+        return result.returncode, result.stdout, result.stderr
+
+    def build_apks(
+        self,
+        bundle_path: str | Path,
+        output_dir: str | Path,
+        device_spec: DeviceSpec,
+    ) -> None:
+        """Build APKs from an Android App Bundle.
+
+        Args:
+            bundle_path: Path to input AAB file
+            output_dir: Directory to output APKS files
+            device_spec: Device specification for APK splitting configuration.
+
+        Raises:
+            BundletoolError: If build command fails
+        """
+        temp_apks_path = create_temp_directory("apks-") / "apks.apks"
+        build_apks_command = ["build-apks", f"--bundle={bundle_path}", f"--output={temp_apks_path}"]
+
+        # Create a temporary file for the device spec JSON
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as temp_file:
+            json.dump(device_spec.model_dump(by_alias=True), temp_file)
+            temp_device_spec_path = temp_file.name
+
+        try:
+            self._run_command(build_apks_command)
+
+            # Extract APKs for the specified device
+            extract_command = [
+                "extract-apks",
+                f"--apks={temp_apks_path}",
+                f"--output-dir={output_dir}",
+                f"--device-spec={temp_device_spec_path}",
+            ]
+            self._run_command(extract_command)
+        finally:
+            # Clean up the temporary file
+            Path(temp_device_spec_path).unlink(missing_ok=True)
+
+
+class DeviceSpec(BaseModel):
+    """Device specification for APK splitting configuration.
+
+    Matches the proto definition from bundletool's device_targeting_config.proto.
+    See https://github.com/google/bundletool/blob/master/src/main/proto/devices.proto,
+    https://github.com/google/bundletool/blob/master/src/main/proto/device_targeting_config.proto
+
+    # Intentionally skipping:
+    # deviceTier
+    # glExtensions
+    # textureCompressionFormats
+    # hasGlEs3
+    # deviceFeature
+    # minScreenWidthDp
+    # maxScreenWidthDp
+    # minScreenHeightDp
+    # maxScreenHeightDp
+    """
+
+    # Required fields
+    sdk_version: int = Field(
+        default=35,
+        alias="sdkVersion",
+        description="Minimum SDK version required",
+        ge=1,  # SDK versions start at 1
+    )
+
+    # Optional fields
+    supported_abis: Sequence[str] | None = Field(
+        default=["arm64-v8a"],
+        alias="supportedAbis",
+        description="List of supported ABIs (e.g. ['arm64-v8a', 'armeabi-v7a'])",
+    )
+    supported_locales: Sequence[str] | None = Field(
+        default=["en"],
+        alias="supportedLocales",
+        description="List of supported locales (e.g. ['en', 'fr'])",
+    )
+    screen_density: int | None = Field(
+        default=420,
+        alias="screenDensity",
+        description="Screen density in dpi",
+        ge=1,  # Must be positive
+    )


### PR DESCRIPTION
In prep for Android treemap generation we'll need to first split the APKs from any AAB. This sets us up to do that. Stacked PRs will handle the basic treemap impls.