### PR TITLE
Small Makefile fixes

### DIFF
--- a/.cursor/rules/launchpad.mdc
+++ b/.cursor/rules/launchpad.mdc
@@ -61,7 +61,7 @@ This is a Python CLI tool for analyzing iOS and Android app bundle sizes, simila
 - `make help` - Show all available commands
 - `make dev-setup` - Set up development environment
 - `make test` - Run all tests (`test-unit`, `test-integration` available separately)
-- `make check` - Run all code quality checks (lint + format + type-check)
+- `make check` - Run all code quality checks (`check-lint`, `check-format`, `check-types` available separately)
 - `make ci` - Full CI pipeline
 - `make run-cli` - Run the CLI tool (use ARGS="..." for arguments)
 - `make clean` - Clean build artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   actions: read
 
 jobs:
-  lint:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -33,14 +33,14 @@ jobs:
       - name: Install dependencies
         run: make install-dev
 
-      - name: Check code formatting
+      - name: Check lint
+        run: make check-lint
+
+      - name: Check format
         run: make check-format
 
-      - name: Run linting checks
-        run: make lint
-
-      - name: Run type checking
-        run: make type-check
+      - name: Check types
+        run: make check-types
 
   test:
     runs-on: ubuntu-latest
@@ -97,7 +97,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [check, test]
 
     steps:
       - name: Checkout code

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,9 +34,11 @@ Run `make help` to see all available commands.
 - `make test-integration` - Run only integration tests
 - `make build` - Build the package
 - `make clean` - Clean build artifacts
-- `make lint` - Run code linting
-- `make format` - Format code
-- `make type-check` - Run type checking
+- `make check-lint` - Run linter
+- `make check-format` - Run formatter in 'check' mode
+- `make check-types` - Run type checking
+- `make check` - Run all the checks
+- `make fix` - Autofix everything possible (e.g. run formatter in format mode)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -146,14 +146,11 @@ make test-service-integration
 ### Code Quality
 
 ```bash
-# Format code
-make format
-
-# Lint and type check
-make lint
-
-# All quality checks (format + lint + type-check)
+# Run all quality checks (check-format + check-lint + check-types)
 make check
+
+# Autofix as many checks as possible.
+make fix
 
 # Full CI pipeline
 make ci


### PR DESCRIPTION
- Update `test` to invoke pytest on all tests. This:
  - saves paying the initaliztion cost of pytest twice
  - makes the output less visually noisy
- Remove `format` - it was an exact duplicate of `fix`.
- Rename `autofix` -> `fix`
- Rename `type-check` -> `check-types` (matching `check-format`)
- Remove `fix` from `check`. The idea being there should be:
  - one command which runs all the checks but *doesn't* modify any
    files. (`check` in this Makefile)
  - one command which autofixes all the checks (as far as possible).
    `fix` in this Makefile.
- Now we have some integration tests so remove the logic which
  displayed a message if there were none.
