### PR TITLE
Add symbol breakdown data to iOS treemap

### DIFF
--- a/src/launchpad/analyzers/apple.py
+++ b/src/launchpad/analyzers/apple.py
@@ -426,7 +426,6 @@ class AppleAppAnalyzer:
             range_builder = RangeMappingBuilder(
                 parser,
                 executable_size,
-                symbol_analysis=symbol_analysis,
             )
             range_map = range_builder.build_range_mapping()
 

--- a/src/launchpad/models/apple.py
+++ b/src/launchpad/models/apple.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import List
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from launchpad.parsers.apple.objc_symbol_type_aggregator import ObjCSymbolTypeGroup
+from launchpad.parsers.apple.swift_symbol_type_aggregator import SwiftSymbolTypeGroup
 
 from .common import BaseAnalysisResults, BaseAppInfo, BaseBinaryAnalysis
 from .insights import DuplicateFilesInsightResult
@@ -73,6 +77,7 @@ class MachOBinaryAnalysis(BaseBinaryAnalysis):
         description="Range mapping for binary content categorization",
         exclude=True,
     )
+    symbol_info: SymbolInfo | None = Field(None, description="Symbol information", exclude=True)
 
     @property
     def has_range_mapping(self) -> bool:
@@ -109,3 +114,9 @@ class AppleInsightResults(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     duplicate_files: DuplicateFilesInsightResult | None = Field(None, description="Duplicate files analysis")
+
+
+@dataclass
+class SymbolInfo:
+    swift_type_groups: List[SwiftSymbolTypeGroup]
+    objc_type_groups: List[ObjCSymbolTypeGroup]

--- a/src/launchpad/models/common.py
+++ b/src/launchpad/models/common.py
@@ -31,17 +31,6 @@ class BaseBinaryAnalysis(BaseModel):
     sections: Dict[str, int] = Field(default_factory=dict, description="Binary sections and their sizes")
 
 
-class SymbolInfo(BaseModel):
-    """Information about a binary symbol."""
-
-    model_config = ConfigDict(frozen=True)
-
-    name: str = Field(..., description="Symbol name")
-    mangled_name: str | None = Field(None, description="Mangled symbol name")
-    size: int = Field(..., ge=0, description="Symbol size in bytes")
-    type: str = Field(..., description="Symbol type")
-
-
 class FileAnalysis(BaseModel):
     """Analysis results for files in the app bundle."""
 

--- a/src/launchpad/parsers/apple/swift_symbol_type_aggregator.py
+++ b/src/launchpad/parsers/apple/swift_symbol_type_aggregator.py
@@ -75,6 +75,7 @@ class SwiftSymbolTypeAggregator:
 
         result: list[SwiftSymbolTypeGroup] = []
         for (module, type_name), symbols in type_groups.items():
+            symbols.sort(key=lambda x: x.size, reverse=True)
             result.append(
                 SwiftSymbolTypeGroup(module=module, type_name=type_name, symbol_count=len(symbols), symbols=symbols)
             )

--- a/src/launchpad/utils/treemap/macho_element_builder.py
+++ b/src/launchpad/utils/treemap/macho_element_builder.py
@@ -1,7 +1,9 @@
+from typing import List
+
 from launchpad.models.apple import MachOBinaryAnalysis
 
 from ...models.common import FileInfo
-from ...models.range_mapping import Range, RangeMap
+from ...models.range_mapping import Range
 from ...models.treemap import TreemapElement, TreemapType
 from ..logging import get_logger
 from .treemap_element_builder import TreemapElementBuilder
@@ -24,19 +26,25 @@ class MachOElementBuilder(TreemapElementBuilder):
     def build_element(self, file_info: FileInfo, display_name: str) -> TreemapElement | None:
         if file_info.path in self.binary_analysis_map:
             binary_analysis = self.binary_analysis_map[file_info.path]
-            if binary_analysis.range_map is not None:
-                # Create a binary treemap with sections
-                return self._build_binary_treemap(binary_analysis.range_map, display_name, file_info.path)
-            else:
-                logger.warning(f"Binary {file_info.path} found but has no range mapping")
+            return self._build_binary_treemap(display_name, file_info.path, binary_analysis)
         else:
             logger.warning(f"Binary {file_info.path} found but not in binary analysis map")
 
         # Fallback to default file element if no binary analysis is available
         return None
 
-    def _build_binary_treemap(self, range_map: RangeMap, name: str, binary_path: str | None = None) -> TreemapElement:
-        # Group ranges by tag
+    def _build_binary_treemap(
+        self, name: str, file_path: str, binary_analysis: MachOBinaryAnalysis
+    ) -> TreemapElement | None:
+        # Group ranges by tag (like DEX builder groups by package)
+        range_map = binary_analysis.range_map
+        symbol_info = binary_analysis.symbol_info
+        symbol_groups = symbol_info.get_symbols_by_section() if symbol_info else {}
+
+        if range_map is None:
+            logger.warning(f"Binary {name} has no range mapping")
+            return None
+
         ranges_by_tag: dict[str, list[Range]] = {}
         for range_obj in range_map.ranges:
             tag = range_obj.tag.value
@@ -66,14 +74,23 @@ class MachOElementBuilder(TreemapElementBuilder):
             elif tag == "external_methods":
                 element_type = TreemapType.EXTERNAL_METHODS
 
+            # Check if we have symbol info for this section
+            symbol_children = []
+            section_name = self._tag_to_section_name(tag)
+            if section_name and symbol_groups:
+                section_symbols = symbol_groups.get(section_name, [])
+                symbol_children = self._create_symbol_elements(section_symbols)
+            else:
+                logger.warning(f"No section name found for tag {tag}")
+
             element = TreemapElement(
                 name=tag,
                 install_size=total_size,
                 download_size=total_size,  # TODO: add download size
                 element_type=element_type,
                 path=None,
-                is_directory=False,
-                children=[],
+                is_directory=bool(symbol_children),
+                children=symbol_children,
                 details={"tag": tag},
             )
 
@@ -122,8 +139,41 @@ class MachOElementBuilder(TreemapElementBuilder):
             install_size=total_size,
             download_size=total_size,
             element_type=TreemapType.EXECUTABLES,
-            path=binary_path,
+            path=file_path,
             is_directory=True,
             children=children,
             details={},
         )
+
+    def _tag_to_section_name(self, tag: str) -> str | None:
+        """Convert a binary tag to a section name for symbol lookup."""
+        # Map binary tags to section names
+        tag_to_section = {
+            "text_segment": "__text",
+            "data_segment": "__data",
+            "const_data": "__const",
+            "swift_metadata": "__swift5_types",
+            "objc_classes": "__objc_classlist",
+            "c_strings": "__cstring",
+            "cfstrings": "__cfstring",
+        }
+        return tag_to_section.get(tag)
+
+    def _create_symbol_elements(self, symbols: list[tuple[str, str, int, int]]) -> list[TreemapElement]:
+        """Create treemap elements for symbols, similar to DEX builder's _create_class_element."""
+        symbol_elements: List[TreemapElement] = []
+
+        for module, name, address, size in symbols:
+            symbol_element = TreemapElement(
+                name=f"{module}.{name}",
+                install_size=size,
+                download_size=size,
+                element_type=TreemapType.MODULES,
+                path=None,
+                is_directory=False,
+                children=[],
+                details={"symbol_name": name, "address": address, "size": size},
+            )
+            symbol_elements.append(symbol_element)
+
+        return symbol_elements


### PR DESCRIPTION
This PR does a few things:
- takes the aggregate symbol size information and converts that to treemap nodes
- adds those treemap nodes to the correct binary sections
- removes some old logic that was rewriting section names in a more confusing way

There's still one level of grouping we can do in follow-up which is to combine type data across multiple sections in the binary, which our old code used to perform. For example you can see the same type information spread out in multiple spots across `__text`, `__data`, etc:
<img width="455" alt="Screenshot 2025-07-01 at 1 09 22 PM" src="https://github.com/user-attachments/assets/31ea905f-ba4b-47bc-a24c-8bc641760a09" />
