### PR TITLE
Add datadog

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,18 @@
 # shellcheck shell=bash
 
-# Load variables from an optional .env file
+# Local development environment variables
+export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
+export KAFKA_GROUP_ID="launchpad-devservices"
+export KAFKA_TOPICS="preprod-artifact-events"
+export LAUNCHPAD_CREATE_KAFKA_TOPIC="1"
+export LAUNCHPAD_ENV="development"
+export LAUNCHPAD_HOST="0.0.0.0"
+export LAUNCHPAD_PORT="2218"
+# STATSD_HOST=... # defaults to 127.0.0.1
+# STATSD_PORT=... # defaults to 8125
+
+# Above variables can be overridden with a local .env file
+# See https://github.com/motdotla/dotenv?tab=readme-ov-file#%EF%B8%8F-usage
 if [[ -f "${PWD}/.env" ]]; then
   dotenv
 fi
@@ -33,11 +45,4 @@ fi
 export VIRTUAL_ENV="${PWD}/.venv"
 PATH_add "${PWD}/.venv/bin"
 
-# local development environment variables
-export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
-export KAFKA_GROUP_ID="launchpad-devservices"
-export KAFKA_TOPICS="preprod-artifact-events"
-export LAUNCHPAD_CREATE_KAFKA_TOPIC="1"
-export LAUNCHPAD_ENV="development"
-export LAUNCHPAD_HOST="0.0.0.0"
-export LAUNCHPAD_PORT="2218"
+

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ legacy/ios/sizeAnalysis/.build/
 
 # in case the user is installing devenv for the first time
 install-devenv.sh
+
+# Local environment variable overrides set by the user.
+.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ google-api-python-client==2.172.0
 protobuf==5.29.5
 asn1crypto>=1.5.0
 cryptography>=41.0.0
+datadog==0.51.*

--- a/src/launchpad/server.py
+++ b/src/launchpad/server.py
@@ -12,7 +12,7 @@ from aiohttp import web
 from aiohttp.typedefs import Handler
 from aiohttp.web import Application, Request, Response, StreamResponse, middleware
 
-from launchpad.utils.logging import get_logger
+from .utils.logging import get_logger
 
 logger = get_logger(__name__)
 
@@ -152,8 +152,8 @@ def get_server_config() -> Dict[str, Any]:
     environment = os.getenv("LAUNCHPAD_ENV")
     if not environment:
         raise ValueError("LAUNCHPAD_ENV environment variable is required")
-
     environment = environment.lower()
+
     is_production = environment == "production"
 
     host = os.getenv("LAUNCHPAD_HOST")

--- a/src/launchpad/utils/statsd.py
+++ b/src/launchpad/utils/statsd.py
@@ -1,0 +1,18 @@
+from datadog.dogstatsd.base import DogStatsd
+
+# There are a few weird issues with DataDog documented in other Sentry repos.
+# See:
+# - https://github.com/getsentry/sentry/blob/81e1b8694f2ab3a63ecab3accf9911cc97accbb0/src/sentry/metrics/dogstatsd.py#L30
+# - https://github.com/getsentry/seer/blob/992299aa44ce744366fe1be0c20b11d99987fa1d/src/seer/fastapi_app.py#L33
+# - https://github.com/DataDog/datadogpy/issues/764
+# Minimize these by:
+# - turning off the problem features
+# - not using the global initialize() and statsd instances.
+
+
+def get_statsd(host: str = "127.0.0.1", port: int = 8125) -> DogStatsd:
+    disable_telemetry = True
+    origin_detection_enabled = False
+    return DogStatsd(
+        host=host, port=port, disable_telemetry=disable_telemetry, origin_detection_enabled=origin_detection_enabled
+    )


### PR DESCRIPTION
One of the prelaunch checklist items is a Datadog dashboard.
Add a single Datadog metric to be able to test this working end-to-end.
A nice thing about the design of statsd is we don't have to do anything
special to disable it in dev.
