### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-        exclude: tests/_fixtures/*
+        exclude: tests/_fixtures/.*
       - id: check-merge-conflict
       - id: debug-statements
 


### PR DESCRIPTION
This resolves the warning:
```
[WARNING] The 'exclude' field in hook 'check-added-large-files' is a regex, not a glob -- matching '/*' probably isn't what you want here
```