### PR TITLE
Remove content in favor of path

### DIFF
--- a/src/launchpad/artifacts/android/aab.py
+++ b/src/launchpad/artifacts/android/aab.py
@@ -75,7 +75,7 @@ class AAB(AndroidArtifact):
 
             apks = []
             for apk_path in apks_dir.glob("*.apk"):
-                apks.append(APK(apk_path, apk_path.read_bytes()))
+                apks.append(APK(apk_path))
 
             self._primary_apks = apks
             return apks

--- a/src/launchpad/artifacts/android/aab.py
+++ b/src/launchpad/artifacts/android/aab.py
@@ -19,15 +19,8 @@ logger = get_logger(__name__)
 
 
 class AAB(AndroidArtifact):
-    """Represents an Android AAB file that can be analyzed."""
-
-    def __init__(self, path: Path, content: bytes) -> None:
-        """Initialize AAB with file path.
-
-        Args:
-            path: Path to the AAB file
-        """
-        super().__init__(content)
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
         self._path = path
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
@@ -36,14 +29,6 @@ class AAB(AndroidArtifact):
         self._primary_apks: list[APK] | None = None
 
     def get_manifest(self) -> AndroidManifest:
-        """Get the Android manifest information.
-
-        Returns:
-            Dictionary containing manifest information
-
-        Raises:
-            ValueError: If manifest cannot be found or parsed
-        """
         if self._manifest is not None:
             return self._manifest
 
@@ -63,14 +48,6 @@ class AAB(AndroidArtifact):
         return self._manifest
 
     def get_resource_tables(self) -> list[ProtobufResourceTable]:  # type: ignore[override]
-        """Get the resource tables from the artifact.
-
-        Returns:
-            List of resource table dictionaries
-
-        Raises:
-            ValueError: If resource tables cannot be found or parsed
-        """
         if self._resource_table is not None:
             return [self._resource_table]
 
@@ -88,11 +65,6 @@ class AAB(AndroidArtifact):
         return [self._resource_table]
 
     def get_primary_apks(self, device_spec: DeviceSpec = DeviceSpec()) -> list[APK]:
-        """Split the AAB into APKS.
-
-        Args:
-            device_spec: Device specification for APK splitting
-        """
         if self._primary_apks is not None:
             return self._primary_apks
 

--- a/src/launchpad/artifacts/android/apk.py
+++ b/src/launchpad/artifacts/android/apk.py
@@ -16,15 +16,8 @@ logger = get_logger(__name__)
 
 
 class APK(AndroidArtifact):
-    """Represents an Android APK file that can be analyzed."""
-
-    def __init__(self, path: Path, content: bytes) -> None:
-        """Initialize APK with file path.
-
-        Args:
-            path: Path to the APK file
-        """
-        super().__init__(content)
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
         self._path = path
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
@@ -32,14 +25,6 @@ class APK(AndroidArtifact):
         self._resource_table: BinaryResourceTable | None = None
 
     def get_manifest(self) -> AndroidManifest:
-        """Get the Android manifest information.
-
-        Returns:
-            Dictionary containing manifest information
-
-        Raises:
-            ValueError: If manifest cannot be found or parsed
-        """
         if self._manifest is not None:
             return self._manifest
 
@@ -59,14 +44,6 @@ class APK(AndroidArtifact):
         return self._manifest
 
     def get_resource_tables(self) -> list[BinaryResourceTable]:  # type: ignore[override]
-        """Get the resource tables from the artifact.
-
-        Returns:
-            List of resource table dictionaries
-
-        Raises:
-            ValueError: If resource tables cannot be found or parsed
-        """
         if self._resource_table is not None:
             return [self._resource_table]
 

--- a/src/launchpad/artifacts/android/zipped_aab.py
+++ b/src/launchpad/artifacts/android/zipped_aab.py
@@ -8,8 +8,8 @@ from .manifest.manifest import AndroidManifest
 
 
 class ZippedAAB(AndroidArtifact):
-    def __init__(self, path: Path, content: bytes) -> None:
-        super().__init__(content)
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._aab: AAB | None = None

--- a/src/launchpad/artifacts/android/zipped_aab.py
+++ b/src/launchpad/artifacts/android/zipped_aab.py
@@ -23,7 +23,7 @@ class ZippedAAB(AndroidArtifact):
 
         for path in self._extract_dir.rglob("*.aab"):
             if path.is_file():
-                self._aab = AAB(path, path.read_bytes())
+                self._aab = AAB(path)
                 return self._aab
 
         raise FileNotFoundError(f"No AAB found in {self._extract_dir}")

--- a/src/launchpad/artifacts/android/zipped_apk.py
+++ b/src/launchpad/artifacts/android/zipped_apk.py
@@ -7,8 +7,8 @@ from .manifest.manifest import AndroidManifest
 
 
 class ZippedAPK(AndroidArtifact):
-    def __init__(self, path: Path, content: bytes) -> None:
-        super().__init__(content)
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
         self.path = path
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()

--- a/src/launchpad/artifacts/android/zipped_apk.py
+++ b/src/launchpad/artifacts/android/zipped_apk.py
@@ -23,7 +23,7 @@ class ZippedAPK(AndroidArtifact):
 
         for path in self._extract_dir.rglob("*.apk"):
             if path.is_file():
-                self._primary_apk = APK(path, path.read_bytes())
+                self._primary_apk = APK(path)
                 return self._primary_apk
 
         raise FileNotFoundError(f"No primary APK found in {self._extract_dir}")

--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -27,10 +27,8 @@ class BinaryInfo:
 
 
 class ZippedXCArchive(AppleArtifact):
-    """A zipped XCArchive file."""
-
-    def __init__(self, path: Path, content: bytes) -> None:
-        super().__init__(content)
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._app_bundle_path: Path | None = None
@@ -39,7 +37,6 @@ class ZippedXCArchive(AppleArtifact):
         self._dsym_files: dict[str, Path] | None = None
 
     def get_plist(self) -> dict[str, Any]:
-        """Get the Info.plist contents."""
         if self._plist is not None:
             return self._plist
 

--- a/src/launchpad/artifacts/artifact.py
+++ b/src/launchpad/artifacts/artifact.py
@@ -8,8 +8,8 @@ from .android.resources.resource_table import ResourceTable
 class Artifact:
     """Base class for all artifacts that can be analyzed."""
 
-    def __init__(self, content: bytes) -> None:
-        self.content = content
+    def __init__(self, path: Path) -> None:
+        self.path = path
 
 
 class AndroidArtifact(Artifact):

--- a/src/launchpad/artifacts/artifact_factory.py
+++ b/src/launchpad/artifacts/artifact_factory.py
@@ -39,34 +39,34 @@ class ArtifactFactory:
                 # Check if zip contains a Info.plist in the root of the .xcarchive folder (ZippedXCArchive)
                 plist_files = [f for f in zip_file.namelist() if f.endswith(".xcarchive/Info.plist")]
                 if plist_files:
-                    return ZippedXCArchive(path, content)
+                    return ZippedXCArchive(path)
 
                 apk_files = [f for f in zip_file.namelist() if f.endswith(".apk")]
                 if len(apk_files) == 1:
-                    return ZippedAPK(path, content)
+                    return ZippedAPK(path)
 
                 aab_files = [f for f in zip_file.namelist() if f.endswith(".aab")]
                 if len(aab_files) == 1:
-                    return ZippedAAB(path, content)
+                    return ZippedAAB(path)
 
                 # Check if zip contains base/manifest/AndroidManifest.xml (AAB)
                 manifest_files = [f for f in zip_file.namelist() if f.endswith("base/manifest/AndroidManifest.xml")]
                 if manifest_files:
-                    return AAB(path, content)
+                    return AAB(path)
 
                 # Check if zip contains AndroidManifest.xml (APK)
                 manifest_files = [f for f in zip_file.namelist() if f.endswith("AndroidManifest.xml")]
                 if manifest_files:
-                    return APK(path, content)
+                    return APK(path)
 
         # Check if it's a direct APK or AAB by looking for AndroidManifest.xml in specific locations
         try:
             with ZipFile(BytesIO(content)) as zip_file:
                 if any(f.endswith("base/manifest/AndroidManifest.xml") for f in zip_file.namelist()):
-                    return AAB(path, content)
+                    return AAB(path)
 
                 if any(f.endswith("AndroidManifest.xml") for f in zip_file.namelist()):
-                    return APK(path, content)
+                    return APK(path)
         except Exception:
             pass
 

--- a/tests/integration/test_macho_parser.py
+++ b/tests/integration/test_macho_parser.py
@@ -9,8 +9,7 @@ from launchpad.parsers.apple.macho_parser import MachOParser
 
 
 def create_macho_parser_from_xcarchive(xcarchive_path: Path) -> MachOParser:
-    with open(xcarchive_path, "rb") as f:
-        archive = ZippedXCArchive(xcarchive_path, f.read())
+    archive = ZippedXCArchive(xcarchive_path)
 
     binary_path = archive.get_binary_path()
     assert binary_path is not None, "Failed to find main binary in xcarchive"

--- a/tests/unit/artifacts/android/test_aab.py
+++ b/tests/unit/artifacts/android/test_aab.py
@@ -12,8 +12,7 @@ def test_aab_path() -> Path:
 
 @pytest.fixture
 def test_aab(test_aab_path: Path) -> AAB:
-    with open(test_aab_path, "rb") as f:
-        return AAB(test_aab_path, f.read())
+    return AAB(test_aab_path)
 
 
 class TestAAB:

--- a/tests/unit/artifacts/android/test_apk.py
+++ b/tests/unit/artifacts/android/test_apk.py
@@ -12,8 +12,7 @@ def test_apk_path() -> Path:
 
 @pytest.fixture
 def test_apk(test_apk_path: Path) -> APK:
-    with open(test_apk_path, "rb") as f:
-        return APK(test_apk_path, f.read())
+    return APK(test_apk_path)
 
 
 class TestAPK:

--- a/tests/unit/artifacts/android/test_zipped_aab.py
+++ b/tests/unit/artifacts/android/test_zipped_aab.py
@@ -12,8 +12,7 @@ def test_zipped_aab_path() -> Path:
 
 @pytest.fixture
 def test_zipped_aab(test_zipped_aab_path: Path) -> ZippedAAB:
-    with open(test_zipped_aab_path, "rb") as f:
-        return ZippedAAB(test_zipped_aab_path, f.read())
+    return ZippedAAB(test_zipped_aab_path)
 
 
 class TestZippedAAB:

--- a/tests/unit/artifacts/android/test_zipped_apk.py
+++ b/tests/unit/artifacts/android/test_zipped_apk.py
@@ -12,8 +12,7 @@ def test_zipped_apk_path() -> Path:
 
 @pytest.fixture
 def test_zipped_apk(test_zipped_apk_path: Path) -> ZippedAPK:
-    with open(test_zipped_apk_path, "rb") as f:
-        return ZippedAPK(test_zipped_apk_path, f.read())
+    return ZippedAPK(test_zipped_apk_path)
 
 
 class TestZippedAPK:

--- a/tests/unit/test_apple_basic_info.py
+++ b/tests/unit/test_apple_basic_info.py
@@ -11,8 +11,7 @@ class TestAppleBasicInfo:
         """Test that range mapping is enabled by default."""
         analyzer = AppleAppAnalyzer()
         path = Path("tests/_fixtures/ios/HackerNews.xcarchive.zip")
-        with open(path, "rb") as f:
-            archive = ZippedXCArchive(path, f.read())
+        archive = ZippedXCArchive(path)
 
         basic_info = analyzer.preprocess(archive)
         assert basic_info.name == "HackerNews"


### PR DESCRIPTION
With https://github.com/getsentry/launchpad/pull/67/ I notice we don't need `content` anymore. Removing it as a cleanup - if any consumer needs `content` they can just do an `os.read` of `path` to get it