### PR TITLE
chore(launchpad): add clarifying comment to config.yaml

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -19,6 +19,7 @@ x-programs:
   devserver:
     command: make serve
 
+# Assuming we only have remote dependencies (currently the case), then below is only relevant when running launchpad as a dependency of the monolith.
 services:
   launchpad:
     image: ghcr.io/getsentry/launchpad:latest


### PR DESCRIPTION
This stuff is not used when running devservices within the launchpad context. it's only when launchpad is ultimately used as a dependency of another service (like the monolith)