### PR TITLE
Calculate symbol sizes

### DIFF
--- a/src/launchpad/parsers/apple/macho_symbol_sizes.py
+++ b/src/launchpad/parsers/apple/macho_symbol_sizes.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import Generator
+
+import lief
+
+from .macho_parser import MachOParser
+
+
+@dataclass
+class SymbolSize:
+    name: str
+    section: str
+    address: int
+    size: int
+
+
+class MachOSymbolSizes:
+    """Calculates the size of each symbol in the binary by using the distance-to-next-symbol heuristic."""
+
+    def __init__(self, binary: lief.MachO.Binary, macho_parser: "MachOParser") -> None:
+        self.binary = binary
+        self.macho_parser = macho_parser
+
+    def get_symbol_sizes(self) -> list[SymbolSize]:
+        """Get the symbol sizes."""
+        symbol_sizes = self._symbol_sizes(self.binary)
+        return list(symbol_sizes)
+
+    def _is_measurable(self, sym: lief.MachO.Symbol) -> bool:
+        """Keep symbols that are actually defined inside a section."""
+        return (
+            sym.origin == lief.MachO.Symbol.ORIGIN.LC_SYMTAB
+            and sym.type == lief.MachO.Symbol.TYPE.SECTION
+            and sym.value != 0
+        )
+
+    def _symbol_sizes(self, bin: lief.MachO.Binary) -> Generator[SymbolSize, None, None]:
+        """Yield (name, addr, size) via the distance-to-next-symbol heuristic."""
+
+        # sort symbols by their address so we can calculate the distance between them
+        syms = sorted((s for s in bin.symbols if self._is_measurable(s)), key=lambda s: s.value)
+
+        for idx, sym in enumerate(syms):
+            start = sym.value
+
+            section = bin.section_from_virtual_address(start)
+            max_section_addr = section.virtual_address + section.size if section else None
+
+            # Only calculate the distance between symbols in the same section
+            if max_section_addr:
+                if idx + 1 < len(syms):
+                    next_sym = syms[idx + 1]
+                    next_sym_section = bin.section_from_virtual_address(next_sym.value)
+                    end = next_sym.value if next_sym_section.name == section.name else max_section_addr
+                else:
+                    end = max_section_addr
+            else:
+                end = syms[idx + 1].value
+
+            yield SymbolSize(
+                sym.demangled_name or str(sym.name), str(section.name) if section else "n/a", start, end - start
+            )


### PR DESCRIPTION
This calculates the size of symbols by finding the distance to the next closest symbol. From what I can tell this matches the numbers output by bloaty and should be OK to use for our size analysis values.

This is reading in the Mach-O binary from provided dSYM files. In follow-up PRs I'll add support for fetching dSYM files from the xcarchive.

**Our output from a test script:**
```
tests/integration/test_macho_parser.py        Size       Address  Symbol
------------------------------------------------------------
   28.34 KB  0x0100082a60 __text  _$s9SwiftSoup20HtmlTreeBuilderStateO7processySbAA5TokenC_AA0cdE0CtKF
   16.00 KB  0x0100000000 n/a  __mh_execute_header
   11.57 KB  0x0100181ab4 __text  _$s6Sentry19decodeArbitraryData0B0SDySSSDySSypGGSgSDySSSDySSAA0cD0OGGSgyKXE_tF
   10.00 KB  0x01002c36b0 __bss  _g_memoryTestBuffer
    9.19 KB  0x01000a9fa8 __text  _$s9SwiftSoup14TokeniserStateO4readyyAA0C0C_AA15CharacterReaderCtKF
    7.58 KB  0x01000e2260 __text  -[SentryOptions validateOptions:didFailWithError:]
    5.71 KB  0x0100010e5c __text  _$s10HackerNews11LoginScreenV4bodyQrvg7SwiftUI9TupleViewVyAE0I0PAEE4fontyQrAE4FontVSgFQOyAiEE15foregroundStyleyQrqd__AE05ShapeM0Rd__lFQOyAE5ImageV_AE5ColorVQo__Qo__AiEE5frame8minWidth05idealS003maxS00R6Height0tV00uV09alignmentQr12CoreGraphics7CGFloatVSg_A5_A5_A5_A5_A5_AE9AlignmentVtFQOyAE6SpacerV_Qo_AiEE7overlay_A1_Qrqd___A7_tAeHRd__lFQOyAiEE04clipN0_5styleQrqd___AE04FillM0VtAE0N0Rd__lFQOyAiEE10background_20ignoresSafeAreaEdgesQrqd___AE4EdgeO3SetVtAeORd__lFQOyAiEE7paddingyQrA22__A5_tFQOyAiEE27textInputAutocapitalizationyQrAE27TextInputAutocapitalizationVSgFQOyAE9TextFieldVyAE4TextVG_Qo__Qo__ASQo__AE16RoundedRectangleVQo__AE06StrokenI0VyA37_AsE05EmptyI0VGQo_AiEEA11__A1_Qrqd___A7_tAeHRd__lFQOyAiEEA12__A13_Qrqd___A15_tAEA16_Rd__lFQOyAiEEA17__A18_Qrqd___A22_tAeORd__lFQOyAiEEA23_yQrA22__A5_tFQOyAE11SecureFieldVyA31_G_Qo__ASQo__A37_Qo__A43_Qo_A31_SgAE6HStackVyAGyA31__AiEE12onTapGesture5count7performQrSi_yyctFQOyA31__Qo_A9_tGGA10_AiEE8disabledyQrSbFQOyAiEE06buttonM0yQrqd__AE015PrimitiveButtonM0Rd__lFQOyAE6ButtonVyAiEEAV5width6heightA1_QrA5__A5_A7_tFQOyAiEEAvwxyZA_A0_A1_QrA5__A5_A5_A5_A5_A5_A7_tFQOyA31__Qo__Qo_G_AE023BorderedProminentButtonM0VQo__Qo_tGyXEfU_
    5.38 KB  0x010019f2a0 __text  _$s6Sentry0A28UserFeedbackWidgetButtonViewC6config6target8selectorAcA0abC13ConfigurationC_yXl10ObjectiveC8SelectorVtcfc
    5.13 KB  0x0100170664 __text  _$sSo20SentryEventDecodableC0A0E4fromABs7Decoder_p_tKcfC
```

**Bloaty output:**
```
    FILE SIZE
 --------------
   0.9%  28.3Ki    _$s9SwiftSoup20HtmlTreeBuilderStateO7processySbAA5TokenC_AA0cdE0CtKF
   0.4%  11.6Ki    _$s6Sentry19decodeArbitraryData0B0SDySSSDySSypGGSgSDySSSDySSAA0cD0OGGSgyKXE_tF
   0.3%  9.19Ki    _$s9SwiftSoup14TokeniserStateO4readyyAA0C0C_AA15CharacterReaderCtKF
   0.2%  7.58Ki    -[SentryOptions validateOptions:didFailWithError:]
   0.2%  5.71Ki    _$s10HackerNews11LoginScreenV4bodyQrvg7SwiftUI9TupleViewVyAE0I0PAEE4fontyQrAE4FontVSgFQOyAiEE15foregroundStyleyQrqd__AE05ShapeM0Rd__lFQOyAE5ImageV_AE5ColorVQo__Qo__AiEE5frame8minWidth05idealS003maxS00R6Height0tV00uV09alignmentQr12CoreGraphics7CGFloatVSg_A5_A5_A5_A5_A5_AE9AlignmentVtFQOyAE6SpacerV_Qo_AiEE7overlay_A1_Qrqd___A7_tAeHRd__lFQOyAiEE04clipN0_5styleQrqd___AE04FillM0VtAE0N0Rd__lFQOyAiEE10background_20ignoresSafeAreaEdgesQrqd___AE4EdgeO3SetVtAeORd__lFQOyAiEE7paddingyQrA22__A5_tFQOyAiEE27textInputAutocapitalizationyQrAE27TextInputAutocapitalizationVSgFQOyAE9TextFieldVyAE4TextVG_Qo__Qo__ASQo__AE16RoundedRectangleVQo__AE06StrokenI0VyA37_AsE05EmptyI0VGQo_AiEEA11__A1_Qrqd___A7_tAeHRd__lFQOyAiEEA12__A13_Qrqd___A15_tAEA16_Rd__lFQOyAiEEA17__A18_Qrqd___A22_tAeORd__lFQOyAiEEA23_yQrA22__A5_tFQOyAE11SecureFieldVyA31_G_Qo__ASQo__A37_Qo__A43_Qo_A31_SgAE6HStackVyAGyA31__AiEE12onTapGesture5count7performQrSi_yyctFQOyA31__Qo_A9_tGGA10_AiEE8disabledyQrSbFQOyAiEE06buttonM0yQrqd__AE015PrimitiveButtonM0Rd__lFQOyAE6ButtonVyAiEEAV5width6heightA1_QrA5__A5_A7_tFQOyAiEEAvwxyZA_A0_A1_QrA5__A5_A5_A5_A5_A5_A7_tFQOyA31__Qo__Qo_G_AE023BorderedProminentButtonM0VQo__Qo_tGyXEfU_
   0.2%  5.38Ki    _$s6Sentry0A28UserFeedbackWidgetButtonViewC6config6target8selectorAcA0abC13ConfigurationC_yXl10ObjectiveC8SelectorVtcfc
   0.2%  5.13Ki    _$sSo20SentryEventDecodableC0A0E4fromABs7Decoder_p_tKcfC
   0.2%  4.73Ki    _$s9SwiftSoup8DocumentC24ensureMetaCharsetElement33_6325FE4B8B02F897E63296C95BCFE5EDLLyyKF
   0.2%  4.62Ki    _setEnabled
   0.1%  3.88Ki    _$s9SwiftSoup11QueryParserC11byAttribute33_C15D272C46078A78BB4F24934DEC7488LLyyKF
   0.1%  3.73Ki    -[SentryClient prepareEvent:withScope:alwaysAttachStacktrace:isFatalEvent:]
   0.1%  3.73Ki    _$s10HackerNews14CommentsHeaderV4bodyQrvg7SwiftUI9TupleViewVyAE0I0PAEE11buttonStyleyQrqd__AE015PrimitiveButtonK0Rd__lFQOyAE0M0VyAiEE5frame8minWidth05idealP003maxP00O6Height0qS00rS09alignmentQr12CoreGraphics7CGFloatVSg_A5yE9AlignmentVtFQOyAE4TextV_Qo_G_AE05PlainmK0VQo__AE6HStackVyAGyA1__A8_yAGyAiEE010foregroundK0yQrqd__AE05ShapeK0Rd__lFQOyAiEE4fontyQrAE4FontVSgFQOyAE5ImageV_Qo__AE5ColorVQo__A1_tGGAE6SpacerVAiEE9clipShape_5styleQrqd___AE04FillK0VtAE5ShapeRd__lFQOyAiEEA9_yQrqd__AEA10_Rd__lFQOyAiEEAN5width6heightAUQrAY_AYA_tFQOyAiEE10background_20ignoresSafeAreaEdgesQrqd___AE4EdgeO3SetVtAEA10_Rd__lFQOyAE9ShareLinkVys15CollectionOfOneVySSGs5NeverOA44_AiEE7paddingyQrA37__AYtFQOyAiEEA45_yQrA37__AYtFQOyA17__Qo__Qo_G_A19_Qo__Qo__A19_Qo__AE7CapsuleVQo_AiEEA25__A26_Qrqd___A28_tAEA29_Rd__lFQOyAiEEA9_yQrqd__AEA10_Rd__lFQOyAiEEA32__A33_Qrqd___A37_tAEA10_Rd__lFQOyAiEEANA30_A31_AUQrAY_AYA_tFQOyAMyA47_G_Qo__A19_Qo__A19_Qo__A53_Qo_AE4MenuVyAiEEA25__A26_Qrqd___A28_tAEA29_Rd__lFQOyAiEEA9_yQrqd__AEA10_Rd__lFQOyAiEEA32__A33_Qrqd___A37_tAEA10_Rd__lFQOyAiEEANA30_A31_AUQrAY_AYA_tFQOyA47__Qo__A19_Qo__A19_Qo__A53_Qo_AMyA1_GGtGGAiEE12onTapGesture5count7performQrSi_yyctFQOyAiEEA25__A26_Qrqd___A28_tAEA29_Rd__lFQOyAiEEA32__A33_Qrqd___A37_tAEA10_Rd__lFQOyAiEEA45_yQrAXFQOyAE6VStackVyAGyA17__AiEE9lineLimityQrSiSgFQOyA2__Qo_tGG_Qo__A19_Qo__AE16RoundedRectangleVQo__Qo_SgtGyXEfU_A68_yXEfU0_
   0.1%  3.65Ki    __Z33sentry_serializedTraceProfileDataP12NSDictionaryIP8NSStringP11objc_objectEyyS1_S5_P7NSArrayIP15SentryDebugMetaEP9SentryHubP18SentryScreenFrames
   0.1%  3.50Ki    _$s6Sentry0A13ReplayOptionsC10dictionaryACSDySSypG_tcfc
   0.1%  3.47Ki    _$s10HackerNews14CommentsScreenV4bodyQrvg7SwiftUI4ViewPAEE7paddingyQr12CoreGraphics7CGFloatVFQOyAE10LazyVStackVyAE05TupleH0VyAgEE5frame5width6height9alignmentQrAKSg_AtE9AlignmentVtFQOyAE6SpacerV_Qo__AA0C6HeaderVAygEEAP8minWidth05idealX003maxX00W6Height0Y6Height0Z6HeightASQrAT_A5tVtFQOyAgEEApqrSQrAT_AtVtFQOyAE06_ShapeH0VyAE9RectangleVAE5ColorVG_Qo__Qo_AyE19_ConditionalContentVyAgEEAHyQrAKFQOyAgEE11scaleEffect_6anchorQrAK_AE9UnitPointVtFQOyAgEE08progressH5StyleyQrqd__AE08ProgressH5StyleRd__lFQOyAE08ProgressH0VyAE05EmptyH0VA26_G_AE016CircularProgressH5StyleVQo__Qo__Qo_AE7ForEachVySayAA12CommentStateVGs5Int64VAgEE6zIndexyQrSdFQOyAgEE7clipped11antialiasedQrSb_tFQOyAgEE10transitionyQrAE13AnyTransitionVFQOyAA10CommentRowV_Qo__Qo__Qo_SgGGtGG_Qo_yXEfU_A54_yXEfU_
   0.1%  3.32Ki    __Z20removeUnknownContextP8NSString
   0.1%  3.29Ki    +[SentrySerialization envelopeWithData:]
   0.1%  3.29Ki    -[SentrySessionReplayIntegration resumePreviousSessionReplay:]
   0.1%  3.29Ki    _$s6Sentry0A28SRDefaultBreadcrumbConverterC7convert4fromAA0A18RRWebEventProtocol_pSgSo0aC0C_tF
```