### PR TITLE
chore(launchpad): move local dev env vars to envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -23,7 +23,6 @@ if ! command -v "$DEVENV" >/dev/null; then
   return 1
 fi
 
-
 # activate
 PATH_add "${PWD}/.devenv/bin"
 
@@ -33,3 +32,12 @@ fi
 
 export VIRTUAL_ENV="${PWD}/.venv"
 PATH_add "${PWD}/.venv/bin"
+
+# local development environment variables
+export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
+export KAFKA_GROUP_ID="launchpad-devservices"
+export KAFKA_TOPICS="preprod-artifact-events"
+export LAUNCHPAD_CREATE_KAFKA_TOPIC="1"
+export LAUNCHPAD_ENV="development"
+export LAUNCHPAD_HOST="0.0.0.0"
+export LAUNCHPAD_PORT="2218"

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,6 @@ VENV_DIR := .venv
 UV := uv
 PYTHON_VENV := $(VENV_DIR)/bin/python
 
-# local development environment variables
-export KAFKA_BOOTSTRAP_SERVERS ?= localhost:9092
-export KAFKA_GROUP_ID ?= launchpad-devservices
-export KAFKA_TOPICS ?= preprod-artifact-events
-export LAUNCHPAD_CREATE_KAFKA_TOPIC := 1
-export LAUNCHPAD_ENV ?= development
-export LAUNCHPAD_HOST ?= 0.0.0.0
-export LAUNCHPAD_PORT ?= 2218
-
 # Create virtual environment and install dependencies with uv
 $(VENV_DIR):
 	$(UV) venv


### PR DESCRIPTION
https://github.com/getsentry/launchpad/pull/66/files#r2165136889 as suggested by @hubertdeng123 

direnv is the only thing that looks at .envrc, so this should be safe