### PR TITLE
Break launchpad serve command into two separate commands for prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ legacy/ios/sizeAnalysis/.build/
 
 # in case the user is installing devenv for the first time
 install-devenv.sh
+
+# Environment files
+.env
+.env.local
+.env.*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,7 @@ USER app
 # Expose ports
 EXPOSE 2218
 
-# Default command
-CMD ["launchpad", "serve"]
+# Default to web server (can be overridden)
+# For consumer: docker run <image> launchpad consumer --prod
+# For development: docker run <image> launchpad devserver
+CMD ["launchpad", "web-server"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ DevServices provides shared Kafka infrastructure used by multiple Sentry service
 # Start shared dependencies (Kafka)
 devservices up
 
-# In another terminal, start the service
-launchpad serve
+# In another terminal, start the development service
+launchpad devserver
 
 # Or run integration tests
 make test-service-integration
@@ -96,10 +96,20 @@ Options:
 
 ### Service Development
 
+#### Local Environment Setup
+
+First, set up your local environment variables:
+
 ```bash
-# Development with shared infrastructure (recommended)
+# Copy the example environment file
+cp env.local.example .env
+```
+
+#### Development Server Options
+
+```bash
 devservices up                  # Start Kafka via devservices
-launchpad serve
+launchpad devserver             # Start combined service
 ```
 
 ### Testing
@@ -136,6 +146,25 @@ make check
 # Full CI pipeline
 make ci
 ```
+
+## Production Deployment
+
+For production Kubernetes deployments, use separate web and consumer components:
+
+```bash
+# Web server only (for web pods)
+launchpad web-server --prod --host 0.0.0.0 --port 8080
+
+# Consumer only (for worker pods)
+launchpad consumer --prod
+```
+
+This architecture allows you to:
+
+- Scale web servers independently from consumers
+- Deploy different configurations for each component
+- Optimize resource allocation per component type
+- Achieve better fault isolation
 
 ## Configuration
 

--- a/env.local.example
+++ b/env.local.example
@@ -1,0 +1,5 @@
+# Local Development Environment Variables
+# Copy this file to .env to use for local development
+
+# Kafka Configuration
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click>=8.1.0
 confluent-kafka>=2.3.0
 lief>=0.14.0
 pydantic>=2.0.0
+python-dotenv>=1.0.0
 rich>=13.0.0
 typing-extensions>=4.8.0
 pytest>=7.4.0

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -5,31 +5,86 @@ from __future__ import annotations
 import asyncio
 import logging
 import signal
-from typing import Any, Dict, Union
+from typing import Any, Dict
+
+from dotenv import load_dotenv
 
 from .kafka import KafkaConsumer, LaunchpadMessage, get_kafka_config
 from .server import LaunchpadServer, get_server_config
 
+# Load environment variables from .env file
+load_dotenv()
+
 logger = logging.getLogger(__name__)
 
 
-class LaunchpadService:
-    """Main service that orchestrates HTTP server and Kafka consumer."""
+class LaunchpadWebService:
+    """Web-only service that runs just the HTTP server."""
 
     def __init__(self) -> None:
         self.server: LaunchpadServer | None = None
-        self.kafka_consumer: KafkaConsumer | None = None
-        self._shutdown_event = asyncio.Event()
-        self._tasks: list[Union[asyncio.Task[Any], asyncio.Future[Any]]] = []
-        self._kafka_task: asyncio.Future[Any] | None = None
+        self._shutdown_initiated = False
 
     async def setup(self) -> None:
-        """Set up the service components."""
-        # Setup HTTP server
+        """Set up the web service components."""
         server_config = get_server_config()
         self.server = LaunchpadServer(host=server_config["host"], port=server_config["port"])
+        logger.info("Web service components initialized")
 
-        # Setup Kafka consumer
+    async def start(self) -> None:
+        """Start the web service."""
+        if not self.server:
+            raise RuntimeError("Service not properly initialized. Call setup() first.")
+
+        logger.info("Starting Launchpad web service...")
+
+        # Set up signal handlers for graceful shutdown
+        self._setup_signal_handlers()
+
+        # Start HTTP server (this will block until shutdown)
+        await self.server.start()
+
+        logger.info("Web service shutdown completed")
+
+    def _setup_signal_handlers(self) -> None:
+        """Set up signal handlers for graceful shutdown."""
+
+        def signal_handler() -> None:
+            if self._shutdown_initiated:
+                logger.info("Received signal during shutdown, ignoring...")
+                return
+
+            logger.info("Received shutdown signal, initiating shutdown...")
+            self._shutdown_initiated = True
+
+            if self.server:
+                self.server.shutdown()
+
+        # Use asyncio's signal handling which properly integrates with the event loop
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGINT, signal_handler)
+        loop.add_signal_handler(signal.SIGTERM, signal_handler)
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Get web service health status."""
+        return {
+            "service": "launchpad-web",
+            "status": "ok",
+            "components": {"server": {"status": "ok" if self.server else "not_initialized"}},
+        }
+
+
+class LaunchpadConsumerService:
+    """Consumer-only service that runs just the Kafka consumer."""
+
+    def __init__(self) -> None:
+        self.kafka_consumer: KafkaConsumer | None = None
+        self._shutdown_event = asyncio.Event()
+        self._kafka_task: asyncio.Future[Any] | None = None
+        self._shutdown_initiated = False
+
+    async def setup(self) -> None:
+        """Set up the consumer service components."""
         kafka_config = get_kafka_config()
         self.kafka_consumer = KafkaConsumer(
             topics=kafka_config["topics"],
@@ -37,8 +92,7 @@ class LaunchpadService:
             bootstrap_servers=kafka_config["bootstrap_servers"],
             message_handler=self.handle_kafka_message,
         )
-
-        logger.info("Service components initialized")
+        logger.info("Consumer service components initialized")
 
     def handle_kafka_message(self, message: LaunchpadMessage) -> None:
         """Handle incoming Kafka messages (synchronous wrapper)."""
@@ -80,26 +134,20 @@ class LaunchpadService:
         logger.info("Android analysis completed (stub)")
 
     async def start(self) -> None:
-        """Start all service components."""
-        if not self.server or not self.kafka_consumer:
+        """Start the consumer service."""
+        if not self.kafka_consumer:
             raise RuntimeError("Service not properly initialized. Call setup() first.")
 
-        logger.info("Starting Launchpad service...")
+        logger.info("Starting Launchpad consumer service...")
 
-        # Set up signal handlers for graceful shutdown first
+        # Set up signal handlers for graceful shutdown
         self._setup_signal_handlers()
 
-        # Start Kafka consumer in a background thread (like Snuba)
+        # Start Kafka consumer in a background thread
         loop = asyncio.get_event_loop()
         self._kafka_task = loop.run_in_executor(None, self.kafka_consumer.run)
-        # Just keep the Future in the tasks list - asyncio.gather can handle it
-        self._tasks.append(self._kafka_task)
 
-        # Start HTTP server as a background task
-        server_task = asyncio.create_task(self.server.start())
-        self._tasks.append(server_task)
-
-        logger.info("Launchpad service started successfully")
+        logger.info("Launchpad consumer service started successfully")
 
         # Wait for shutdown signal
         await self._shutdown_event.wait()
@@ -110,95 +158,115 @@ class LaunchpadService:
     def _setup_signal_handlers(self) -> None:
         """Set up signal handlers for graceful shutdown."""
 
-        def signal_handler(signum: int, frame: Any) -> None:
+        def signal_handler() -> None:
             if self._shutdown_event.is_set():
-                logger.info(f"Received signal {signum} during shutdown, ignoring...")
+                logger.info("Received signal during shutdown, ignoring...")
                 return
 
-            logger.info(f"Received signal {signum}, initiating shutdown...")
+            logger.info("Received shutdown signal, initiating shutdown...")
+            self._shutdown_initiated = True
 
-            # Signal Kafka consumer shutdown immediately (like Snuba)
+            # Signal Kafka consumer shutdown immediately
             if self.kafka_consumer:
-                try:
-                    logger.info("Signal handler: signaling Kafka consumer shutdown")
-                    self.kafka_consumer.shutdown()
-                except Exception as e:
-                    logger.warning(f"Error in signal handler stopping Kafka: {e}")
+                logger.info("Signaling Kafka consumer shutdown")
+                self.kafka_consumer.shutdown()
 
             # Cancel the kafka task directly to interrupt the executor thread
             if self._kafka_task and not self._kafka_task.done():
-                try:
-                    logger.info("Signal handler: cancelling Kafka task")
-                    self._kafka_task.cancel()
-                except Exception as e:
-                    logger.warning(f"Error cancelling Kafka task: {e}")
+                self._kafka_task.cancel()
 
             # Set the shutdown event to start async cleanup
             self._shutdown_event.set()
 
-        signal.signal(signal.SIGTERM, signal_handler)
-        signal.signal(signal.SIGINT, signal_handler)
+        # Use asyncio's signal handling which properly integrates with the event loop
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGINT, signal_handler)
+        loop.add_signal_handler(signal.SIGTERM, signal_handler)
 
     async def _cleanup(self) -> None:
-        """Clean up service resources."""
-        logger.info("Cleaning up service resources...")
+        """Clean up consumer resources."""
+        logger.info("Cleaning up consumer resources...")
 
-        # Stop Kafka consumer first (signal shutdown)
-        if self.kafka_consumer:
-            try:
-                logger.info("Signaling Kafka consumer to shutdown")
-                self.kafka_consumer.shutdown()
-                logger.info("Kafka consumer shutdown signal sent")
-            except Exception as e:
-                logger.warning(f"Error stopping Kafka consumer: {e}")
+        # Only call shutdown if it wasn't already called by signal handler
+        if self.kafka_consumer and not self._shutdown_initiated:
+            logger.info("Signaling Kafka consumer to shutdown")
+            self.kafka_consumer.shutdown()
 
-        # Stop HTTP server
-        if self.server:
+        # Wait for Kafka task to complete
+        if self._kafka_task:
             try:
-                self.server.shutdown()
-                logger.info("HTTP server stopped")
-            except Exception as e:
-                logger.warning(f"Error shutting down server: {e}")
-
-        # Wait for all tasks to complete or timeout
-        if self._tasks:
-            try:
-                logger.info("Waiting for tasks to complete...")
-                await asyncio.wait_for(asyncio.gather(*self._tasks, return_exceptions=True), timeout=5.0)
-                logger.info("All tasks completed")
+                await asyncio.wait_for(self._kafka_task, timeout=5.0)
+                logger.info("Kafka task completed")
+            except asyncio.CancelledError:
+                logger.info("Kafka task was cancelled (expected during shutdown)")
             except asyncio.TimeoutError:
-                logger.warning("Some tasks did not complete within timeout, cancelling remaining tasks")
-                # Cancel remaining tasks if they didn't complete
-                for task in self._tasks:
-                    if not task.done():
-                        logger.info(f"Cancelling task: {task}")
-                        task.cancel()
-
-                # Give cancelled tasks a moment to clean up
+                logger.warning("Kafka task did not complete within timeout, cancelling...")
+                self._kafka_task.cancel()
                 try:
-                    await asyncio.wait_for(asyncio.gather(*self._tasks, return_exceptions=True), timeout=2.0)
+                    await asyncio.wait_for(self._kafka_task, timeout=2.0)
+                    logger.info("Kafka task completed after cancellation")
+                except asyncio.CancelledError:
+                    logger.info("Kafka task was cancelled (expected)")
                 except asyncio.TimeoutError:
-                    logger.warning("Some tasks did not respond to cancellation")
+                    logger.warning("Kafka task did not respond to cancellation")
 
-        logger.info("Service cleanup completed")
+        logger.info("Consumer cleanup completed")
 
     async def health_check(self) -> Dict[str, Any]:
-        """Get overall service health status."""
-        health_status: Dict[str, Any] = {"service": "launchpad", "status": "ok", "components": {}}
+        """Get consumer service health status."""
+        health_status: Dict[str, Any] = {"service": "launchpad-consumer", "status": "ok", "components": {}}
 
         # Check Kafka health
         if self.kafka_consumer:
             kafka_health = await self.kafka_consumer.health_check()
             health_status["components"]["kafka"] = kafka_health
 
-        # Check server health
-        health_status["components"]["server"] = {"status": "ok" if self.server else "not_initialized"}
-
         return health_status
 
 
-async def run_service() -> None:
-    """Run the Launchpad service."""
-    service = LaunchpadService()
+# Backwards compatibility functions
+async def run_web_service() -> None:
+    """Run only the web service."""
+    service = LaunchpadWebService()
     await service.setup()
     await service.start()
+
+
+async def run_consumer_service() -> None:
+    """Run only the consumer service."""
+    service = LaunchpadConsumerService()
+    await service.setup()
+    await service.start()
+
+
+async def run_service() -> None:
+    """Run both web and consumer services together (for development)."""
+    logger.info("Starting combined Launchpad service...")
+
+    # Create and setup both services
+    web_service = LaunchpadWebService()
+    consumer_service = LaunchpadConsumerService()
+
+    await web_service.setup()
+    await consumer_service.setup()
+
+    logger.info("Combined service components initialized")
+
+    # Start both services as background tasks
+    web_task = asyncio.create_task(web_service.start())
+    consumer_task = asyncio.create_task(consumer_service.start())
+
+    logger.info("Combined Launchpad service started successfully")
+
+    # Wait for any task to complete (which means shutdown was triggered)
+    try:
+        await asyncio.wait([web_task, consumer_task], return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        # Cancel any remaining tasks
+        for task in [web_task, consumer_task]:
+            if not task.done():
+                task.cancel()
+
+        # Wait for cancellation to complete
+        await asyncio.gather(web_task, consumer_task, return_exceptions=True)
+        logger.info("Combined service shutdown completed")


### PR DESCRIPTION
Decouples the kafka consumer and web server as suggested here https://github.com/getsentry/launchpad/pull/16#discussion_r2145214451

For local development, you can still run `launchpad devserver` (instead of `launchpad serve`) to get both the web server and kafka consumer running together.. but now we have the two following commands:

```
launchpad web-server
launchpad consumer
```

for now ive just updated the docker image to only run the web server. More to come...