### PR TITLE
Download build-tools such as apksigner

### DIFF
--- a/scripts/deps
+++ b/scripts/deps
@@ -52,6 +52,7 @@ class Dep:
     architecture: Optional[str] = None
     system: Optional[str] = None
     binaries: Optional[List[Bin]] = None
+    content_hash: Optional[str] = None  # Hash of extracted content instead of archive
 
     def __post_init__(self):
         assert self.architecture and self.system or (not self.architecture and not self.system), (
@@ -59,6 +60,10 @@ class Dep:
         )
         assert self.architecture is None or self.architecture in KNOWN_ARCHITECTURES, f"{self.architecture} not known"
         assert self.system is None or self.system in KNOWN_SYSTEMS, f"{self.system} not known"
+        # Either hash or content_hash should be provided, but not both. Treat empty string as not set for content_hash.
+        hash_set = self.hash is not None
+        content_hash_set = self.content_hash not in (None, "")
+        assert hash_set != content_hash_set, f"{self!r} must define hash xor content_hash"
 
     def __str__(self):
         if self.is_machine_dependent():
@@ -114,6 +119,30 @@ DEPS = [
         ],
     ),
     Dep(
+        "build-tools.tar.gz",
+        "https://android.googlesource.com/platform/prebuilts/sdk/+archive/refs/tags/android-12.0.0_r34/tools/linux.tar.gz",
+        hash=None,
+        architecture="x86_64",
+        system="linux",
+        content_hash="80730e9f25590bcbda80bca9e02f59c66e937a68032fe40b78a5e71a58e9c975",
+        binaries=[
+            Bin(source="build-tools/lib/apksigner.jar", target="apksigner.jar"),
+            Bin(source="build-tools/bin/apksigner", target="apksigner"),
+        ],
+    ),
+    Dep(
+        "build-tools.tar.gz",
+        "https://android.googlesource.com/platform/prebuilts/sdk/+archive/refs/tags/android-12.0.0_r34/tools/darwin.tar.gz",
+        hash=None,
+        architecture="x86_64",
+        system="darwin",
+        content_hash="1520caa90f3aefb742fa12ddc05d04aa85a10108a49a7cb4470e6feae4b83b6b",
+        binaries=[
+            Bin(source="build-tools/lib/apksigner.jar", target="apksigner.jar"),
+            Bin(source="build-tools/bin/apksigner", target="apksigner"),
+        ],
+    ),
+    Dep(
         "webp.tar.gz",
         "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0-linux-x86-64.tar.gz",
         "f4bf49f85991f50e86a5404d16f15b72a053bb66768ed5cc0f6d042277cc2bb8",
@@ -165,6 +194,31 @@ def hash_file(path):
         return hashlib.sha256(f.read()).hexdigest()
 
 
+def hash_extracted_content(dep):
+    """Calculate hash of extracted content for content-based verification."""
+    if not dep.is_archive():
+        return None
+
+    target_path = dep.target_path()
+    if not os.path.exists(target_path):
+        return None
+
+    content_hash = hashlib.sha256()
+
+    for root, dirs, files in os.walk(target_path):
+        # Sort for deterministic ordering
+        dirs.sort()
+        files.sort()
+
+        for file in files:
+            file_path = os.path.join(root, file)
+            # Hash the file content
+            with open(file_path, "rb") as f:
+                content_hash.update(f.read())
+
+    return content_hash.hexdigest()
+
+
 def check_call(*args, **kwargs):
     try:
         return subprocess.check_call(args, **kwargs)
@@ -190,11 +244,22 @@ def ensure_good_binary(dep, binary):
 def ensure_good_dep(dep):
     download_path = dep.download_path()
     assert os.path.exists(download_path)
-    actual = hash_file(download_path)
-    expected = dep.hash
-    assert actual == expected, f"Expected hash for {dep} to be {expected} was {actual}"
-    if dep.is_archive():
-        assert os.path.exists(dep.target_path())
+
+    if dep.content_hash:
+        # Content-based verification
+        if dep.is_archive():
+            assert os.path.exists(dep.target_path())
+            actual = hash_extracted_content(dep)
+            expected = dep.content_hash
+            assert actual == expected, f"Expected content hash for {dep} to be {expected} was {actual}"
+    else:
+        # Archive-based verification
+        actual = hash_file(download_path)
+        expected = dep.hash
+        assert actual == expected, f"Expected hash for {dep} to be {expected} was {actual}"
+        if dep.is_archive():
+            assert os.path.exists(dep.target_path())
+
     for binary in dep.get_binaries():
         ensure_good_binary(dep, binary)
 
@@ -237,6 +302,7 @@ def main():
     parser.add_argument(
         "--check", action="store_true", help="Don't download dependencies just check if they are up-to-date"
     )
+
     parser.add_argument(
         "--local-architecture",
         default=get_architecture(),
@@ -288,7 +354,18 @@ def main():
                         if os.path.isdir(child):
                             for p in os.listdir(child):
                                 shutil.move(os.path.join(child, p), target_path)
-                        remove_tree(child)
+                            remove_tree(child)
+
+                # Special handling for build-tools: move lib files to bin directory
+                if dep.name == "build-tools.tar.gz":
+                    lib_dir = os.path.join(target_path, "lib")
+                    bin_dir = os.path.join(target_path, "bin")
+                    if os.path.exists(lib_dir) and os.path.exists(bin_dir):
+                        for file in os.listdir(lib_dir):
+                            lib_file = os.path.join(lib_dir, file)
+                            bin_file = os.path.join(bin_dir, file)
+                            if os.path.isfile(lib_file):
+                                shutil.copy2(lib_file, bin_file)
 
             for binary in dep.get_binaries():
                 ensure_dir(dep.bin_directory())


### PR DESCRIPTION
This also adds the ability to calculate the content has instead of the
archive hash since the hash was not consistent for the build-tools.