### PR TITLE
feat(devservices): Add ghcr image to devservices config

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -15,11 +15,13 @@ x-sentry-service-config:
     default: [kafka]
     containerized: [kafka, launchpad]
 
+x-programs:
+  devserver:
+    command: make serve
+
 services:
   launchpad:
-    build:
-      context: ..
-      dockerfile: Dockerfile
+    image: ghcr.io/getsentry/launchpad:latest
     ports:
       - 127.0.0.1:2218:2218 # Bind to localhost only - no external access
     command:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Include main dependencies
 -r requirements.txt
 
-devservices>=1.2.0
+devservices>=1.2.1
 
 # Development dependencies
 pytest>=7.4.0


### PR DESCRIPTION
This allows the sentry repo to bring up the launchpad service in a container