### PR TITLE
Add large file analysis that triggers for images larger than 10MB

### DIFF
--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -10,7 +10,7 @@ from launchpad.artifacts.android.zipped_apk import ZippedAPK
 from launchpad.artifacts.artifact import AndroidArtifact
 from launchpad.parsers.android.dex.types import ClassDefinition
 from launchpad.size.insights.android.image_optimization import WebPOptimizationInsight
-from launchpad.size.insights.common import DuplicateFilesInsight
+from launchpad.size.insights.common import DuplicateFilesInsight, LargeImageFileInsight
 from launchpad.size.insights.insight import InsightsInput
 from launchpad.size.models.android import (
     AndroidAnalysisResults,
@@ -92,6 +92,7 @@ class AndroidAnalyzer:
             insights = AndroidInsightResults(
                 duplicate_files=DuplicateFilesInsight().generate(insights_input),
                 webp_optimization=WebPOptimizationInsight().generate(insights_input),
+                large_files=LargeImageFileInsight().generate(insights_input),
             )
 
         return AndroidAnalysisResults(

--- a/src/launchpad/size/models/android.py
+++ b/src/launchpad/size/models/android.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict, Field
 
 from .common import BaseAnalysisResults, BaseAppInfo
-from .insights import DuplicateFilesInsightResult
+from .insights import DuplicateFilesInsightResult, LargeImageFileInsightResult
 
 
 class AndroidAppInfo(BaseAppInfo):
@@ -28,6 +28,7 @@ class AndroidInsightResults(BaseModel):
 
     duplicate_files: DuplicateFilesInsightResult | None = Field(None, description="Duplicate files analysis")
     webp_optimization: WebPOptimizationInsightResult | None = Field(None, description="WebP optimization analysis")
+    large_files: LargeImageFileInsightResult | None = Field(None, description="Large files analysis")
 
 
 class AndroidAnalysisResults(BaseAnalysisResults):

--- a/src/launchpad/size/models/insights.py
+++ b/src/launchpad/size/models/insights.py
@@ -22,3 +22,9 @@ class DuplicateFilesInsightResult(BaseInsightResult):
     def duplicate_count(self) -> int:
         """Number of duplicate files (excluding the original)."""
         return len(self.files) - 1
+
+
+class LargeImageFileInsightResult(BaseInsightResult):
+    """Results from large image files analysis."""
+
+    files: List[FileInfo] = Field(..., description="Image files larger than 10MB")

--- a/tests/integration/test_large_file_insight_integration.py
+++ b/tests/integration/test_large_file_insight_integration.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from launchpad.artifacts.artifact_factory import ArtifactFactory
+from launchpad.size.analyzers.android import AndroidAnalyzer
+
+
+class TestLargeFileInsightIntegration:
+    def test_large_file_insight_with_hackernews_apk(self):
+        """Test large file insight with the HackerNews APK fixture."""
+        apk_path = Path("tests/_fixtures/android/hn.apk")
+
+        artifact = ArtifactFactory.from_path(apk_path)
+        analyzer = AndroidAnalyzer(skip_insights=False)
+
+        results = analyzer.analyze(artifact)
+
+        assert results.insights is not None
+        assert results.insights.large_files is not None
+
+        # The HackerNews APK doesn't have anything larger than 10MB,
+        # We check for a valid structure.
+        assert results.insights.large_files.total_savings >= 0

--- a/tests/unit/test_large_file_insight.py
+++ b/tests/unit/test_large_file_insight.py
@@ -1,0 +1,123 @@
+from unittest.mock import Mock
+
+from launchpad.size.insights.common import LargeImageFileInsight
+from launchpad.size.insights.insight import InsightsInput
+from launchpad.size.models.common import BaseAppInfo, FileAnalysis, FileInfo
+from launchpad.size.models.insights import LargeImageFileInsightResult
+from launchpad.size.models.treemap import TreemapType
+
+
+class TestLargeImageFileInsight:
+    def setup_method(self):
+        self.insight = LargeImageFileInsight()
+
+    def test_generate_with_large_files(self):
+        large_file_1 = FileInfo(
+            path="assets/large_video.mp4",
+            size=15 * 1024 * 1024,  # 15MB
+            file_type="mp4",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash1",
+        )
+        large_file_2 = FileInfo(
+            path="assets/large_image.png",
+            size=12 * 1024 * 1024,  # 12MB
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash2",
+        )
+        small_file = FileInfo(
+            path="assets/small_image.png",
+            size=5 * 1024 * 1024,  # 5MB
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash3",
+        )
+
+        file_analysis = FileAnalysis(files=[large_file_1, large_file_2, small_file])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+            image_files=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LargeImageFileInsightResult)
+        assert len(result.files) == 1
+
+        assert result.files[0].path == "assets/large_image.png"
+
+    def test_generate_with_no_large_files(self):
+        small_file_1 = FileInfo(
+            path="assets/small_image1.png",
+            size=5 * 1024 * 1024,  # 5MB
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash1",
+        )
+        small_file_2 = FileInfo(
+            path="assets/small_image2.png",
+            size=8 * 1024 * 1024,  # 8MB
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash2",
+        )
+
+        file_analysis = FileAnalysis(files=[small_file_1, small_file_2])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+            image_files=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LargeImageFileInsightResult)
+        assert len(result.files) == 0
+
+    def test_generate_with_empty_file_list(self):
+        file_analysis = FileAnalysis(files=[])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+            image_files=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LargeImageFileInsightResult)
+        assert len(result.files) == 0
+
+    def test_generate_with_exactly_threshold_size(self):
+        threshold_file = FileInfo(
+            path="assets/threshold_image.png",
+            size=10 * 1024 * 1024,  # Exactly 10MB
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash1",
+        )
+
+        file_analysis = FileAnalysis(files=[threshold_file])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+            image_files=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LargeImageFileInsightResult)
+        assert len(result.files) == 0  # Should not include files exactly at threshold


### PR DESCRIPTION
This triggers an analysis only for images that are larger than 10MB.
This reports the savings as 50% of the image size assuming the image can be shrunk in half.