### PR TITLE
Add support for SI units

### DIFF
--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -114,6 +114,7 @@ class AndroidAnalyzer:
             file_analysis=file_analysis,
             insights=insights,
             analysis_duration=None,
+            uses_si_units=False,
         )
 
     def _get_file_analysis(self, apks: list[APK]) -> FileAnalysis:

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -114,7 +114,7 @@ class AndroidAnalyzer:
             file_analysis=file_analysis,
             insights=insights,
             analysis_duration=None,
-            uses_si_units=False,
+            use_si_units=False,
         )
 
     def _get_file_analysis(self, apks: list[APK]) -> FileAnalysis:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -161,7 +161,7 @@ class AppleAppAnalyzer:
             treemap=treemap,
             insights=insights,
             analysis_duration=None,
-            uses_si_units=True,
+            use_si_units=True,
         )
 
         return results

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -161,6 +161,7 @@ class AppleAppAnalyzer:
             treemap=treemap,
             insights=insights,
             analysis_duration=None,
+            uses_si_units=True,
         )
 
         return results

--- a/src/launchpad/size/models/common.py
+++ b/src/launchpad/size/models/common.py
@@ -76,6 +76,7 @@ class BaseAnalysisResults(BaseModel):
     analysis_duration: float | None = Field(None, ge=0, description="Analysis duration in seconds")
     file_analysis: FileAnalysis = Field(..., description="File-level analysis results")
     treemap: TreemapResults | None = Field(..., description="Hierarchical size analysis treemap")
+    uses_si_units: bool = Field(default=False, description="Whether to use SI units for size display")
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary with serializable datetime."""

--- a/src/launchpad/size/models/common.py
+++ b/src/launchpad/size/models/common.py
@@ -76,7 +76,7 @@ class BaseAnalysisResults(BaseModel):
     analysis_duration: float | None = Field(None, ge=0, description="Analysis duration in seconds")
     file_analysis: FileAnalysis = Field(..., description="File-level analysis results")
     treemap: TreemapResults | None = Field(..., description="Hierarchical size analysis treemap")
-    uses_si_units: bool = Field(default=False, description="Whether to use SI units for size display")
+    use_si_units: bool = Field(default=False, description="Whether to use SI units for size display")
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary with serializable datetime."""

--- a/src/launchpad/size/treemap/treemap_builder.py
+++ b/src/launchpad/size/treemap/treemap_builder.py
@@ -342,6 +342,6 @@ class TreemapBuilder:
 
 # Platform-specific filesystem block sizes (in bytes)
 FILESYSTEM_BLOCK_SIZES = {
-    "ios": 4 * 1024,  # iOS uses 4KB filesystem blocks
+    "ios": 4 * 1000,  # iOS uses 4KB filesystem blocks
     "android": 4 * 1024,  # Android typically uses 4KB as well
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,14 +2,14 @@ import { useState } from 'react';
 import './App.css';
 import FileUpload from './components/FileUpload';
 import TreemapVisualization from './components/TreemapVisualization';
-import type { TreemapResults } from './types/treemap';
+import type { FileAnalysisReport } from './utils/dataConverter';
 
 function App() {
-  const [treemapData, setTreemapData] = useState<TreemapResults | null>(null);
+  const [treemapData, setTreemapData] = useState<FileAnalysisReport | null>(null);
   const [sizeMode, setSizeMode] = useState<'install' | 'download'>('install');
   const [error, setError] = useState<string | null>(null);
 
-  const handleDataLoad = (data: TreemapResults) => {
+  const handleDataLoad = (data: FileAnalysisReport) => {
     setTreemapData(data);
     setError(null);
   };
@@ -24,9 +24,9 @@ function App() {
     setError(null);
   };
 
-  const formatBytes = (bytes: number): string => {
+  const formatBytes = (bytes: number, usesSiUnits: boolean): string => {
     if (bytes === 0) return '0 Bytes';
-    const k = 1024;
+    const k = usesSiUnits ? 1000 : 1024;
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];

--- a/web/src/components/FileUpload.tsx
+++ b/web/src/components/FileUpload.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import type { TreemapResults } from '../types/treemap';
-import { convertFileAnalysisToTreemap, detectDataFormat, validateTreemapData } from '../utils/dataConverter';
+import type { FileAnalysisReport } from '../utils/dataConverter';
+import { parseFileAnalysisReport } from '../utils/dataConverter';
 
 interface FileUploadProps {
-  onDataLoad: (data: TreemapResults) => void;
+  onDataLoad: (data: FileAnalysisReport) => void;
   onError: (error: string) => void;
 }
 
@@ -26,58 +26,11 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onDataLoad, onError }) =
       console.log('Raw data keys:', Object.keys(rawData));
       console.log('Raw data sample:', JSON.stringify(rawData, null, 2).substring(0, 1000) + '...');
 
-      // Check if the data has a treemap property
-      if ('treemap' in rawData) {
-        // Validate TreemapResults format
-        const validation = validateTreemapData(rawData.treemap);
-        console.log('TreemapResults validation:', validation);
-        if (!validation.isValid) {
-          throw new Error(`Invalid TreemapResults format: ${validation.error}`);
-        }
-        onDataLoad(rawData.treemap);
-      } else {
-        // Detect the data format for file analysis support
-        const format = detectDataFormat(rawData);
-        console.log('Detected format:', format);
+      // Parse the file analysis report
+      const report = parseFileAnalysisReport(rawData);
 
-        if (format === 'treemap') {
-          // Validate TreemapResults format
-          const validation = validateTreemapData(rawData);
-          console.log('TreemapResults validation:', validation);
-          if (!validation.isValid) {
-            throw new Error(`Invalid TreemapResults format: ${validation.error}`);
-          }
-          onDataLoad(rawData);
-        } else if (format === 'file_analysis') {
-          // Convert file analysis format to TreemapResults
-          console.log('Converting file analysis format to treemap format...');
-          const treemapData = convertFileAnalysisToTreemap(rawData);
-          console.log('Converted treemap data:', {
-            total_install_size: treemapData.total_install_size,
-            file_count: treemapData.file_count,
-            platform: treemapData.platform,
-            root_children_count: treemapData.root.children.length
-          });
-          onDataLoad(treemapData);
-        } else {
-          console.error('Unknown format detected. Raw data structure:', {
-            keys: Object.keys(rawData),
-            hasRoot: 'root' in rawData,
-            hasFileAnalysis: 'file_analysis' in rawData,
-            hasAppInfo: 'app_info' in rawData,
-            hasTotalInstallSize: 'total_install_size' in rawData,
-            hasTotalDownloadSize: 'total_download_size' in rawData
-          });
-          throw new Error(
-            'Unsupported file format. Expected either:\n' +
-            '1. JSON with "treemap" property containing TreemapResults\n' +
-            '2. Direct TreemapResults format\n' +
-            '3. File analysis format\n\n' +
-            'Please check that your JSON file matches one of these formats.\n' +
-            `Detected keys: ${Object.keys(rawData).join(', ')}`
-          );
-        }
-      }
+      // Pass the full report
+      onDataLoad(report);
     } catch (err) {
       if (err instanceof SyntaxError) {
         onError('Invalid JSON file. Please check that the file contains valid JSON.');
@@ -99,9 +52,9 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onDataLoad, onError }) =
       }
       const rawData = await response.json();
 
-      // The sample data is in file analysis format, so convert it
-      const treemapData = convertFileAnalysisToTreemap(rawData);
-      onDataLoad(treemapData);
+      // Parse the file analysis report
+      const report = parseFileAnalysisReport(rawData);
+      onDataLoad(report);
     } catch (err) {
       onError(`Error loading sample data: ${err instanceof Error ? err.message : 'Unknown error'}`);
     } finally {
@@ -175,7 +128,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onDataLoad, onError }) =
                 Drop a JSON file here or click to select
               </div>
               <div style={{ fontSize: '14px', color: '#666' }}>
-                Supports TreemapResults format and file analysis files
+                Supports FileAnalysisReport format
               </div>
             </div>
           )}

--- a/web/src/components/TreemapVisualization.tsx
+++ b/web/src/components/TreemapVisualization.tsx
@@ -170,7 +170,7 @@ export const TreemapVisualization: React.FC<TreemapVisualizationProps> = ({
             </div>
             <div style="font-family: Rubik; line-height: 1;">
               <p style="font-size: 14px; font-weight: bold; margin-bottom: -2px;">${info.name}</p>
-              <p style="font-size: 12px; margin-bottom: -4px;">Size: ${formatBytes(value, data.uses_si_units)}</p>
+              <p style="font-size: 12px; margin-bottom: -4px;">Size: ${formatBytes(value, data.use_si_units)}</p>
               <p style="font-size: 12px;">Percentage: ${percent}%</p>
             </div>
           </div>

--- a/web/src/components/TreemapVisualization.tsx
+++ b/web/src/components/TreemapVisualization.tsx
@@ -1,10 +1,11 @@
 import ReactECharts from 'echarts-for-react';
 import React from 'react';
-import type { EChartsTreemapData, TreemapElement, TreemapResults } from '../types/treemap';
+import type { EChartsTreemapData, TreemapElement } from '../types/treemap';
 import { TreemapType } from '../types/treemap';
+import type { FileAnalysisReport } from '../utils/dataConverter';
 
 interface TreemapVisualizationProps {
-  data: TreemapResults;
+  data: FileAnalysisReport;
   sizeMode: 'install' | 'download';
 }
 
@@ -69,9 +70,9 @@ const TYPE_COLORS: Record<TreemapType, string> = {
   [TreemapType.UNMAPPED]: COLORS.purple,
 };
 
-function formatBytes(bytes: number): string {
+function formatBytes(bytes: number, usesSiUnits: boolean): string {
   if (bytes === 0) return '0 Bytes';
-  const k = 1024;
+  const k = usesSiUnits ? 1000 : 1024;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
@@ -141,8 +142,9 @@ export const TreemapVisualization: React.FC<TreemapVisualizationProps> = ({
   data,
   sizeMode
 }) => {
-  const chartData = convertToEChartsData(data.root, sizeMode);
-  const totalSize = sizeMode === 'install' ? data.total_install_size : data.total_download_size;
+  const treemapData = data.treemap;
+  const chartData = convertToEChartsData(treemapData.root, sizeMode);
+  const totalSize = sizeMode === 'install' ? treemapData.total_install_size : treemapData.total_download_size;
 
   const option = {
     tooltip: {
@@ -168,7 +170,7 @@ export const TreemapVisualization: React.FC<TreemapVisualizationProps> = ({
             </div>
             <div style="font-family: Rubik; line-height: 1;">
               <p style="font-size: 14px; font-weight: bold; margin-bottom: -2px;">${info.name}</p>
-              <p style="font-size: 12px; margin-bottom: -4px;">Size: ${formatBytes(value)}</p>
+              <p style="font-size: 12px; margin-bottom: -4px;">Size: ${formatBytes(value, data.uses_si_units)}</p>
               <p style="font-size: 12px;">Percentage: ${percent}%</p>
             </div>
           </div>

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -32,7 +32,7 @@ export interface FileAnalysisReport {
     [key: string]: unknown;
   };
   generated_at: string;
-  uses_si_units: boolean;
+  use_si_units: boolean;
 }
 
 export function parseFileAnalysisReport(data: unknown): FileAnalysisReport {

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -1,5 +1,4 @@
-import type { TreemapElement, TreemapResults } from '../types/treemap';
-import { TreemapType } from '../types/treemap';
+import type { TreemapResults } from '../types/treemap';
 
 // File analysis format interfaces
 interface FileAnalysisFile {
@@ -24,266 +23,22 @@ interface AppInfo {
   bundle_id: string;
 }
 
-interface FileAnalysisReport {
+export interface FileAnalysisReport {
   file_analysis: FileAnalysisData;
+  treemap: TreemapResults;
   app_info: AppInfo;
   binary_analysis?: {
     executable_size: number;
     [key: string]: unknown;
   };
   generated_at: string;
+  uses_si_units: boolean;
 }
 
-// File type to TreemapType mapping
-const FILE_TYPE_TO_TREEMAP_TYPE: Record<string, TreemapType> = {
-  'unknown': TreemapType.EXECUTABLES,
-  'png': TreemapType.ASSETS,
-  'jpg': TreemapType.ASSETS,
-  'jpeg': TreemapType.ASSETS,
-  'gif': TreemapType.ASSETS,
-  'svg': TreemapType.ASSETS,
-  'car': TreemapType.COMPILED_RESOURCES,
-  'plist': TreemapType.PLISTS,
-  'mobileprovision': TreemapType.SIGNATURES,
-  'ttf': TreemapType.RESOURCES,
-  'otf': TreemapType.RESOURCES,
-  'xcprivacy': TreemapType.MANIFESTS,
-  'bundle': TreemapType.RESOURCES,
-  'framework': TreemapType.FRAMEWORKS,
-  'dylib': TreemapType.FRAMEWORKS,
-  'a': TreemapType.FRAMEWORKS,
-};
-
-export function detectDataFormat(data: unknown): 'treemap' | 'file_analysis' | 'unknown' {
-  console.log('detectDataFormat called with data type:', typeof data);
-
+export function parseFileAnalysisReport(data: unknown): FileAnalysisReport {
   if (typeof data !== 'object' || data === null) {
-    console.log('detectDataFormat: data is not an object or is null');
-    return 'unknown';
+    throw new Error('Data must be an object');
   }
 
-  const obj = data as Record<string, unknown>;
-  console.log('detectDataFormat: object keys:', Object.keys(obj));
-
-  // Check for TreemapResults format
-  const hasRoot = 'root' in obj;
-  const hasTotalInstallSize = 'total_install_size' in obj;
-  const hasTotalDownloadSize = 'total_download_size' in obj;
-
-  console.log('TreemapResults format check:', {
-    hasRoot,
-    hasTotalInstallSize,
-    hasTotalDownloadSize
-  });
-
-  if (hasRoot && hasTotalInstallSize && hasTotalDownloadSize) {
-    console.log('detectDataFormat: detected as treemap format');
-    return 'treemap';
-  }
-
-  // Check for file analysis format
-  const hasFileAnalysis = 'file_analysis' in obj;
-  const hasAppInfo = 'app_info' in obj;
-
-  console.log('File analysis format check:', {
-    hasFileAnalysis,
-    hasAppInfo
-  });
-
-  if (hasFileAnalysis && hasAppInfo) {
-    console.log('detectDataFormat: detected as file analysis format');
-    return 'file_analysis';
-  }
-
-  console.log('detectDataFormat: format unknown');
-  return 'unknown';
-}
-
-export function convertFileAnalysisToTreemap(fileAnalysisData: FileAnalysisReport): TreemapResults {
-  const { file_analysis, app_info, binary_analysis } = fileAnalysisData;
-
-  // Create a map to store directory elements
-  const directoryMap = new Map<string, TreemapElement>();
-  const categoryBreakdown: Record<string, Record<string, number>> = {};
-
-  // Helper function to get or create directory element
-  function getOrCreateDirectory(path: string): TreemapElement {
-    if (directoryMap.has(path)) {
-      return directoryMap.get(path)!;
-    }
-
-    const parts = path.split('/');
-    const name = parts[parts.length - 1] || path;
-    const element: TreemapElement = {
-      name,
-      install_size: 0,
-      download_size: 0,
-      element_type: TreemapType.FILES,
-      path,
-      is_directory: true,
-      children: [],
-      details: {},
-    };
-    directoryMap.set(path, element);
-    return element;
-  }
-
-  // Process all files and build the tree
-  for (const [fileType, files] of Object.entries(file_analysis.files_by_type)) {
-    if (files.length === 0) continue;
-
-    const treemapType = FILE_TYPE_TO_TREEMAP_TYPE[fileType] || TreemapType.OTHER;
-
-    for (const file of files) {
-      const filePath = file.path;
-      const parts = filePath.split('/');
-      const fileName = parts[parts.length - 1];
-
-      // Create file element
-      const fileElement: TreemapElement = {
-        name: fileName,
-        install_size: file.size,
-        download_size: Math.round(file.size * 0.8), // Estimate 80% compression
-        element_type: treemapType,
-        path: filePath,
-        is_directory: false,
-        children: [],
-        details: {
-          file_type: file.file_type,
-          hash_md5: file.hash_md5,
-        },
-      };
-
-      // Add to category breakdown
-      if (!categoryBreakdown[treemapType]) {
-        categoryBreakdown[treemapType] = {};
-      }
-      if (!categoryBreakdown[treemapType][fileType]) {
-        categoryBreakdown[treemapType][fileType] = 0;
-      }
-      categoryBreakdown[treemapType][fileType] += file.size;
-
-      // Build directory structure
-      let currentPath = '';
-      for (let i = 0; i < parts.length - 1; i++) {
-        currentPath = currentPath ? `${currentPath}/${parts[i]}` : parts[i];
-        const dirElement = getOrCreateDirectory(currentPath);
-
-        // If this is the parent directory of the file, add the file as a child
-        if (i === parts.length - 2) {
-          dirElement.children.push(fileElement);
-          dirElement.install_size += file.size;
-          dirElement.download_size += Math.round(file.size * 0.8);
-        }
-      }
-    }
-  }
-
-  // Get the root directory
-  const rootElement: TreemapElement = {
-    name: app_info.name || 'App',
-    install_size: file_analysis.total_size,
-    download_size: Math.round(file_analysis.total_size * 0.8),
-    element_type: undefined,
-    path: undefined,
-    is_directory: true,
-    children: Array.from(directoryMap.values()).filter(dir => !dir.path?.includes('/')),
-    details: {
-      app_version: app_info.version,
-      app_build: app_info.build,
-      bundle_id: app_info.bundle_id,
-      executable_size: binary_analysis?.executable_size || 0,
-    },
-  };
-
-  return {
-    root: rootElement,
-    total_install_size: file_analysis.total_size,
-    total_download_size: Math.round(file_analysis.total_size * 0.8),
-    file_count: file_analysis.file_count,
-    category_breakdown: categoryBreakdown,
-    platform: 'ios', // Assume iOS for file analysis format
-  };
-}
-
-export function validateTreemapData(data: unknown): { isValid: boolean; error?: string } {
-  console.log('validateTreemapData called');
-
-  if (typeof data !== 'object' || data === null) {
-    return { isValid: false, error: 'Data must be an object' };
-  }
-
-  const obj = data as Record<string, unknown>;
-  console.log('Validating TreemapResults with keys:', Object.keys(obj));
-
-  if (!('root' in obj)) {
-    return { isValid: false, error: 'Missing "root" property' };
-  }
-
-  if (typeof obj.root !== 'object' || obj.root === null) {
-    return { isValid: false, error: '"root" property must be an object' };
-  }
-
-  const root = obj.root as Record<string, unknown>;
-  console.log('Root object keys:', Object.keys(root));
-
-  if (typeof obj.total_install_size !== 'number') {
-    return {
-      isValid: false,
-      error: `Missing or invalid "total_install_size" property. Got: ${typeof obj.total_install_size} (${obj.total_install_size})`
-    };
-  }
-
-  if (typeof obj.total_download_size !== 'number') {
-    return {
-      isValid: false,
-      error: `Missing or invalid "total_download_size" property. Got: ${typeof obj.total_download_size} (${obj.total_download_size})`
-    };
-  }
-
-  if (typeof obj.file_count !== 'number') {
-    return {
-      isValid: false,
-      error: `Missing or invalid "file_count" property. Got: ${typeof obj.file_count} (${obj.file_count})`
-    };
-  }
-
-  // Validate root element structure
-  if (typeof root.name !== 'string') {
-    return {
-      isValid: false,
-      error: `Root element missing or invalid "name" property. Got: ${typeof root.name}`
-    };
-  }
-
-  if (typeof root.install_size !== 'number') {
-    return {
-      isValid: false,
-      error: `Root element missing or invalid "install_size" property. Got: ${typeof root.install_size}`
-    };
-  }
-
-  if (typeof root.download_size !== 'number') {
-    return {
-      isValid: false,
-      error: `Root element missing or invalid "download_size" property. Got: ${typeof root.download_size}`
-    };
-  }
-
-  if (typeof root.is_directory !== 'boolean') {
-    return {
-      isValid: false,
-      error: `Root element missing or invalid "is_directory" property. Got: ${typeof root.is_directory}`
-    };
-  }
-
-  if (!Array.isArray(root.children)) {
-    return {
-      isValid: false,
-      error: `Root element missing or invalid "children" property. Got: ${typeof root.children}`
-    };
-  }
-
-  console.log('TreemapResults validation passed');
-  return { isValid: true };
+  return data as FileAnalysisReport;
 }


### PR DESCRIPTION
Apple platforms use SI units when displaying file sizes (multiples of 1000 instead of 1024). It took me forever to realize this is why the sizes were slightly off for the iOS treemap. Now they both match up:

<img width="478" alt="Screenshot 2025-07-08 at 11 06 36 AM" src="https://github.com/user-attachments/assets/6c3259c0-cc00-4c0b-b4a5-e918e7ff7cc4" />

<img width="458" alt="Screenshot 2025-07-08 at 11 06 44 AM" src="https://github.com/user-attachments/assets/71c087de-17c7-4d1f-883e-c7965167b40e" />
