### PR TITLE
Fix ty warnings and make future warnings errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check-format:  ## Check code format without modifying files
 	$(PYTHON_VENV) -m ruff format --check src/ tests/
 
 check-types:  ## Run type checking with ty
-	$(PYTHON_VENV) -m ty check src
+	$(PYTHON_VENV) -m ty check --error-on-warning src
 
 fix:  ## Auto-fix code issues (format, remove unused imports, fix line endings)
 	$(PYTHON_VENV) -m ruff format src/ tests/

--- a/src/launchpad/server.py
+++ b/src/launchpad/server.py
@@ -149,11 +149,11 @@ class LaunchpadServer:
 
 def get_server_config() -> Dict[str, Any]:
     """Get server configuration from environment."""
-    environment = os.getenv("LAUNCHPAD_ENV").lower()
+    environment = os.getenv("LAUNCHPAD_ENV")
     if not environment:
         raise ValueError("LAUNCHPAD_ENV environment variable is required")
 
-    environment = environment
+    environment = environment.lower()
     is_production = environment == "production"
 
     host = os.getenv("LAUNCHPAD_HOST")


### PR DESCRIPTION
Warnings should either be explicitly silenced or be hard errors (and
hence cause the CI to fail) otherwise we just accumulate noise over
time.

See https://github.com/getsentry/launchpad/actions/runs/15931749638/job/44942320527?pr=93#step:8:20
