### PR TITLE
Call new endpoints

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,6 +8,7 @@ export LAUNCHPAD_CREATE_KAFKA_TOPIC="1"
 export LAUNCHPAD_ENV="development"
 export LAUNCHPAD_HOST="0.0.0.0"
 export LAUNCHPAD_PORT="2218"
+export LAUNCHPAD_RPC_SHARED_SECRET="launchpad-also-very-long-value-haha"
 # STATSD_HOST=... # defaults to 127.0.0.1
 # STATSD_PORT=... # defaults to 8125
 
@@ -44,5 +45,3 @@ fi
 
 export VIRTUAL_ENV="${PWD}/.venv"
 PATH_add "${PWD}/.venv/bin"
-
-

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,15 @@ test-kafka-message:  ## Send a test message to Kafka (requires Kafka running)
 test-kafka-multiple:  ## Send multiple test messages to Kafka
 	$(PYTHON_VENV) scripts/test_kafka.py --count 5 --interval 0
 
+test-download-artifact:
+	$(PYTHON_VENV) scripts/test_download_artifact.py --verbose
+
+test-artifact-update:
+	$(PYTHON_VENV) scripts/test_artifact_update.py --build-version "1.0.0" --build-number 42 --verbose
+
+test-artifact-size-analysis-upload:
+	$(PYTHON_VENV) scripts/test_artifact_size_analysis_upload.py --verbose
+
 test-service-integration:  ## Run full integration test with devservices
 	@echo "Starting Kafka services via devservices..."
 	@devservices up

--- a/scripts/test_artifact_size_analysis_upload.py
+++ b/scripts/test_artifact_size_analysis_upload.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Script to test uploading size analysis files to Sentry using the complete chunking flow."""
+
+import json
+import logging
+import os
+import sys
+
+import click
+
+sys.path.insert(0, "src")
+from launchpad.sentry_client import SentryClient
+
+
+@click.command()
+@click.option(
+    "--base-url", default="http://localhost:8000", help="Base URL for Sentry API"
+)
+@click.option("--org", default="sentry", help="Organization slug")
+@click.option("--project", default="internal", help="Project slug")
+@click.option("--artifact-id", default="1", help="Artifact ID to upload analysis for")
+@click.option("--file-path", default="README.md", help="Path to file to upload")
+@click.option("--verbose", is_flag=True, help="Enable verbose logging")
+def main(
+    base_url: str,
+    org: str,
+    project: str,
+    artifact_id: str,
+    file_path: str,
+    verbose: bool,
+) -> None:
+    """Test uploading size analysis files to Sentry using the complete chunking flow."""
+
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Verify file exists
+    if not os.path.exists(file_path):
+        click.echo(f"❌ File not found: {file_path}")
+        sys.exit(1)
+
+    file_size = os.path.getsize(file_path)
+
+    try:
+        click.echo(
+            f"Testing size analysis upload: {org}/{project}/artifacts/{artifact_id}"
+        )
+        click.echo(f"📁 File: {file_path} ({file_size:,} bytes)")
+
+        client = SentryClient(base_url=base_url)
+
+        click.echo("🔄 Starting size analysis upload...")
+        click.echo("   📊 Calculating checksums...")
+        click.echo("   🚀 Calling assemble endpoint...")
+
+        response = client.upload_size_analysis_file(
+            org, project, artifact_id, file_path
+        )
+
+        if "error" in response:
+            click.echo(
+                f"❌ Failed: {response['error']} (Status: {response.get('status_code', 'Unknown')})"
+            )
+            if "message" in response:
+                click.echo(f"   Message: {response['message']}")
+            sys.exit(1)
+
+        click.echo("✅ Size analysis upload successful!")
+
+        # Show relevant response data
+        if "checksum" in response:
+            click.echo(f"📄 File checksum: {response['checksum']}")
+        if "chunks" in response:
+            click.echo(f"🧩 Chunks processed: {len(response['chunks'])} chunk(s)")
+        if "state" in response:
+            click.echo(f"📊 Analysis state: {response['state']}")
+
+        if verbose:
+            click.echo(f"📄 Full response: {json.dumps(response, indent=2)}")
+
+    except FileNotFoundError as e:
+        click.echo(f"❌ File error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"❌ Error: {e}")
+        if verbose:
+            import traceback
+
+            click.echo(traceback.format_exc())
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_artifact_update.py
+++ b/scripts/test_artifact_update.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Script to test updating artifacts in Sentry using the internal endpoint."""
+
+import json
+import logging
+import sys
+from datetime import datetime
+
+import click
+
+sys.path.insert(0, "src")
+from launchpad.sentry_client import SentryClient
+
+
+@click.command()
+@click.option(
+    "--base-url", default="http://localhost:8000", help="Base URL for Sentry API"
+)
+@click.option("--org", default="sentry", help="Organization slug")
+@click.option("--project", default="internal", help="Project slug")
+@click.option("--artifact-id", default="1", help="Artifact ID to update")
+@click.option("--artifact-type", type=int, help="Artifact type (0=APK, 1=IPA, 2=AAB)")
+@click.option("--build-version", help="Build version string")
+@click.option("--build-number", type=int, help="Build number")
+@click.option("--error-message", help="Error message (sets state to FAILED)")
+@click.option("--verbose", is_flag=True, help="Enable verbose logging")
+def main(
+    base_url: str,
+    org: str,
+    project: str,
+    artifact_id: str,
+    artifact_type: int | None,
+    build_version: str | None,
+    build_number: int | None,
+    error_message: str | None,
+    verbose: bool,
+) -> None:
+    """Test updating artifacts in Sentry using the internal endpoint."""
+
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Build update data from provided options
+    update_data = {}
+
+    if artifact_type is not None:
+        update_data["artifact_type"] = artifact_type
+    if build_version:
+        update_data["build_version"] = build_version
+    if build_number is not None:
+        update_data["build_number"] = build_number
+    if error_message:
+        update_data["error_message"] = error_message
+
+    # Add a timestamp to show it was updated
+    update_data["date_built"] = datetime.utcnow().isoformat() + "Z"
+
+    if not update_data or update_data == {"date_built": update_data["date_built"]}:
+        click.echo("❌ No update fields provided. Use --help to see available options.")
+        sys.exit(1)
+
+    try:
+        click.echo(f"Testing update: {org}/{project}/artifacts/{artifact_id}")
+        click.echo(f"Update data: {json.dumps(update_data, indent=2)}")
+
+        client = SentryClient(base_url=base_url)
+        response = client.update_artifact(org, project, artifact_id, update_data)
+
+        if "error" in response:
+            click.echo(
+                f"❌ Failed: {response['error']} (Status: {response.get('status_code', 'Unknown')})"
+            )
+            if "message" in response:
+                click.echo(f"   Message: {response['message']}")
+            sys.exit(1)
+
+        success = response.get("success", False)
+        updated_fields = response.get("updated_fields", [])
+        artifact_id_resp = response.get("artifact_id", "Unknown")
+
+        if success:
+            click.echo(f"✅ Successfully updated artifact {artifact_id_resp}")
+            click.echo(
+                f"📝 Updated fields: {', '.join(updated_fields) if updated_fields else 'none'}"
+            )
+        else:
+            click.echo("⚠️  Update completed but success flag is False")
+
+        if verbose:
+            click.echo(f"📄 Full response: {json.dumps(response, indent=2)}")
+
+    except Exception as e:
+        click.echo(f"❌ Error: {e}")
+        if verbose:
+            import traceback
+
+            click.echo(traceback.format_exc())
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_download_artifact.py
+++ b/scripts/test_download_artifact.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Script to test downloading artifacts from Sentry using the internal endpoint."""
+
+import json
+import logging
+import os
+import sys
+import time
+
+import click
+
+sys.path.insert(0, "src")
+from launchpad.sentry_client import SentryClient
+
+
+@click.command()
+@click.option(
+    "--base-url", default="http://localhost:8000", help="Base URL for Sentry API"
+)
+@click.option("--org", default="sentry", help="Organization slug")
+@click.option("--project", default="internal", help="Project slug")
+@click.option("--artifact-id", default="1", help="Artifact ID to download")
+@click.option("--verbose", is_flag=True, help="Enable verbose logging")
+def main(
+    base_url: str, org: str, project: str, artifact_id: str, verbose: bool
+) -> None:
+    """Test downloading artifacts from Sentry using the internal endpoint."""
+
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    try:
+        click.echo(f"Testing download: {org}/{project}/artifacts/{artifact_id}")
+
+        client = SentryClient(base_url=base_url)
+        start_time = time.time()
+
+        response = client.download_artifact(org, project, artifact_id)
+        duration = time.time() - start_time
+
+        if "error" in response:
+            click.echo(
+                f"❌ Failed: {response['error']} (Status: {response.get('status_code', 'Unknown')})"
+            )
+            sys.exit(1)
+
+        file_content = response.get("file_content", b"")
+        file_size = len(file_content)
+
+        if not file_content:
+            click.echo("❌ No file content received")
+            sys.exit(1)
+
+        # Save file to disk
+        timestamp = int(time.time())
+        file_ext = ".zip" if file_content.startswith(b"PK") else ".bin"
+        filename = (
+            f"preprod_artifact_{org}_{project}_{artifact_id}_{timestamp}{file_ext}"
+        )
+        file_path = os.path.join(os.getcwd(), filename)
+
+        with open(file_path, "wb") as f:
+            f.write(file_content)
+
+        # Verify and report
+        disk_size = os.path.getsize(file_path)
+        integrity_ok = file_size == disk_size
+
+        click.echo(f"✅ Downloaded {file_size:,} bytes in {duration:.2f}s")
+        click.echo(f"💾 Saved to: {file_path}")
+        click.echo(
+            f"{'✅' if integrity_ok else '⚠️ '} File integrity: {'OK' if integrity_ok else 'MISMATCH'}"
+        )
+
+        if verbose:
+            click.echo(
+                f"📄 Headers: {json.dumps(response.get('headers', {}), indent=2)}"
+            )
+
+    except Exception as e:
+        click.echo(f"❌ Error: {e}")
+        if verbose:
+            import traceback
+
+            click.echo(traceback.format_exc())
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -1,0 +1,304 @@
+"""Client for making authenticated API calls to the Sentry monolith."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import secrets
+
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class SentryClient:
+    """Client for authenticated API calls to the Sentry monolith."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.shared_secret = os.getenv("LAUNCHPAD_RPC_SHARED_SECRET")
+        if not self.shared_secret:
+            raise RuntimeError("LAUNCHPAD_RPC_SHARED_SECRET must be provided or set as environment variable")
+
+    def assemble_size_analysis(
+        self,
+        org: str | int,
+        project: str | int,
+        artifact_id: str | int,
+        checksum: str,
+        chunks: list[str],
+    ) -> Dict[str, Any]:
+        """Call the assemble size analysis endpoint."""
+        # Validate hex strings
+        if not re.match(r"^[a-fA-F0-9]+$", checksum):
+            raise ValueError("Invalid checksum format")
+        for chunk in chunks:
+            if not re.match(r"^[a-fA-F0-9]+$", chunk):
+                raise ValueError("Invalid chunk format")
+
+        data = {
+            "checksum": checksum,
+            "chunks": chunks,
+            "assemble_type": "size_analysis",
+        }
+
+        endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/assemble-generic/"
+        return self._make_json_request("POST", endpoint, data, operation="Assemble request")
+
+    def download_artifact(self, org: str, project: str, artifact_id: str) -> Dict[str, Any]:
+        """Download preprod artifact."""
+        endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/"
+        url = self._build_url(endpoint)
+
+        try:
+            logger.debug(f"GET {url}")
+            response = requests.get(url, headers=self._get_auth_headers(), timeout=120, stream=True)
+
+            if response.status_code != 200:
+                return self._handle_error_response(response, "Download")
+
+            # Read content with size limit
+            content = b""
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    content += chunk
+                if len(content) > 5 * 1024 * 1024 * 1024:  # 5GB limit
+                    logger.warning("Download truncated at 5GB")
+                    break
+
+            return {
+                "success": True,
+                "file_content": content,
+                "file_size_bytes": len(content),
+                "headers": dict(response.headers),
+            }
+        except Exception as e:
+            logger.error(f"Download failed: {e}")
+            return {"error": str(e)}
+
+    def update_artifact(self, org: str, project: str, artifact_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update preprod artifact."""
+        endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/update/"
+        return self._make_json_request("PUT", endpoint, data, operation="Update")
+
+    def upload_size_analysis_file(
+        self,
+        org: str,
+        project: str,
+        artifact_id: str,
+        file_path: str,
+        max_retries: int = 3,
+    ) -> Dict[str, Any]:
+        """Upload size analysis file with chunking following Rust sentry-cli pattern."""
+        # Basic path validation
+        path = Path(file_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        if ".." in file_path:
+            raise ValueError(f"Invalid file path: {file_path}")
+
+        with open(path, "rb") as f:
+            content = f.read()
+
+        logger.info(f"Uploading {file_path} ({len(content)} bytes, {len(content) / 1024 / 1024:.2f} MB)")
+
+        # Step 1: Get chunk upload options from server
+        logger.debug("Getting chunk upload options...")
+        options_result = self._get_chunk_upload_options(org)
+        if "error" in options_result:
+            return {"error": f"Failed to get chunk upload options: {options_result['error']}"}
+
+        chunk_options = options_result.get("chunking", {})
+        chunk_size = chunk_options.get("chunk_size", 8 * 1024 * 1024)  # fallback to 8MB
+        max_chunks = chunk_options.get("max_chunks", 64)
+
+        logger.debug(f"Server chunk config: size={chunk_size}, max_chunks={max_chunks}")
+
+        # Step 2: Create chunks and calculate checksums
+        total_checksum = hashlib.sha1(content).hexdigest()
+        chunks = self._create_chunks(content, chunk_size)
+        chunk_checksums = [c["checksum"] for c in chunks]
+
+        logger.info(f"File prepared: SHA1={total_checksum}, chunks={len(chunks)}")
+
+        # Step 3: Upload ALL chunks first (following Rust pattern)
+        logger.info(f"Uploading all {len(chunks)} chunks...")
+        self._upload_chunks(org, chunks, chunk_checksums)
+
+        # Step 4: Assemble with retry loop
+        for attempt in range(max_retries):
+            logger.debug(f"Assembly attempt {attempt + 1}/{max_retries}")
+
+            result = self.assemble_size_analysis(
+                org=org,
+                project=project,
+                artifact_id=artifact_id,
+                checksum=total_checksum,
+                chunks=chunk_checksums,
+            )
+
+            state = result.get("state")
+            if state in ["ok", "created"]:
+                logger.info("Upload and assembly successful")
+                return result
+            elif state == "not_found":
+                missing = result.get("missingChunks", [])
+                if not missing:
+                    logger.warning("Assembly failed but no missing chunks reported")
+                    return result
+
+                logger.info(f"Re-uploading {len(missing)} missing chunks")
+                if not self._upload_chunks(org, chunks, missing):
+                    logger.warning(f"Some chunks failed to re-upload on attempt {attempt + 1}")
+            else:
+                logger.warning(f"Assembly attempt {attempt + 1} failed: {result}")
+                if attempt == max_retries - 1:  # Last attempt
+                    return result
+
+        return {"error": f"Failed after {max_retries} attempts"}
+
+    def _get_auth_headers(self, body: bytes | None = None) -> Dict[str, str]:
+        """Get authentication headers for a request."""
+        body = body or b""
+        signature = hmac.new(self.shared_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        return {
+            "Authorization": f"rpcsignature rpc0:{signature}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_url(self, endpoint: str) -> str:
+        """Build full URL from endpoint."""
+        return f"{self.base_url}{endpoint}"
+
+    def _handle_error_response(self, response: requests.Response, operation: str) -> Dict[str, Any]:
+        """Handle non-200 response with consistent error format."""
+        logger.warning(f"{operation} failed: {response.status_code}")
+        return {
+            "error": f"HTTP {response.status_code}",
+            "status_code": response.status_code,
+        }
+
+    def _make_json_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: Dict[str, Any] | None = None,
+        timeout: int = 30,
+        operation: str | None = None,
+    ) -> Dict[str, Any]:
+        """Make a JSON request with standard error handling."""
+        url = self._build_url(endpoint)
+        body = json.dumps(data).encode("utf-8") if data else b""
+        operation = operation or f"{method} {endpoint}"
+
+        logger.debug(f"{method} {url}")
+        response = requests.request(
+            method=method,
+            url=url,
+            data=body or None,
+            headers=self._get_auth_headers(body),
+            timeout=timeout,
+        )
+
+        if response.status_code != 200:
+            return self._handle_error_response(response, operation)
+
+        return response.json()
+
+    def _get_chunk_upload_options(self, org: str) -> Dict[str, Any]:
+        """Get chunk upload configuration from server."""
+        endpoint = f"/api/0/organizations/{org}/chunk-upload/"
+        return self._make_json_request("GET", endpoint, operation="Get chunk options")
+
+    def _create_chunks(self, content: bytes, chunk_size: int) -> list[Dict[str, Any]]:
+        """Split content into chunks with checksums."""
+        chunks = []
+        for i in range(0, len(content), chunk_size):
+            data = content[i : i + chunk_size]
+            chunks.append(
+                {
+                    "checksum": hashlib.sha1(data).hexdigest(),
+                    "data": data,
+                    "size": len(data),
+                }
+            )
+
+        logger.debug(f"Created {len(chunks)} chunks")
+
+        # Show individual chunk details (limit for large files, similar to Rust version)
+        max_chunks_to_show = 5
+        for i, chunk in enumerate(chunks[:max_chunks_to_show]):
+            logger.debug(f"  Chunk {i + 1}: {chunk['size']} bytes (SHA1: {chunk['checksum']})")
+        if len(chunks) > max_chunks_to_show:
+            logger.debug(f"  ... and {len(chunks) - max_chunks_to_show} more chunks")
+
+        return chunks
+
+    def _upload_chunks(self, org: str, chunks: list[Dict[str, Any]], target_checksums: list[str]) -> bool:
+        """Upload chunks by checksum list."""
+        chunk_map = {c["checksum"]: c for c in chunks}
+        success = 0
+
+        for checksum in target_checksums:
+            if checksum not in chunk_map:
+                logger.error(f"Chunk not found in map: {checksum}")
+                continue
+
+            if self._upload_chunk(org, chunk_map[checksum]):
+                success += 1
+                logger.debug(f"Uploaded chunk {success}/{len(target_checksums)}: {checksum}")
+
+        logger.debug(f"Uploaded {success}/{len(target_checksums)} chunks successfully")
+        return success == len(target_checksums)
+
+    def _upload_chunk(self, org: str, chunk: Dict[str, Any]) -> bool:
+        """Upload single chunk."""
+        url = f"{self.base_url}/api/0/organizations/{org}/chunk-upload/"
+        boundary = f"----FormBoundary{secrets.token_hex(16)}"
+
+        # Create multipart body
+        body = self._create_multipart_body(boundary, chunk["checksum"], chunk["data"])
+
+        # For multipart, we need custom headers
+        signature = hmac.new(self.shared_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        headers = {
+            "Authorization": f"rpcsignature rpc0:{signature}",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        }
+
+        try:
+            response = requests.post(url, data=body, headers=headers, timeout=60)
+
+            success = response.status_code in [200, 201, 409]  # 409 = already exists
+            if not success:
+                logger.warning(f"Chunk upload failed: {response.status_code}")
+            return success
+
+        except Exception as e:
+            logger.error(f"Chunk upload error: {e}")
+            return False
+
+    def _create_multipart_body(self, boundary: str, filename: str, data: bytes) -> bytes:
+        """Create multipart/form-data body."""
+        lines = [
+            f"--{boundary}",
+            f'Content-Disposition: form-data; name="file"; filename="{filename}"',
+            "Content-Type: application/octet-stream",
+            "",
+        ]
+
+        parts = [
+            "\r\n".join(lines).encode("utf-8"),
+            b"\r\n",
+            data,
+            f"\r\n--{boundary}--\r\n".encode("utf-8"),
+        ]
+
+        return b"".join(parts)


### PR DESCRIPTION
Add endpoint calling interface. The test scripts are just temporary references for now. Once my kafka PRs land, we can do this on the latest main branches of the two projects:

0. (optional) run `make reset-db` in sentry dir for a clean slate
1. Run sentry locally: `sentry devserver --workers` 
2. Open `http://127.0.0.1:8000/settings/sentry/auth-tokens` and create an auth token.
3. Open the launchpad repo and run `make serve` to ensure the launchpad server is also running locally
4. Open sentry-cli and run `./target/release/sentry-cli --log-level=debug --auth-token {your_auth_token} mobile-app upload {any_apk_or_xcarchive} --org sentry --project internal`. This should successfully upload the artifact to your local sentry instance. You can check in your local postgres: there should now be a row in the PreprodArtifact and `sentry_file` tables

Step #4 will also submit a kafka message which will then trigger the processing task in launchpad. 

**My next PR will wire up the processing task to include the network calls back to the monolith**

For now we can test these endpoints with the make commands I've added


note: we've updated the sentry's devservices config so technically you can also now run launchpad as a dependency of sentry by running `devservices up --mode launchpad` in the sentry repo