### PR TITLE
Create TreemapElementBuilder pattern for implementing more granular element builders

### DIFF
--- a/src/launchpad/analyzers/android.py
+++ b/src/launchpad/analyzers/android.py
@@ -9,7 +9,7 @@ from ..models.common import FileAnalysis, FileInfo
 from ..models.treemap import FILE_TYPE_TO_TREEMAP_TYPE, TreemapType
 from ..utils.file_utils import calculate_file_hash
 from ..utils.logging import get_logger
-from ..utils.treemap_builder import TreemapBuilder
+from ..utils.treemap.treemap_builder import TreemapBuilder
 
 logger = get_logger(__name__)
 

--- a/src/launchpad/analyzers/apple.py
+++ b/src/launchpad/analyzers/apple.py
@@ -19,7 +19,7 @@ from ..parsers.apple.macho_parser import MachOParser
 from ..parsers.apple.range_mapping_builder import RangeMappingBuilder
 from ..utils.file_utils import calculate_file_hash, get_file_size
 from ..utils.logging import get_logger
-from ..utils.treemap_builder import TreemapBuilder
+from ..utils.treemap.treemap_builder import TreemapBuilder
 
 logger = get_logger(__name__)
 

--- a/src/launchpad/utils/file_utils.py
+++ b/src/launchpad/utils/file_utils.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from ..models.common import FileInfo
 from .logging import get_logger
 
 logger = get_logger(__name__)
@@ -88,3 +89,18 @@ def cleanup_directory(directory: Path) -> None:
     if directory.exists() and directory.is_dir():
         shutil.rmtree(directory)
         logger.debug(f"Cleaned up directory: {directory}")
+
+
+def calculate_aligned_install_size(file_info: FileInfo, filesystem_block_size: int) -> int:
+    """Calculate the aligned install size of a file.
+
+    Args:
+        file_info: File information
+        filesystem_block_size: Filesystem block size
+    """
+    file_size = file_info.size
+    if file_size == 0:
+        return 0
+
+    # Round up to nearest filesystem block boundary
+    return ((file_size - 1) // filesystem_block_size + 1) * filesystem_block_size

--- a/src/launchpad/utils/treemap/default_file_element_builder.py
+++ b/src/launchpad/utils/treemap/default_file_element_builder.py
@@ -1,7 +1,7 @@
 from ...models.common import FileInfo
 from ...models.treemap import TreemapElement
 from ...utils.file_utils import calculate_aligned_install_size
-from .element_builder import TreemapElementBuilder
+from .treemap_element_builder import TreemapElementBuilder
 
 
 class DefaultFileElementBuilder(TreemapElementBuilder):

--- a/src/launchpad/utils/treemap/default_file_element_builder.py
+++ b/src/launchpad/utils/treemap/default_file_element_builder.py
@@ -1,0 +1,28 @@
+from ...models.common import FileInfo
+from ...models.treemap import TreemapElement
+from ...utils.file_utils import calculate_aligned_install_size
+from .element_builder import TreemapElementBuilder
+
+
+class DefaultFileElementBuilder(TreemapElementBuilder):
+    def build_element(self, file_info: FileInfo, display_name: str) -> TreemapElement:
+        install_size = calculate_aligned_install_size(file_info, self.filesystem_block_size)
+        download_size = int(install_size * self.download_compression_ratio)
+
+        details: dict[str, object] = {
+            "hash": file_info.hash_md5,  # File hash for deduplication
+        }
+
+        # Add file extension only for actual files (not binary subsections)
+        if file_info.file_type and file_info.file_type != "unknown":
+            details["fileExtension"] = file_info.file_type
+
+        return TreemapElement(
+            name=display_name,
+            install_size=install_size,
+            download_size=download_size,
+            element_type=file_info.treemap_type,
+            path=file_info.path,
+            is_directory=False,
+            details=details,
+        )

--- a/src/launchpad/utils/treemap/element_builder.py
+++ b/src/launchpad/utils/treemap/element_builder.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ...models import FileInfo, TreemapElement
+from ..logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class TreemapElementBuilder(ABC):
+
+    def __init__(
+        self,
+        download_compression_ratio: float,
+        filesystem_block_size: int,
+    ) -> None:
+        self.download_compression_ratio = max(0.0, min(1.0, download_compression_ratio))
+        self.filesystem_block_size = filesystem_block_size
+
+    @abstractmethod
+    def build_element(self, file_info: FileInfo, display_name: str) -> TreemapElement | None:
+        """Build a treemap element for the given file.
+        @DefaultFileElementBuilder will be used if `None` returned.
+
+        Args:
+            file_info: File information
+            display_name: Display name for the element
+
+        Returns:
+            Treemap element representing the file, `None` if the file is not supported
+        """
+        pass

--- a/src/launchpad/utils/treemap/macho_element_builder.py
+++ b/src/launchpad/utils/treemap/macho_element_builder.py
@@ -1,0 +1,91 @@
+from launchpad.models.apple import MachOBinaryAnalysis
+
+from ...models.common import FileInfo
+from ...models.range_mapping import Range, RangeMap
+from ...models.treemap import TreemapElement, TreemapType
+from ..logging import get_logger
+from .element_builder import TreemapElementBuilder
+
+logger = get_logger(__name__)
+
+
+class MachOElementBuilder(TreemapElementBuilder):
+
+    def __init__(
+        self,
+        download_compression_ratio: float,
+        filesystem_block_size: int,
+        binary_analysis_map: dict[str, MachOBinaryAnalysis],
+    ) -> None:
+        super().__init__(
+            download_compression_ratio=download_compression_ratio, filesystem_block_size=filesystem_block_size
+        )
+        self.binary_analysis_map = binary_analysis_map
+
+    def build_element(self, file_info: FileInfo, display_name: str) -> TreemapElement | None:
+        if file_info.path in self.binary_analysis_map:
+            binary_analysis = self.binary_analysis_map[file_info.path]
+            if binary_analysis.range_map is not None:
+                # Create a binary treemap with sections
+                return self._build_binary_treemap(binary_analysis.range_map, display_name, file_info.path)
+            else:
+                logger.warning(f"Binary {file_info.path} found but has no range mapping")
+        else:
+            logger.warning(f"Binary {file_info.path} found but not in binary analysis map")
+
+        # Fallback to default file element if no binary analysis is available
+        return None
+
+    def _build_binary_treemap(self, range_map: RangeMap, name: str, binary_path: str | None = None) -> TreemapElement:
+        # Group ranges by tag
+        ranges_by_tag: dict[str, list[Range]] = {}
+        for range_obj in range_map.ranges:
+            tag = range_obj.tag.value
+            if tag not in ranges_by_tag:
+                ranges_by_tag[tag] = []
+            ranges_by_tag[tag].append(range_obj)
+
+        # Create child elements for each tag
+        children: list[TreemapElement] = []
+        for tag, ranges in ranges_by_tag.items():
+            total_size = sum(r.size for r in ranges)
+            children.append(
+                TreemapElement(
+                    name=tag,
+                    install_size=total_size,
+                    download_size=total_size,  # Binary sections don't compress
+                    element_type=TreemapType.EXECUTABLES,
+                    path=None,
+                    is_directory=False,
+                    children=[],
+                    details={"tag": tag},
+                )
+            )
+
+        # Add unmapped regions if any
+        if range_map.unmapped_size > 0:
+            children.append(
+                TreemapElement(
+                    name="Unmapped",
+                    install_size=int(range_map.unmapped_size),
+                    download_size=int(range_map.unmapped_size),
+                    element_type=TreemapType.UNMAPPED,
+                    path=None,
+                    is_directory=False,
+                    children=[],
+                    details={},
+                )
+            )
+
+        # Create root element
+        total_size = sum(child.install_size for child in children)
+        return TreemapElement(
+            name=name,
+            install_size=total_size,
+            download_size=total_size,
+            element_type=TreemapType.EXECUTABLES,
+            path=binary_path,
+            is_directory=True,
+            children=children,
+            details={},
+        )

--- a/src/launchpad/utils/treemap/macho_element_builder.py
+++ b/src/launchpad/utils/treemap/macho_element_builder.py
@@ -4,7 +4,7 @@ from ...models.common import FileInfo
 from ...models.range_mapping import Range, RangeMap
 from ...models.treemap import TreemapElement, TreemapType
 from ..logging import get_logger
-from .element_builder import TreemapElementBuilder
+from .treemap_element_builder import TreemapElementBuilder
 
 logger = get_logger(__name__)
 

--- a/src/launchpad/utils/treemap/treemap_builder.py
+++ b/src/launchpad/utils/treemap/treemap_builder.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Literal
 
-from launchpad.utils.treemap.element_builder import TreemapElementBuilder
+from launchpad.utils.treemap.treemap_element_builder import TreemapElementBuilder
 
 from ...models import FileAnalysis, FileInfo, MachOBinaryAnalysis, TreemapElement, TreemapResults
 from ...models.treemap import TreemapType

--- a/src/launchpad/utils/treemap/treemap_builder.py
+++ b/src/launchpad/utils/treemap/treemap_builder.py
@@ -1,5 +1,3 @@
-"""Treemap builder for creating hierarchical size analysis from file data."""
-
 from __future__ import annotations
 
 import os
@@ -7,22 +5,26 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Literal
 
-from ..models import FileAnalysis, FileInfo, MachOBinaryAnalysis, Range, RangeMap, TreemapElement, TreemapResults
-from ..models.treemap import TreemapType
-from ..utils.logging import get_logger
+from launchpad.utils.treemap.element_builder import TreemapElementBuilder
+
+from ...models import FileAnalysis, FileInfo, MachOBinaryAnalysis, TreemapElement, TreemapResults
+from ...models.treemap import TreemapType
+from ...utils.file_utils import calculate_aligned_install_size
+from ..logging import get_logger
+from .default_file_element_builder import DefaultFileElementBuilder
+from .macho_element_builder import MachOElementBuilder
 
 logger = get_logger(__name__)
 
 
 class TreemapBuilder:
-    """Builder for creating treemap structures from file analysis data."""
-
     def __init__(
         self,
         app_name: str,
         platform: Literal["ios", "android"],
         download_compression_ratio: float,
         filesystem_block_size: int | None = None,
+        # TODO: We should try to move iOS-specific logic out of this class's constructor
         binary_analysis_map: Dict[str, MachOBinaryAnalysis] | None = None,
     ) -> None:
         """Initialize the treemap builder.
@@ -75,119 +77,31 @@ class TreemapBuilder:
         )
 
     def _create_file_element(self, file_info: FileInfo, display_name: str) -> TreemapElement:
-        """Create a TreemapElement for a single file."""
-        if file_info.file_type == "macho":
-            if file_info.path in self.binary_analysis_map:
-                binary_analysis = self.binary_analysis_map[file_info.path]
-                if binary_analysis.range_map is not None:
-                    # Create a binary treemap with sections
-                    return self.build_binary_treemap(binary_analysis.range_map, display_name, file_info.path)
-                else:
-                    logger.warning(f"Binary {file_info.path} found but has no range mapping")
-            else:
-                logger.warning(f"Binary {file_info.path} found but not in binary analysis map")
-
-        # Calculate platform-aligned install size and compressed download size
-        install_size = self._calculate_aligned_install_size(file_info)
-        download_size = int(install_size * self.download_compression_ratio)
-
-        details: Dict[str, object] = {
-            "hash": file_info.hash_md5,  # File hash for deduplication
-        }
-
-        # Add file extension only for actual files (not binary subsections)
-        if file_info.file_type and file_info.file_type != "unknown":
-            details["fileExtension"] = file_info.file_type
-
-        return TreemapElement(
-            name=display_name,
-            install_size=install_size,
-            download_size=download_size,
-            element_type=file_info.treemap_type,
-            path=file_info.path,
-            is_directory=False,
-            details=details,
+        default_element_builder = DefaultFileElementBuilder(
+            download_compression_ratio=self.download_compression_ratio,
+            filesystem_block_size=self.filesystem_block_size,
         )
 
-    def build_binary_treemap(self, range_map: RangeMap, name: str, binary_path: str | None = None) -> TreemapElement:
-        """Build a treemap element from binary range mapping.
-
-        Args:
-            range_map: Range mapping for binary content
-            name: Name of the binary
-            binary_path: Optional path to the binary file
-
-        Returns:
-            Treemap element representing the binary sections
-        """
-        # Group ranges by tag
-        ranges_by_tag: Dict[str, List[Range]] = {}
-        for range_obj in range_map.ranges:
-            tag = range_obj.tag.value
-            if tag not in ranges_by_tag:
-                ranges_by_tag[tag] = []
-            ranges_by_tag[tag].append(range_obj)
-
-        # Create child elements for each tag
-        children: List[TreemapElement] = []
-        for tag, ranges in ranges_by_tag.items():
-            total_size = sum(r.size for r in ranges)
-            children.append(
-                TreemapElement(
-                    name=tag,
-                    install_size=total_size,
-                    download_size=total_size,  # Binary sections don't compress
-                    element_type=TreemapType.EXECUTABLES,
-                    path=None,
-                    is_directory=False,
-                    children=[],
-                    details={"tag": tag},
+        element_builder: TreemapElementBuilder = default_element_builder
+        match file_info.file_type:
+            case "macho":
+                element_builder = MachOElementBuilder(
+                    download_compression_ratio=self.download_compression_ratio,
+                    filesystem_block_size=self.filesystem_block_size,
+                    binary_analysis_map=self.binary_analysis_map,
                 )
+
+        logger.debug(f"Using {element_builder.__class__.__name__} for {file_info.file_type}")
+
+        element = element_builder.build_element(file_info, display_name)
+        if element is None:
+            logger.debug(
+                f"None returned from {element_builder.__class__.__name__} for {file_info.file_type}, "
+                f"using DefaultFileElementBuilder"
             )
+            element = default_element_builder.build_element(file_info, display_name)
 
-        # Add unmapped regions if any
-        if range_map.unmapped_size > 0:
-            children.append(
-                TreemapElement(
-                    name="Unmapped",
-                    install_size=int(range_map.unmapped_size),
-                    download_size=int(range_map.unmapped_size),
-                    element_type=TreemapType.UNMAPPED,
-                    path=None,
-                    is_directory=False,
-                    children=[],
-                    details={},
-                )
-            )
-
-        # Create root element
-        total_size = sum(child.install_size for child in children)
-        return TreemapElement(
-            name=name,
-            install_size=total_size,
-            download_size=total_size,
-            element_type=TreemapType.EXECUTABLES,
-            path=binary_path,
-            is_directory=True,
-            children=children,
-            details={},
-        )
-
-    def _calculate_aligned_install_size(self, file_info: FileInfo) -> int:
-        """Calculate the actual install size considering filesystem block alignment.
-
-        Args:
-            file_info: File information including size and type
-
-        Returns:
-            Install size rounded up to nearest filesystem block boundary
-        """
-        file_size = file_info.size
-        if file_size == 0:
-            return 0
-
-        # Round up to nearest filesystem block boundary
-        return ((file_size - 1) // self.filesystem_block_size + 1) * self.filesystem_block_size
+        return element
 
     def _build_file_hierarchy(self, file_analysis: FileAnalysis) -> List[TreemapElement]:
         """Build hierarchical file structure from file analysis."""
@@ -403,9 +317,8 @@ class TreemapBuilder:
 
         for file_info in file_analysis.files:
             treemap_type = file_info.treemap_type.value
-
             # Use filesystem block-aligned size for install calculations
-            install_size = self._calculate_aligned_install_size(file_info)
+            install_size = calculate_aligned_install_size(file_info, self.filesystem_block_size)
             download_size = int(install_size * self.download_compression_ratio)
 
             breakdown[treemap_type]["install"] += install_size

--- a/src/launchpad/utils/treemap/treemap_element_builder.py
+++ b/src/launchpad/utils/treemap/treemap_element_builder.py
@@ -30,4 +30,4 @@ class TreemapElementBuilder(ABC):
         Returns:
             Treemap element representing the file, `None` if the file is not supported
         """
-        pass
+        raise NotImplementedError("Not implemented")


### PR DESCRIPTION
Creates a new pattern that I felt worked well for Android treemap building - `TreemapElementBuilder`. This allows specific files to generate a treemap node in a more specific manner than others. For example, Dex will show a breakdown of classes and other info as child nodes of a single "Dex" node, which would muddy up `TreemapBuilder` if left in there. Also could allow for more siloed tests for specific treemap elements in the near future, which I'll work to add for Dex.