### PR TITLE
Fix unzip

### DIFF
--- a/src/launchpad/artifacts/android/apk.py
+++ b/src/launchpad/artifacts/android/apk.py
@@ -18,14 +18,15 @@ logger = get_logger(__name__)
 class APK(AndroidArtifact):
     """Represents an Android APK file that can be analyzed."""
 
-    def __init__(self, content: bytes) -> None:
-        """Initialize APK with raw bytes content.
+    def __init__(self, path: Path, content: bytes) -> None:
+        """Initialize APK with file path.
 
         Args:
-            content: Raw bytes of the APK file
+            path: Path to the APK file
         """
         super().__init__(content)
-        self._zip_provider = ZipProvider(content)
+        self._path = path
+        self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._manifest: AndroidManifest | None = None
         self._resource_table: BinaryResourceTable | None = None

--- a/src/launchpad/artifacts/android/zipped_aab.py
+++ b/src/launchpad/artifacts/android/zipped_aab.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ..artifact import AndroidArtifact
 from ..providers.zip_provider import ZipProvider
 from .aab import AAB
@@ -6,9 +8,9 @@ from .manifest.manifest import AndroidManifest
 
 
 class ZippedAAB(AndroidArtifact):
-    def __init__(self, content: bytes) -> None:
+    def __init__(self, path: Path, content: bytes) -> None:
         super().__init__(content)
-        self._zip_provider = ZipProvider(content)
+        self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._aab: AAB | None = None
 
@@ -21,7 +23,7 @@ class ZippedAAB(AndroidArtifact):
 
         for path in self._extract_dir.rglob("*.aab"):
             if path.is_file():
-                self._aab = AAB(path.read_bytes())
+                self._aab = AAB(path, path.read_bytes())
                 return self._aab
 
         raise FileNotFoundError(f"No AAB found in {self._extract_dir}")

--- a/src/launchpad/artifacts/android/zipped_apk.py
+++ b/src/launchpad/artifacts/android/zipped_apk.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ..artifact import AndroidArtifact
 from ..providers.zip_provider import ZipProvider
 from .apk import APK
@@ -5,9 +7,10 @@ from .manifest.manifest import AndroidManifest
 
 
 class ZippedAPK(AndroidArtifact):
-    def __init__(self, content: bytes) -> None:
+    def __init__(self, path: Path, content: bytes) -> None:
         super().__init__(content)
-        self._zip_provider = ZipProvider(content)
+        self.path = path
+        self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._primary_apk: APK | None = None
 
@@ -20,7 +23,7 @@ class ZippedAPK(AndroidArtifact):
 
         for path in self._extract_dir.rglob("*.apk"):
             if path.is_file():
-                self._primary_apk = APK(path.read_bytes())
+                self._primary_apk = APK(path, path.read_bytes())
                 return self._primary_apk
 
         raise FileNotFoundError(f"No primary APK found in {self._extract_dir}")

--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -14,9 +14,9 @@ logger = get_logger(__name__)
 class ZippedXCArchive(AppleArtifact):
     """A zipped XCArchive file."""
 
-    def __init__(self, content: bytes) -> None:
+    def __init__(self, path: Path, content: bytes) -> None:
         super().__init__(content)
-        self._zip_provider = ZipProvider(content)
+        self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._app_bundle_path: Path | None = None
         self._plist: dict[str, Any] | None = None

--- a/src/launchpad/size/cli.py
+++ b/src/launchpad/size/cli.py
@@ -87,10 +87,8 @@ def size_command(
                 )
             )
 
-            input_file = stack.enter_context(open(input_path, "rb"))
-
             task = progress.add_task("Analyzing...", total=None)
-            results = do_size(input_file, **flags)
+            results = do_size(input_path, **flags)
             if output_format == "json":
                 write_results_as_json(results, output)
             else:

--- a/src/launchpad/size/runner.py
+++ b/src/launchpad/size/runner.py
@@ -1,7 +1,8 @@
 import json
 import time
 
-from typing import Any, BinaryIO, TextIO, cast
+from pathlib import Path
+from typing import Any, TextIO, cast
 
 from ..analyzers.android import AndroidAnalyzer
 from ..analyzers.apple import AppleAppAnalyzer
@@ -10,9 +11,9 @@ from ..artifacts.artifact_factory import ArtifactFactory
 from ..models.common import BaseAnalysisResults
 
 
-def do_size(input_file: BinaryIO, **flags: Any) -> BaseAnalysisResults:
+def do_size(path: Path, **flags: Any) -> BaseAnalysisResults:
     start_time = time.time()
-    artifact = ArtifactFactory.from_file(input_file)
+    artifact = ArtifactFactory.from_path(path)
 
     # isinstance switch below is a bit sad. Ryan suggested a
     # get_analyzer method on artifact which might be nicer.

--- a/tests/integration/size/test_runner.py
+++ b/tests/integration/size/test_runner.py
@@ -9,9 +9,9 @@ from launchpad.size.runner import do_size, write_results_as_json
 class TestSizeRunner:
     def test_apple(self) -> None:
         output_file = TextIOWrapper(BytesIO())
-        with open(Path("tests/_fixtures/ios/HackerNews.xcarchive.zip"), "rb") as input_file:
-            results = do_size(input_file)
-            write_results_as_json(results, output_file)
+        path = Path("tests/_fixtures/ios/HackerNews.xcarchive.zip")
+        results = do_size(path)
+        write_results_as_json(results, output_file)
 
         output_file.seek(0)
         size = json.load(output_file)
@@ -19,9 +19,9 @@ class TestSizeRunner:
 
     def test_android(self) -> None:
         output_file = TextIOWrapper(BytesIO())
-        with open(Path("tests/_fixtures/android/hn.aab"), "rb") as input_file:
-            results = do_size(input_file)
-            write_results_as_json(results, output_file)
+        path = Path("tests/_fixtures/android/hn.aab")
+        results = do_size(path)
+        write_results_as_json(results, output_file)
 
         output_file.seek(0)
         size = json.load(output_file)

--- a/tests/integration/test_treemap_generation.py
+++ b/tests/integration/test_treemap_generation.py
@@ -415,7 +415,7 @@ class TestTreemapGeneration:
         assert assets.element_type == "assets"
 
         # Verify category breakdown
-        assert treemap.category_breakdown["files"] == {"install": 122880, "download": 98298}
+        assert treemap.category_breakdown["files"] == {"install": 118784, "download": 95022}
         assert treemap.category_breakdown["assets"] == {"install": 4841472, "download": 3873176}
         assert treemap.category_breakdown["plists"] == {"install": 28672, "download": 22932}
         assert treemap.category_breakdown["executables"] == {"download": 2886859, "install": 3608576}
@@ -424,5 +424,5 @@ class TestTreemapGeneration:
         # Verify totals
         # assert treemap.total_install_size == 13278496
         # assert treemap.total_download_size == 12061966
-        assert treemap.file_count == 32
+        assert treemap.file_count == 31
         assert treemap.platform == "ios"

--- a/tests/unit/artifacts/android/test_aab.py
+++ b/tests/unit/artifacts/android/test_aab.py
@@ -13,7 +13,7 @@ def test_aab_path() -> Path:
 @pytest.fixture
 def test_aab(test_aab_path: Path) -> AAB:
     with open(test_aab_path, "rb") as f:
-        return AAB(f.read())
+        return AAB(test_aab_path, f.read())
 
 
 class TestAAB:

--- a/tests/unit/artifacts/android/test_apk.py
+++ b/tests/unit/artifacts/android/test_apk.py
@@ -13,7 +13,7 @@ def test_apk_path() -> Path:
 @pytest.fixture
 def test_apk(test_apk_path: Path) -> APK:
     with open(test_apk_path, "rb") as f:
-        return APK(f.read())
+        return APK(test_apk_path, f.read())
 
 
 class TestAPK:

--- a/tests/unit/artifacts/android/test_zipped_aab.py
+++ b/tests/unit/artifacts/android/test_zipped_aab.py
@@ -13,7 +13,7 @@ def test_zipped_aab_path() -> Path:
 @pytest.fixture
 def test_zipped_aab(test_zipped_aab_path: Path) -> ZippedAAB:
     with open(test_zipped_aab_path, "rb") as f:
-        return ZippedAAB(f.read())
+        return ZippedAAB(test_zipped_aab_path, f.read())
 
 
 class TestZippedAAB:

--- a/tests/unit/artifacts/android/test_zipped_apk.py
+++ b/tests/unit/artifacts/android/test_zipped_apk.py
@@ -13,7 +13,7 @@ def test_zipped_apk_path() -> Path:
 @pytest.fixture
 def test_zipped_apk(test_zipped_apk_path: Path) -> ZippedAPK:
     with open(test_zipped_apk_path, "rb") as f:
-        return ZippedAPK(f.read())
+        return ZippedAPK(test_zipped_apk_path, f.read())
 
 
 class TestZippedAPK:

--- a/tests/unit/test_apple_basic_info.py
+++ b/tests/unit/test_apple_basic_info.py
@@ -10,8 +10,9 @@ class TestAppleBasicInfo:
     def test_basic_info(self) -> None:
         """Test that range mapping is enabled by default."""
         analyzer = AppleAppAnalyzer()
-        with open(Path("tests/_fixtures/ios/HackerNews.xcarchive.zip"), "rb") as f:
-            archive = ZippedXCArchive(f.read())
+        path = Path("tests/_fixtures/ios/HackerNews.xcarchive.zip")
+        with open(path, "rb") as f:
+            archive = ZippedXCArchive(path, f.read())
 
         basic_info = analyzer.preprocess(archive)
         assert basic_info.name == "HackerNews"


### PR DESCRIPTION
The unzipping was not preserving symlinks, breaking the code signature of apps. This updates it to use `unzip` which supports symlinks and produces valid binaries according to `codesign`

It also fixes one of the tests which was thinking the app was larger than it really was, because it was doubling the size of the symlinked files