### PR TITLE
Add scripts/deps to download dependencies

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -35,8 +35,11 @@ if ! command -v "$DEVENV" >/dev/null; then
   return 1
 fi
 
-# activate
-PATH_add "${PWD}/.devenv/bin"
+PATH_add "${PWD}/.devenv/all/bin"
+case $(uname -s) in
+  Darwin)     PATH_add "${PWD}/.devenv/aarch64-darwin/bin";;
+  *) PATH_add "${PWD}/.devenv/x86_64-linux/bin";;
+esac
 
 if [ ! -d .venv ]; then
     devenv sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,28 @@ jobs:
       - name: Check types
         run: make check-types
 
+      - name: Check deps
+        run: make check-deps
+
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install dependencies
+        run: make install-dev
 
       - name: Build Docker image with test fixtures
         run: docker build --build-arg TEST_BUILD=true -t launchpad-test .

--- a/.github/workflows/ghcr-image-upload.yml
+++ b/.github/workflows/ghcr-image-upload.yml
@@ -13,6 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install dependencies
+        run: make install-dev
+
       - run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,12 @@ android-analysis-report.json
 *_treemap_cli.json
 legacy/ios/sizeAnalysis/.build/
 
-# in case the user is installing devenv for the first time
+# devenv cached downloads
+/.devenv
+
+# In case the user is installing devenv for the first time:
 install-devenv.sh
 
 # Local environment variable overrides set by the user.
 .env
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Setup bundletool
-RUN curl https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar -4 -sL -o /usr/local/bin/bundletool.jar && \
-    echo '#!/bin/bash' > /usr/local/bin/bundletool && \
-    echo 'java -jar /usr/local/bin/bundletool.jar "$@"' >> /usr/local/bin/bundletool && \
-    chmod +x /usr/local/bin/bundletool
-
-# Setup cwebp
-RUN curl -L https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0-linux-x86-64.tar.gz -o /tmp/webp.tar.gz && \
-    tar -xzf /tmp/webp.tar.gz -C /usr/local --strip-components=1 && \
-    rm /tmp/webp.tar.gz
+COPY .devenv/all/bin /usr/local/bin/
+COPY .devenv/x86_64-linux/bin /usr/local/bin/
 
 # Set working directory
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-unit test-integration lint format type-check fix check-format check-types clean build build-wheel clean-venv check ci all run-cli status
+.PHONY: help test test-unit test-integration lint format type-check fix check-format check-types clean build build-wheel clean-venv check ci all run-cli status check-deps
 
 # Default target
 help:
@@ -15,9 +15,10 @@ $(VENV_DIR):
 	$(UV) venv
 
 # Just used for CI
-install-dev: $(VENV_DIR)  ## Install development dependencies
+install-dev: $(VENV_DIR)
 	$(UV) pip install -r requirements-dev.txt
 	$(UV) pip install -e .
+	$(PYTHON_VENV) scripts/deps
 	$(VENV_DIR)/bin/pre-commit install
 
 test:
@@ -38,6 +39,9 @@ check-format:  ## Check code format without modifying files
 
 check-types:  ## Run type checking with ty
 	$(PYTHON_VENV) -m ty check --error-on-warning src
+
+check-deps:
+	$(PYTHON_VENV) scripts/deps --check
 
 fix:  ## Auto-fix code issues (format, remove unused imports, fix line endings)
 	$(PYTHON_VENV) -m ruff format src/ tests/
@@ -65,7 +69,7 @@ clean:
 	rm -rf $(VENV_DIR)
 
 # Combined targets for CI
-check: check-lint check-format check-types
+check: check-lint check-format check-types check-deps
 
 ci: install-dev check test
 

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,6 +1,10 @@
-from devenv.lib import config, venv, fs  # type: ignore
+import os
 import subprocess
 import sys
+
+from devenv.lib import config, venv, fs  # type: ignore
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def run_uv_command(cmd: list[str], cwd: str) -> None:
     """Run a uv command and handle errors."""
@@ -40,5 +44,9 @@ def main(context: dict[str, str]) -> int:
             )
 
     fs.ensure_symlink("../../config/hooks/post-merge", f"{reporoot}/.git/hooks/post-merge")  # type: ignore
+
+
+    deps_path = os.path.join(ROOT_DIR, "scripts", "deps")
+    subprocess.check_output([deps_path])
 
     return 0

--- a/scripts/deps
+++ b/scripts/deps
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+
+"""
+Handles downloading and ensuring the runtime dependencies of launchpad
+are up-to-date. We require various dependencies
+(cwebp, bundletool, etc). Some of these are architecture/OS dependant
+and some are not. There are three situations to care about:
+local development, CI, and production. We ideally want use the same
+pinned version of the dependencies in three situations and specify
+those versions in a single place.
+
+This script can be invoked from: devenv, make, and, manually.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, List
+import argparse
+import os
+import platform
+import sys
+import hashlib
+import subprocess
+import shutil
+import stat
+import textwrap
+
+# Don't add non-standard library dependencies since this can be ran
+# prior to the venv getting set up.
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEPS_DIR = os.path.join(ROOT_DIR, ".devenv")
+KNOWN_ARCHITECTURES = {"x86_64", "aarch64"}
+KNOWN_SYSTEMS = {"darwin", "linux"}
+
+
+@dataclass
+class Bin:
+    text: Optional[str] = None
+    source: Optional[str] = None
+    target: str = ""
+
+    def __post_init__(self):
+        assert bool(self.text) != bool(self.source), f"{self} must define text xor source"
+        assert self.target, f"{self} must define target"
+
+
+@dataclass
+class Dep:
+    name: str
+    url: str
+    hash: str
+    architecture: Optional[str] = None
+    system: Optional[str] = None
+    binaries: Optional[List[Bin]] = None
+
+    def __post_init__(self):
+        assert self.architecture and self.system or (not self.architecture and not self.system), (
+            f"{self!r} must set both architecture and system or neither."
+        )
+        assert self.architecture is None or self.architecture in KNOWN_ARCHITECTURES, f"{self.architecture} not known"
+        assert self.system is None or self.system in KNOWN_SYSTEMS, f"{self.system} not known"
+
+    def __str__(self):
+        if self.is_machine_dependent():
+            return f"{self.name}-{self.architecture}-{self.system}"
+        else:
+            return f"{self.name}"
+
+    def is_archive(self):
+        return self.name.endswith(".tar.gz")
+
+    def is_machine_dependent(self):
+        return self.architecture or self.system
+
+    def directory(self):
+        if self.is_machine_dependent():
+            return os.path.join(DEPS_DIR, f"{self.architecture}-{self.system}")
+        else:
+            return os.path.join(DEPS_DIR, "all")
+
+    def bin_directory(self):
+        return os.path.join(self.directory(), "bin")
+
+    def get_binary_source_path(self, binary):
+        assert binary.source
+        return os.path.join(self.directory(), binary.source)
+
+    def get_binary_target_path(self, binary):
+        return os.path.join(self.bin_directory(), binary.target)
+
+    def target_path(self):
+        assert self.is_archive()
+        return os.path.join(self.directory(), self.name.split(".")[0])
+
+    def download_path(self):
+        return os.path.join(self.directory(), self.name)
+
+    def get_binaries(self):
+        return self.binaries or []
+
+
+BUNDLETOOL_SHIM = """#!/bin/sh
+java -jar $(dirname "$(realpath $0)")/bundletool.jar "$@"
+"""
+
+DEPS = [
+    Dep(
+        "bundletool.jar",
+        "https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar",
+        "675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c",
+        binaries=[
+            Bin(source="bundletool.jar", target="bundletool.jar"),
+            Bin(text=BUNDLETOOL_SHIM, target="bundletool"),
+        ],
+    ),
+    Dep(
+        "webp.tar.gz",
+        "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0-linux-x86-64.tar.gz",
+        "f4bf49f85991f50e86a5404d16f15b72a053bb66768ed5cc0f6d042277cc2bb8",
+        architecture="x86_64",
+        system="linux",
+        binaries=[
+            Bin(source="webp/bin/cwebp", target="cwebp"),
+        ],
+    ),
+    Dep(
+        "webp.tar.gz",
+        "http://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0-rc1-mac-arm64.tar.gz",
+        "246acaba42a4e945811046ec382a7923cc1925b049cec45d2d1dda052e772afa",
+        architecture="aarch64",
+        system="darwin",
+        binaries=[
+            Bin(source="webp/bin/cwebp", target="cwebp"),
+        ],
+    ),
+]
+
+
+# See https://mcyoung.xyz/2025/04/14/target-triples we normalize to
+# the preferred LLVM name.
+def get_architecture():
+    architecture = platform.machine().lower()
+    match architecture:
+        case "arm64":
+            return "aarch64"
+        case "aarch64":
+            return "aarch64"
+        case "x86_64":
+            return "x86_64"
+        case "amd64":
+            return "x86_64"
+    raise ValueError(f"Unknown architecture {architecture}")
+
+
+# See https://mcyoung.xyz/2025/04/14/target-triples
+def get_system():
+    system = platform.system().lower()
+    if system in KNOWN_SYSTEMS:
+        return system
+    raise ValueError(f"Unknown system {system}")
+
+
+def hash_file(path):
+    with open(path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def check_call(*args, **kwargs):
+    try:
+        return subprocess.check_call(args, **kwargs)
+    except subprocess.CalledProcessError as e:
+        cmd = " ".join(e.cmd)
+        print(f"Command: '{cmd}' exited with status '{e.returncode}'", file=sys.stderr)
+        sys.exit(1)
+
+
+def ensure_good_binary(dep, binary):
+    target_path = dep.get_binary_target_path(binary)
+    assert os.path.exists(target_path), f"Expected file at {target_path}"
+
+    if binary.text:
+        with open(target_path) as f:
+            assert f.read() == binary.text, f"{target_path} does not match {binary.text}"
+    else:
+        source_path = dep.get_binary_source_path(binary)
+        assert hash_file(source_path) == hash_file(target_path)
+    assert os.stat(target_path).st_mode & stat.S_IEXEC
+
+
+def ensure_good_dep(dep):
+    download_path = dep.download_path()
+    assert os.path.exists(download_path)
+    actual = hash_file(download_path)
+    expected = dep.hash
+    assert actual == expected, f"Expected hash for {dep} to be {expected} was {actual}"
+    if dep.is_archive():
+        assert os.path.exists(dep.target_path())
+    for binary in dep.get_binaries():
+        ensure_good_binary(dep, binary)
+
+
+def is_good_dep(dep):
+    try:
+        ensure_good_dep(dep)
+    except AssertionError as e:
+        return False
+    else:
+        return True
+
+
+def get_bad_deps():
+    """Return list of 'bad' deps. Deps are bad if they are missing or out-of-date."""
+    return [dep for dep in DEPS if not is_good_dep(dep)]
+
+
+def download_url(url, path):
+    return check_call("curl", "-L", "-#", "-o", path, url)
+
+
+def ensure_dir(directory):
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+
+def remove_tree(path):
+    if not os.path.exists(path):
+        return
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+    else:
+        os.remove(path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--print-paths", action="store_true", help="Print paths that should be added to PATH")
+    parser.add_argument(
+        "--check", action="store_true", help="Don't download dependencies just check if they are up-to-date"
+    )
+    parser.add_argument(
+        "--local-architecture",
+        default=get_architecture(),
+        choices=KNOWN_ARCHITECTURES,
+        help="Override the current architecture (%(default)s)",
+    )
+    parser.add_argument(
+        "--local-system", default=get_system(), choices=KNOWN_SYSTEMS, help="Override the current system (%(default)s)"
+    )
+    args = parser.parse_args()
+
+    if args.print_paths:
+        print(os.path.join(DEPS_DIR, "all", "bin"))
+        print(os.path.join(DEPS_DIR, f"{args.local_architecture}-{args.local_system}", "bin"))
+        return 0
+
+    bad_deps = get_bad_deps()
+    bad_names = ", ".join(str(d) for d in bad_deps)
+
+    if not bad_deps:
+        # All clean so nothing to do.
+        return 0
+    elif args.check:
+        # We have some bad dependencies but the user passed --check so
+        # just list those.
+        assert bad_deps
+        argz = " ".join([a for a in sys.argv[1:] if a != "--check"])
+        print(f"\033[91mBuild deps ({bad_names}) are stale. Please run: scripts/deps {argz}\033[0m")
+        return 1
+    else:
+        print(f"The following deps are stale: {bad_names}")
+        for dep in bad_deps:
+            ensure_dir(dep.directory())
+            download_path = dep.download_path()
+            download_url(dep.url, download_path)
+
+            if dep.is_archive():
+                target_path = dep.target_path()
+                remove_tree(target_path)
+                ensure_dir(target_path)
+                check_call("tar", "-oxf", download_path, cwd=target_path)
+
+                # If the archive contains one root folder, rebase one level up moving all
+                # its sub files and folders inside target_path.
+                if os.path.isdir(target_path):
+                    children = os.listdir(target_path)
+                    if len(children) == 1:
+                        child = os.path.join(target_path, children[0])
+                        if os.path.isdir(child):
+                            for p in os.listdir(child):
+                                shutil.move(os.path.join(child, p), target_path)
+                        remove_tree(child)
+
+            for binary in dep.get_binaries():
+                ensure_dir(dep.bin_directory())
+                target_path = dep.get_binary_target_path(binary)
+                if binary.text:
+                    with open(target_path, "w") as f:
+                        f.write(binary.text)
+                else:
+                    source_path = dep.get_binary_source_path(binary)
+                    shutil.copyfile(source_path, target_path)
+                os.chmod(target_path, 0o755)
+
+            ensure_good_dep(dep)
+
+        # Now everything ought to be up-to-date. If not error to avoid
+        # situations where we are constantly re-downloading a dep.
+        assert not get_bad_deps()
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Launchpad requires a bunch of tools at runtime. The current intended
list is: `ffmpeg`, `assetutil`, `imagemin`, `afconvert`, `codesign`, 
`lipo`, `bitcode_strip`, `strip`, `dyld_info`, `apksigner`, `bundletool`,
`aapt2`, `cwebp` - but more may be discovered.

We need these tools in three scenarios:
- local development 
- CI
- production

Ideally you want to use a) a pinned version and b) the same pinned
version across all three situations. https://github.com/getsentry/launchpad/pull/86
changed the tests to use Docker which solves keeping CI and
production in sync - but still means for local development you
either need to always build the docker image (which is slow) or
manually install deps as you discover them missing.

Also while testing the Docker image in CI is good (in that it is
more representative of production) there are some cases where
it becomes a hassle to e.g. compute coverage https://github.com/getsentry/launchpad/pull/97
which was the motivation for this change.

This adds a script which downloads all the needed dependancies
into:
- `.devenv/*`

We divide the dependancies into  
- `.devenv/all/` - for platform independent tools (e.g. `.jar`s)
- `.devenv/x86_64-linux/`
- `.devenv/aarch64-darwin/`

etc - for native binaries.

We take the actual tools from the downloaded files and copy them to:
- `.devenv/all/bin/`
- `.devenv/x86_64-linux/bin/`
- `.devenv/aarch64-darwin/bin/`

Adding a tool is simple:

```
Dep(
      "mynativetool.tar.gz",
      "https://github.com/example/example/archive/refs/tags/mynativetool.tar.gz",
      "f4bf49f85991f50e86a5404d16f15b72a053bb66768ed5cc0f6d042277cc2bb8",
      architecture="x86_64",
      system="linux",
      binaries=[
          Bin(source="mynativetool/foo", target="foo"),
      ],
),
```
for a platform dependent tool. Or just:
```
Dep(
    "bundletool.jar",
    "https://github.com/google/bundletool/releases/download/1.18.1/bundletool-all-1.18.1.jar",
    "675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c",
),
```
for an platform independent tool.

- The hash ensures everyone is always using the exact same
version and makes it easy to detect when we need to download
a new version.
- It's fully hermetic so you're never in a situation where you are
breaking your global dev environment because `launchpad`
needs an older/newer version of `bundletool` than something
else.

This allows us to:
- make Docker image creation more hermetic and simpler
- gets closer to 'single button' dev env setup.

This script is used from:
- `make` - as part of `make install-deps` making it useful again.
- `devenv` - as part of `devenv sync`

In `.envrc` we add the relevant paths to `PATH`.
In the `Dockerfile` we copy the relevant files into the image.

Rather than having a separate script it would have been nice to add
this to `devenv` which broadly seems to be solving a similar issue
but just does not want to work in CI.