### PR TITLE
Minor insight tweak & cleanups

### DIFF
--- a/src/launchpad/analyzers/apple.py
+++ b/src/launchpad/analyzers/apple.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, List, Tuple
 import lief
 
 from ..artifacts import AppleArtifact, ZippedXCArchive
-from ..insights.common import DuplicateFilesInsight, InsightsInput
+from ..insights.common import DuplicateFilesInsight
+from ..insights.insight import InsightsInput
 from ..models import AppleAnalysisResults, AppleAppInfo, FileAnalysis, FileInfo, MachOBinaryAnalysis
 from ..models.apple import AppleInsightResults
 from ..models.treemap import FILE_TYPE_TO_TREEMAP_TYPE, TreemapType
@@ -128,7 +129,7 @@ class AppleAppAnalyzer:
                 treemap=treemap,
             )
             insights = AppleInsightResults(
-                duplicate_files=DuplicateFilesInsight().__call__(insights_input),
+                duplicate_files=DuplicateFilesInsight().get_results(insights_input),
             )
 
         results = AppleAnalysisResults(

--- a/src/launchpad/analyzers/apple.py
+++ b/src/launchpad/analyzers/apple.py
@@ -129,7 +129,7 @@ class AppleAppAnalyzer:
                 treemap=treemap,
             )
             insights = AppleInsightResults(
-                duplicate_files=DuplicateFilesInsight().get_results(insights_input),
+                duplicate_files=DuplicateFilesInsight().generate(insights_input),
             )
 
         results = AppleAnalysisResults(

--- a/src/launchpad/insights/common.py
+++ b/src/launchpad/insights/common.py
@@ -3,57 +3,16 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import Dict, List, Protocol, TypeVar
+from typing import Dict, List
 
-from launchpad.models.common import FileAnalysis, FileInfo
+from launchpad.insights.insight import Insight, InsightsInput
+from launchpad.models.common import FileInfo
 from launchpad.models.insights import DuplicateFilesInsightResult
-from launchpad.models.treemap import TreemapResults
-
-from ..models.apple import AppleAppInfo, MachOBinaryAnalysis
-
-T_co = TypeVar("T_co", covariant=True)
-
-
-@dataclass
-class InsightsInput:
-    app_info: AppleAppInfo
-    file_analysis: FileAnalysis
-    treemap: TreemapResults | None
-    binary_analysis: List[MachOBinaryAnalysis]
-
-
-class Insight(Protocol[T_co]):
-    """Protocol for insight functions.
-
-    Insights are functions that take analysis results and return typed insight results.
-    All data needed for the insight must be collected during the main analysis phase.
-    """
-
-    def __call__(self, input: InsightsInput) -> T_co:
-        """Generate insights from analysis results.
-
-        Args:
-            results: The analysis results to generate insights from
-
-        Returns:
-            Typed insight results
-        """
-        ...
 
 
 class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
-    """Insight for duplicate files analysis."""
 
-    def __call__(self, input: InsightsInput) -> DuplicateFilesInsightResult:
-        """Generate insights about duplicate files.
-
-        Args:
-            results: The analysis results to generate insights from
-
-        Returns:
-            Duplicate files insight results
-        """
+    def get_results(self, input: InsightsInput) -> DuplicateFilesInsightResult:
         # Group files by hash
         files_by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
         for file in input.file_analysis.files:

--- a/src/launchpad/insights/common.py
+++ b/src/launchpad/insights/common.py
@@ -12,7 +12,7 @@ from launchpad.models.insights import DuplicateFilesInsightResult
 
 class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
 
-    def get_results(self, input: InsightsInput) -> DuplicateFilesInsightResult:
+    def generate(self, input: InsightsInput) -> DuplicateFilesInsightResult:
         # Group files by hash
         files_by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
         for file in input.file_analysis.files:

--- a/src/launchpad/insights/insight.py
+++ b/src/launchpad/insights/insight.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Protocol, TypeVar
 
@@ -23,7 +24,8 @@ class Insight(Protocol[T_co]):
     All data needed for the insight must be collected during the main analysis phase.
     """
 
-    def get_results(self, input: InsightsInput) -> T_co:
+    @abstractmethod
+    def generate(self, input: InsightsInput) -> T_co:
         """Generate insights from analysis results.
 
         Args:

--- a/src/launchpad/insights/insight.py
+++ b/src/launchpad/insights/insight.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Protocol, TypeVar
+
+from ..models.apple import AppleAppInfo, MachOBinaryAnalysis
+from ..models.common import FileAnalysis
+from ..models.treemap import TreemapResults
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+@dataclass
+class InsightsInput:
+    app_info: AppleAppInfo
+    file_analysis: FileAnalysis
+    treemap: TreemapResults | None
+    binary_analysis: list[MachOBinaryAnalysis]
+
+
+class Insight(Protocol[T_co]):
+    """Protocol for insight functions.
+
+    Insights are functions that take analysis results and return typed insight results.
+    All data needed for the insight must be collected during the main analysis phase.
+    """
+
+    def get_results(self, input: InsightsInput) -> T_co:
+        """Generate insights from analysis results.
+
+        Args:
+            results: The analysis results to generate insights from
+
+        Returns:
+            Typed insight results
+        """
+        raise NotImplementedError("Not implemented")


### PR DESCRIPTION
Was reviewing https://github.com/getsentry/launchpad/pull/51/ and realized the `__call__` notation felt awkward (did some [reading](https://realpython.com/python-callable-instances/) on it). If anything, IMO we should remove `__call__` and replace with an invocation of the instance (`DuplicateFilesInsight()(insights_input)`), which feels even more awkward.

Instead I renamed it to `get_results` to make this a bit more understandable without Python callable context IMO and moved base models outside of `common.py` and removed some Cursor gen'd docs