### PR TITLE
Add Webp Optimization analysis

### DIFF
--- a/src/launchpad/analyzers/android.py
+++ b/src/launchpad/analyzers/android.py
@@ -9,6 +9,7 @@ from ..artifacts.android.zipped_apk import ZippedAPK
 from ..artifacts.artifact import AndroidArtifact
 from ..insights.common import DuplicateFilesInsight
 from ..insights.insight import InsightsInput
+from ..insights.webp_asset import WebpAssetInsight
 from ..models.android import (
     AndroidAnalysisResults,
     AndroidAppInfo,
@@ -82,9 +83,11 @@ class AndroidAnalyzer:
                 file_analysis=file_analysis,
                 treemap=treemap,
                 binary_analysis=[],
+                artifact=artifact,
             )
             insights = AndroidInsightResults(
                 duplicate_files=DuplicateFilesInsight().generate(insights_input),
+                webp_assets=WebpAssetInsight().generate(insights_input),
             )
 
         return AndroidAnalysisResults(

--- a/src/launchpad/analyzers/apple.py
+++ b/src/launchpad/analyzers/apple.py
@@ -127,6 +127,7 @@ class AppleAppAnalyzer:
                 file_analysis=file_analysis,
                 binary_analysis=binary_analysis,
                 treemap=treemap,
+                artifact=artifact,
             )
             insights = AppleInsightResults(
                 duplicate_files=DuplicateFilesInsight().generate(insights_input),

--- a/src/launchpad/insights/insight.py
+++ b/src/launchpad/insights/insight.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import List, Protocol, TypeVar
 
+from launchpad.artifacts.artifact import Artifact
 from launchpad.models.common import BaseAppInfo, BaseBinaryAnalysis, FileAnalysis
 from launchpad.models.treemap import TreemapResults
 
@@ -14,6 +15,7 @@ class InsightsInput:
     file_analysis: FileAnalysis
     treemap: TreemapResults | None
     binary_analysis: List[BaseBinaryAnalysis]
+    artifact: Artifact | None = None
 
 
 class Insight(Protocol[T_co]):

--- a/src/launchpad/insights/webp_asset.py
+++ b/src/launchpad/insights/webp_asset.py
@@ -1,0 +1,246 @@
+"""WebP asset optimization insights for Android apps."""
+
+from __future__ import annotations
+
+import tempfile
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..models.common import FileInfo
+from ..models.insights import WebpAssetInsightResult
+from ..utils.image.cwebp import Cwebp
+from ..utils.logging import get_logger
+from .common import Insight, InsightsInput
+
+logger = get_logger(__name__)
+
+SUPPORTED_IMAGE_FORMATS = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp"}
+
+MIN_IMAGE_SIZE = 4 * 1024
+
+MIN_SAVINGS_THRESHOLD = 500
+
+
+class WebpAssetInsight(Insight[WebpAssetInsightResult]):
+    def generate(self, input: InsightsInput) -> WebpAssetInsightResult:
+        """Generate WebP optimization insights from analysis results.
+
+        Args:
+            input: Analysis input containing file information
+
+        Returns:
+            WebpAssetInsightResult with optimization opportunities
+        """
+        # Store artifact reference for use in helper methods
+        self._current_artifact = input.artifact
+
+        optimization_opportunities: List[Dict[str, Any]] = []
+        total_potential_savings = 0
+
+        try:
+            cwebp = Cwebp()
+        except FileNotFoundError:
+            logger.warning("cwebp not found, skipping WebP optimization analysis")
+            return WebpAssetInsightResult(
+                optimization_opportunities=[],
+                total_potential_savings=0,
+                total_savings=0,
+            )
+
+        # Find image files that could be optimized
+        for file_info in input.file_analysis.files:
+            if not self._is_optimizable_image(file_info):
+                continue
+
+            try:
+                savings = self._analyze_image_optimization(file_info, cwebp)
+                if savings and savings["potential_savings"] >= MIN_SAVINGS_THRESHOLD:
+                    optimization_opportunities.append(savings)
+                    total_potential_savings += savings["potential_savings"]
+            except Exception as e:
+                logger.debug(f"Failed to analyze image {file_info.path}: {e}")
+                continue
+
+        optimization_opportunities.sort(key=lambda x: x["potential_savings"], reverse=True)
+
+        return WebpAssetInsightResult(
+            optimization_opportunities=optimization_opportunities,
+            total_potential_savings=total_potential_savings,
+            total_savings=total_potential_savings,
+        )
+
+    def _is_optimizable_image(self, file_info: FileInfo) -> bool:
+        """Check if a file is an optimizable image.
+
+        Args:
+            file_info: File information
+
+        Returns:
+            True if the file can be optimized with WebP
+        """
+        file_path = Path(file_info.path.lower())
+        if file_path.suffix not in SUPPORTED_IMAGE_FORMATS:
+            return False
+
+        if file_path.suffix == ".webp":
+            return False
+
+        if file_path.name.endswith(".9.png"):
+            return False
+
+        if file_info.size < MIN_IMAGE_SIZE:
+            return False
+
+        path_str = file_info.path.lower()
+        if not any(
+            directory in path_str
+            for directory in [
+                "res/",
+                "assets/",
+            ]
+        ):
+            return False
+
+        return True
+
+    def _analyze_image_optimization(self, file_info: FileInfo, cwebp: Cwebp) -> Optional[Dict[str, Any]]:
+        """Analyze a single image for WebP optimization potential.
+
+        Args:
+            file_info: File information for the image
+            cwebp: Cwebp instance for compression
+
+        Returns:
+            Dictionary with optimization details or None if no optimization possible
+        """
+        original_size = file_info.size
+        file_path = Path(file_info.path)
+        file_extension = file_path.suffix.lower()
+
+        try:
+            with tempfile.NamedTemporaryFile(suffix=file_extension, delete=False) as temp_input:
+                temp_input_path = Path(temp_input.name)
+
+            with tempfile.NamedTemporaryFile(suffix=".webp", delete=False) as temp_output:
+                temp_output_path = Path(temp_output.name)
+
+            try:
+                if not self._extract_image_from_artifact(file_info, temp_input_path):
+                    logger.debug(f"Failed to extract image {file_info.path} from APK")
+                    return None
+
+                webp_size = self._compress_image_with_cwebp(temp_input_path, temp_output_path, cwebp)
+
+                if webp_size is None:
+                    logger.debug(f"Failed to compress image {file_info.path} with cwebp")
+                    return None
+
+                potential_savings = original_size - webp_size
+
+                # Only suggest optimization if savings are significant
+                if potential_savings >= MIN_SAVINGS_THRESHOLD:
+                    return {
+                        "file_path": file_info.path,
+                        "original_size": original_size,
+                        "webp_size": webp_size,
+                        "potential_savings": potential_savings,
+                        "compression_ratio": webp_size / original_size,
+                        "file_type": file_extension,
+                    }
+
+                return None
+
+            finally:
+                # Clean up temporary files
+                try:
+                    temp_input_path.unlink(missing_ok=True)
+                    temp_output_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+
+        except Exception as e:
+            logger.debug(f"Error analyzing image {file_info.path}: {e}")
+            return None
+
+    def _extract_image_from_artifact(self, file_info: FileInfo, temp_input_path: Path) -> bool:
+        """Extract an image file from the artifact to a temporary location.
+
+        Args:
+            file_info: File information for the image
+            temp_input_path: Path to write the extracted image
+
+        Returns:
+            True if extraction was successful, False otherwise
+        """
+        try:
+            # Get the artifact from the insights input
+            if not hasattr(self, "_current_artifact") or self._current_artifact is None:
+                logger.debug("No artifact available for file extraction")
+                return False
+
+            from ..artifacts.android.aab import AAB
+            from ..artifacts.android.apk import APK
+            from ..artifacts.android.zipped_aab import ZippedAAB
+            from ..artifacts.android.zipped_apk import ZippedAPK
+
+            artifacts = []
+            if isinstance(self._current_artifact, AAB):
+                artifacts = self._current_artifact.get_primary_apks()
+            elif isinstance(self._current_artifact, ZippedAAB):
+                artifacts = self._current_artifact.get_primary_apks()
+            elif isinstance(self._current_artifact, ZippedAPK):
+                artifacts.append(self._current_artifact.get_primary_apk())
+            elif isinstance(self._current_artifact, APK):
+                artifacts.append(self._current_artifact)
+            else:
+                logger.debug(f"Unsupported artifact type: {type(self._current_artifact)}")
+                return False
+
+            for artifact in artifacts:
+                extract_path = artifact.get_extract_path()
+                image_path = extract_path / file_info.path
+
+                if image_path.exists() and image_path.is_file():
+                    # Copy the file to the temporary location
+                    import shutil
+
+                    shutil.copy2(image_path, temp_input_path)
+                    return True
+
+            logger.debug(f"Image file {file_info.path} not found in any APK")
+            return False
+
+        except Exception as e:
+            logger.debug(f"Error extracting image {file_info.path}: {e}")
+            return False
+
+    def _compress_image_with_cwebp(self, temp_input_path: Path, temp_output_path: Path, cwebp: Cwebp) -> Optional[int]:
+        """Compress an image using cwebp and return the compressed size.
+
+        Args:
+            temp_input_path: Path to the input image
+            temp_output_path: Path to write the compressed WebP image
+            cwebp: Cwebp instance
+
+        Returns:
+            Compressed file size in bytes, or None if compression failed
+        """
+        try:
+            args = []
+
+            args.append("-lossless")
+
+            args.extend([str(temp_input_path), "-o", str(temp_output_path)])
+
+            cwebp.run(args)
+
+            if temp_output_path.exists():
+                return temp_output_path.stat().st_size
+            else:
+                logger.debug("cwebp did not create output file")
+                return None
+
+        except Exception as e:
+            logger.debug(f"Error compressing image with cwebp: {e}")
+            return None

--- a/src/launchpad/models/android.py
+++ b/src/launchpad/models/android.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 from .common import BaseAnalysisResults, BaseAppInfo
-from .insights import DuplicateFilesInsightResult
+from .insights import DuplicateFilesInsightResult, WebpAssetInsightResult
 
 
 class AndroidAppInfo(BaseAppInfo):
@@ -13,6 +13,7 @@ class AndroidInsightResults(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     duplicate_files: DuplicateFilesInsightResult | None = Field(None, description="Duplicate files analysis")
+    webp_assets: WebpAssetInsightResult | None = Field(None, description="WebP asset optimization analysis")
 
 
 class AndroidAnalysisResults(BaseAnalysisResults):

--- a/src/launchpad/models/insights.py
+++ b/src/launchpad/models/insights.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -22,3 +22,14 @@ class DuplicateFilesInsightResult(BaseInsightResult):
     def duplicate_count(self) -> int:
         """Number of duplicate files (excluding the original)."""
         return len(self.files) - 1
+
+
+class WebpAssetInsightResult(BaseInsightResult):
+    """Results from WebP asset optimization analysis."""
+
+    optimization_opportunities: List[Dict[str, Any]] = Field(
+        ..., description="List of image files that could be optimized with WebP"
+    )
+    total_potential_savings: int = Field(
+        ..., ge=0, description="Total potential savings in bytes from WebP optimization"
+    )

--- a/src/launchpad/utils/image/cwebp.py
+++ b/src/launchpad/utils/image/cwebp.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+
+from typing import List, Optional
+
+from ..logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class CwebpError(Exception):
+    """Exception raised when cwebp operations fail."""
+
+    def __init__(self, message: str, return_code: int, stderr: str):
+        super().__init__(message)
+        self.return_code = return_code
+        self.stderr = stderr
+
+
+class Cwebp:
+    """Wrapper for the cwebp command-line tool for WebP compression."""
+
+    def __init__(self, cwebp_path: Optional[str] = None):
+        self.cwebp_path = cwebp_path or "cwebp"
+        self._verify_installation()
+
+    def _verify_installation(self) -> None:
+        try:
+            result = subprocess.run(
+                [self.cwebp_path, "-version"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            logger.debug(f"cwebp version: {result.stdout.strip()}")
+        except subprocess.CalledProcessError as e:
+            raise CwebpError(
+                f"cwebp version check failed: {e.stderr}",
+                e.returncode,
+                e.stderr,
+            )
+        except FileNotFoundError:
+            raise FileNotFoundError(f"cwebp not found. Please install WebP tools. Expected path: {self.cwebp_path}")
+
+    def run(self, args: List[str]) -> subprocess.CompletedProcess[str]:
+        """Run cwebp with the given arguments.
+
+        Args:
+            args: List of arguments to pass to cwebp
+
+        Returns:
+            CompletedProcess result
+
+        Raises:
+            CwebpError: If cwebp execution fails
+        """
+        try:
+            full_args = [self.cwebp_path] + args
+            return subprocess.run(full_args, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as e:
+            raise CwebpError(
+                f"cwebp execution failed: {e.stderr}",
+                e.returncode,
+                e.stderr,
+            )

--- a/tests/integration/test_webp_asset_integration.py
+++ b/tests/integration/test_webp_asset_integration.py
@@ -1,0 +1,71 @@
+"""Integration tests for WebP asset optimization insights."""
+
+from pathlib import Path
+
+import pytest
+
+from launchpad.analyzers.android import AndroidAnalyzer
+from launchpad.artifacts.artifact_factory import ArtifactFactory
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return Path("tests/_fixtures/")
+
+
+@pytest.fixture
+def android_fixtures(fixtures_dir: Path) -> dict[str, Path]:
+    android_dir = fixtures_dir / "android"
+    return {
+        "aab": android_dir / "hn.aab",
+        "zipped_aab": android_dir / "zipped_aab.zip",
+        "apk": android_dir / "hn.apk",
+        "zipped_apk": android_dir / "zipped_apk.zip",
+        "app-debug.apk": android_dir / "app-debug.apk",
+    }
+
+
+@pytest.fixture
+def android_analyzer() -> AndroidAnalyzer:
+    return AndroidAnalyzer()
+
+
+class TestWebpAssetIntegration:
+    """Integration tests for WebP asset optimization insights."""
+
+    def test_webp_asset_insight_with_hackernews_apk(self, android_fixtures: dict[str, Path]):
+        """Test WebP asset insight with the Hacker News APK."""
+        apk_path = android_fixtures["app-debug.apk"]
+
+        artifact = ArtifactFactory.from_path(apk_path)
+        analyzer = AndroidAnalyzer(skip_insights=False)
+
+        results = analyzer.analyze(artifact)
+
+        assert results.insights is not None
+        assert results.insights.webp_assets is not None
+
+        webp_insight = results.insights.webp_assets
+        assert isinstance(webp_insight.optimization_opportunities, list)
+        assert isinstance(webp_insight.total_potential_savings, int)
+        assert webp_insight.total_potential_savings > 0
+
+        opportunity = webp_insight.optimization_opportunities[0]
+        assert "file_path" in opportunity
+        assert "original_size" in opportunity
+        assert "webp_size" in opportunity
+        assert "potential_savings" in opportunity
+        assert "compression_ratio" in opportunity
+        assert "file_type" in opportunity
+
+        assert isinstance(opportunity["file_path"], str)
+        assert isinstance(opportunity["original_size"], int)
+        assert isinstance(opportunity["webp_size"], int)
+        assert isinstance(opportunity["potential_savings"], int)
+        assert isinstance(opportunity["compression_ratio"], float)
+        assert isinstance(opportunity["file_type"], str)
+
+        # Verify logical constraints
+        assert opportunity["original_size"] == 48061
+        assert opportunity["webp_size"] == 34370
+        assert opportunity["potential_savings"] == 13691

--- a/tests/unit/test_webp_asset_insight.py
+++ b/tests/unit/test_webp_asset_insight.py
@@ -1,0 +1,210 @@
+"""Tests for WebP asset optimization insights."""
+
+from unittest.mock import Mock, patch
+
+from launchpad.insights.insight import InsightsInput
+from launchpad.insights.webp_asset import MIN_IMAGE_SIZE, SUPPORTED_IMAGE_FORMATS, WebpAssetInsight
+from launchpad.models.common import BaseAppInfo, FileInfo
+from launchpad.models.insights import WebpAssetInsightResult
+from launchpad.models.treemap import TreemapType
+
+
+class TestWebpAssetInsight:
+    """Test cases for WebpAssetInsight."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.insight = WebpAssetInsight()
+
+    def test_is_optimizable_image_supported_formats(self):
+        """Test that supported image formats are identified as optimizable."""
+        for extension in SUPPORTED_IMAGE_FORMATS:
+            file_info = FileInfo(
+                path=f"res/drawable/test{extension}",
+                size=MIN_IMAGE_SIZE + 1000,
+                file_type=extension.lstrip("."),
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="test_hash",
+            )
+            assert self.insight._is_optimizable_image(file_info) is True
+
+    def test_is_optimizable_image_webp_already(self):
+        """Test that WebP files are not considered optimizable."""
+        file_info = FileInfo(
+            path="res/drawable/test.webp",
+            size=MIN_IMAGE_SIZE + 1000,
+            file_type="webp",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="test_hash",
+        )
+        assert self.insight._is_optimizable_image(file_info) is False
+
+    def test_is_optimizable_image_too_small(self):
+        """Test that very small files are not considered optimizable."""
+        file_info = FileInfo(
+            path="res/drawable/test.png",
+            size=MIN_IMAGE_SIZE - 100,
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="test_hash",
+        )
+        assert self.insight._is_optimizable_image(file_info) is False
+
+    def test_is_optimizable_image_unsupported_format(self):
+        """Test that unsupported formats are not considered optimizable."""
+        file_info = FileInfo(
+            path="res/drawable/test.gif",
+            size=MIN_IMAGE_SIZE + 1000,
+            file_type="gif",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="test_hash",
+        )
+        assert self.insight._is_optimizable_image(file_info) is False
+
+    def test_is_optimizable_image_skip_9patch(self):
+        """Test that 9-patch files are not considered optimizable."""
+        file_info = FileInfo(
+            path="res/drawable/button.9.png",
+            size=MIN_IMAGE_SIZE + 1000,
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="test_hash",
+        )
+        assert self.insight._is_optimizable_image(file_info) is False
+
+    def test_is_optimizable_image_only_res_assets_directories(self):
+        """Test that only files in res or assets directories are considered optimizable."""
+        # File in res directory - should be optimizable
+        file_info_res = FileInfo(
+            path="res/drawable/test.png",
+            size=MIN_IMAGE_SIZE + 1000,
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="test_hash",
+        )
+        assert self.insight._is_optimizable_image(file_info_res) is True
+
+        # File in assets directory - should be optimizable
+        file_info_assets = FileInfo(
+            path="assets/images/test.png",
+            size=MIN_IMAGE_SIZE + 1000,
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="test_hash",
+        )
+        assert self.insight._is_optimizable_image(file_info_assets) is True
+
+        # File in other directory - should not be optimizable
+        file_info_other = FileInfo(
+            path="lib/test.png",
+            size=MIN_IMAGE_SIZE + 1000,
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="test_hash",
+        )
+        assert self.insight._is_optimizable_image(file_info_other) is False
+
+    def test_generate_with_cwebp_available(self):
+        """Test insight generation when cwebp is available."""
+        # Create test files
+        files = [
+            FileInfo(
+                path="res/drawable/test.png",
+                size=MIN_IMAGE_SIZE + 1000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="test_hash",
+            ),
+            FileInfo(
+                path="res/drawable/test.jpg",
+                size=MIN_IMAGE_SIZE + 2000,
+                file_type="jpg",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="test_hash2",
+            ),
+        ]
+
+        # Create insights input
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=Mock(files=files),
+            treemap=Mock(),
+            binary_analysis=[],
+            artifact=Mock(),
+        )
+
+        # Generate insights
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, WebpAssetInsightResult)
+        assert len(result.optimization_opportunities) >= 0  # May be 0 if extraction fails
+        assert result.total_potential_savings >= 0
+
+    @patch("launchpad.insights.webp_asset.Cwebp")
+    def test_generate_with_cwebp_not_available(self, mock_cwebp_class):
+        """Test insight generation when cwebp is not available."""
+        # Mock cwebp to raise FileNotFoundError
+        mock_cwebp_class.side_effect = FileNotFoundError("cwebp not found")
+
+        # Create test files
+        files = [
+            FileInfo(
+                path="res/drawable/test.png",
+                size=MIN_IMAGE_SIZE + 1000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="test_hash",
+            ),
+        ]
+
+        # Create insights input
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=Mock(files=files),
+            treemap=Mock(),
+            binary_analysis=[],
+            artifact=Mock(),
+        )
+
+        # Generate insights
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, WebpAssetInsightResult)
+        assert len(result.optimization_opportunities) == 0
+        assert result.total_potential_savings == 0
+
+    def test_generate_no_optimizable_images(self):
+        """Test insight generation when no images are optimizable."""
+        # Create test files that are not optimizable
+        files = [
+            FileInfo(
+                path="test.txt",
+                size=MIN_IMAGE_SIZE + 1000,
+                file_type="txt",
+                treemap_type=TreemapType.OTHER,
+                hash_md5="test_hash",
+            ),
+            FileInfo(
+                path="test.webp",
+                size=MIN_IMAGE_SIZE + 1000,
+                file_type="webp",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="test_hash2",
+            ),
+        ]
+
+        # Create insights input
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=Mock(files=files),
+            treemap=Mock(),
+            binary_analysis=[],
+            artifact=Mock(),
+        )
+
+        # Generate insights
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, WebpAssetInsightResult)
+        assert len(result.optimization_opportunities) == 0
+        assert result.total_potential_savings == 0


### PR DESCRIPTION
This checks to see if the images could be smaller if they were optimized
with webp.
This uses the same logic as we previously had in
`WebPAssetInsightDetector.kt`

Constraints:
* only scan `png`, `jpeg`, `jpg` or `bmp`
* skip 9 patch (`.9.png`)
* only scan `res` or `asset` directories

There's a lot of code in here so I'm looking to make sure the direction
is correct.

Questions:
* Do we have a pattern that I should use for creating the temporary
  files to scan the webp?
* Do we need the unit tests? Or are the integration tests sufficient?
* I added an Artifact field to `InsightsInput` is there a better way to
  do this?
