### PR TITLE
Use docker for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,62 +42,31 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Build Docker image with test fixtures
+        run: docker build --build-arg TEST_BUILD=true -t launchpad-test .
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: pyproject.toml
-
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: adopt
-
-      - name: Setup bundletool
+      - name: Run all tests in Docker
         run: |
-          curl https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar -4 -sL -o 'bundletool.jar'
-          echo '#!/bin/bash' > bundletool
-          echo 'java -jar "$(dirname "$0")/bundletool.jar" "$@"' >> bundletool
-          chmod +x bundletool
-          echo "$(pwd)" >> $GITHUB_PATH
-          ./bundletool version
+          docker run --rm \
+            -e LAUNCHPAD_ENV=development \
+            -e LAUNCHPAD_HOST=localhost \
+            -e LAUNCHPAD_PORT=2218 \
+            -e KAFKA_BOOTSTRAP_SERVERS="localhost:9092" \
+            -e KAFKA_GROUP_ID="launchpad-test" \
+            -e KAFKA_TOPICS="preprod-artifact-events" \
+            launchpad-test python -m pytest tests/ -v --tb=short
 
-      - name: Setup cwebp
+      - name: Test CLI installation and basic functionality in Docker
         run: |
-          curl -L https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0-linux-x86-64.tar.gz -o webp.tar.gz
-          tar -xzf webp.tar.gz
-          echo "$(pwd)/libwebp-1.5.0-linux-x86-64/bin" >> $GITHUB_PATH
-          ./libwebp-1.5.0-linux-x86-64/bin/cwebp -version
-
-      - name: Test cwebp
-        run: cwebp -version
-
-      - name: Install dependencies
-        run: make install-dev
-
-      - name: Run unit tests
-        run: make test-unit
-
-      - name: Run integration tests
-        run: make test-integration
-
-      - name: Test CLI installation and basic functionality
-        run: |
-          make run-cli ARGS="--help"
+          docker run --rm \
+            -e LAUNCHPAD_ENV=development \
+            -e LAUNCHPAD_HOST=localhost \
+            -e LAUNCHPAD_PORT=2218 \
+            launchpad-test launchpad --help
 
   build:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use Python 3.12 slim image
 FROM python:3.12-slim-bookworm
 
+# Build argument to determine if this is a test build
+ARG TEST_BUILD=false
+
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -11,28 +14,54 @@ ENV PYTHONUNBUFFERED=1 \
 RUN groupadd --gid 1000 app && \
     useradd --uid 1000 --gid app --shell /bin/bash --create-home app
 
-# Install system dependencies
+# Install system dependencies including JDK 17
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         git \
         build-essential \
+        openjdk-17-jdk \
+        unzip \
+        zip \
+        file \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Setup bundletool
+RUN curl https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar -4 -sL -o /usr/local/bin/bundletool.jar && \
+    echo '#!/bin/bash' > /usr/local/bin/bundletool && \
+    echo 'java -jar /usr/local/bin/bundletool.jar "$@"' >> /usr/local/bin/bundletool && \
+    chmod +x /usr/local/bin/bundletool
+
+# Setup cwebp
+RUN curl -L https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0-linux-x86-64.tar.gz -o /tmp/webp.tar.gz && \
+    tar -xzf /tmp/webp.tar.gz -C /usr/local --strip-components=1 && \
+    rm /tmp/webp.tar.gz
 
 # Set working directory
 WORKDIR /app
 
 # Copy requirements and install Python dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
 
-# Copy source code
+# Copy source code, tests, and scripts
 COPY src/ ./src/
-COPY pyproject.toml .
+COPY tests/ ./tests/
+COPY scripts/ ./scripts/
+COPY devservices/ ./devservices/
+COPY pyproject.toml pytest.ini ./
 COPY README.md .
 COPY LICENSE .
+
+# Conditionally copy test fixtures only for test builds
+RUN if [ "$TEST_BUILD" = "true" ]; then \
+        echo "Test build detected - including test fixtures"; \
+    else \
+        echo "Production build - excluding test fixtures"; \
+        rm -rf tests/_fixtures; \
+    fi
 
 RUN pip install -e .
 


### PR DESCRIPTION
There were a bunch of tools the code requires now that were not installed in the docker container, like `zip`, `unzip`, and `file`. This updates the CI tests to use the docker container and fixes the missing dependencies