### PR TITLE
chore: silence warnings when running service tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*


### PR DESCRIPTION
```
tests/test_integration.py:129
  /Users/nicolashinderling/dev/launchpad/tests/test_integration.py:129: PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.integration

tests/test_service.py::TestLaunchpadServer::test_health_check
tests/test_service.py::TestLaunchpadServer::test_ready_check
  /Users/nicolashinderling/dev/launchpad/src/launchpad/server.py:84: DeprecationWarning: debug argument is deprecated
    app = web.Application(

tests/test_service.py::TestLaunchpadServer::test_health_check
tests/test_service.py::TestLaunchpadServer::test_ready_check
  /Users/nicolashinderling/dev/launchpad/src/launchpad/server.py:90: NotAppKeyWarning: It is recommended to use web.AppKey instances for keys.
  https://docs.aiohttp.org/en/stable/web_advanced.html#application-s-config
    app["debug"] = self.config["debug"]

tests/test_service.py::TestLaunchpadServer::test_health_check
tests/test_service.py::TestLaunchpadServer::test_ready_check
  /Users/nicolashinderling/dev/launchpad/src/launchpad/server.py:91: NotAppKeyWarning: It is recommended to use web.AppKey instances for keys.
  https://docs.aiohttp.org/en/stable/web_advanced.html#application-s-config
    app["environment"] = self.config["environment"]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```