### PR TITLE
Implement LargeLocalizedStrings analysis for iOS

### DIFF
--- a/src/launchpad/size/insights/apple/localized_strings.py
+++ b/src/launchpad/size/insights/apple/localized_strings.py
@@ -3,9 +3,32 @@ from launchpad.size.models.apple import LocalizedStringInsightResult
 
 
 class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
-    def generate(self, input: InsightsInput) -> LocalizedStringInsightResult:
-        return LocalizedStringInsightResult(
-            files=[],
-            file_count=0,
-            total_size=0,
-        )
+    """Insight for analyzing localized strings files in iOS apps."""
+
+    # 100KB threshold for reporting localized strings
+    THRESHOLD_BYTES = 100 * 1024  # 100KB
+
+    def generate(self, input: InsightsInput) -> LocalizedStringInsightResult | None:
+        """Generate insight for localized strings files.
+
+        Finds all Localizable.strings files in *.lproj directories,
+        calculates total size, and returns insight if above threshold.
+        """
+        localized_files = []
+        total_size = 0
+
+        # Find all Localizable.strings files in *.lproj directories
+        for file_info in input.file_analysis.files:
+            # Check if file path ends with *.lproj/Localizable.strings
+            if file_info.path.endswith(".lproj/Localizable.strings"):
+                localized_files.append(file_info)
+                total_size += file_info.size
+
+        # Only return insight if total size exceeds threshold
+        if total_size > self.THRESHOLD_BYTES:
+            return LocalizedStringInsightResult(
+                files=localized_files,
+                total_savings=total_size,
+            )
+
+        return None

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -44,8 +44,6 @@ class LocalizedStringInsightResult(BaseInsightResult):
     """Results from localized string analysis."""
 
     files: List[FileInfo] = Field(..., description="Localized strings files exceeding 100KB threshold")
-    file_count: int = Field(..., description="Total number of localized strings files")
-    total_size: int = Field(..., description="Total size of all localized strings files")
 
 
 class AppleAppInfo(BaseAppInfo):

--- a/tests/unit/test_localized_strings_insight.py
+++ b/tests/unit/test_localized_strings_insight.py
@@ -1,0 +1,232 @@
+from unittest.mock import Mock
+
+from launchpad.size.insights.apple.localized_strings import LocalizedStringsInsight
+from launchpad.size.insights.insight import InsightsInput
+from launchpad.size.models.apple import LocalizedStringInsightResult
+from launchpad.size.models.common import BaseAppInfo, FileAnalysis, FileInfo
+from launchpad.size.models.treemap import TreemapType
+
+
+class TestLocalizedStringsInsight:
+    def setup_method(self):
+        self.insight = LocalizedStringsInsight()
+
+    def test_generate_with_large_localized_strings(self):
+        """Test that insight is generated when total size exceeds 100KB threshold."""
+        # Create localized strings files that exceed 100KB total
+        localized_file_1 = FileInfo(
+            full_path="en.lproj/Localizable.strings",
+            path="en.lproj/Localizable.strings",
+            size=60 * 1024,  # 60KB
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash1",
+        )
+        localized_file_2 = FileInfo(
+            full_path="es.lproj/Localizable.strings",
+            path="es.lproj/Localizable.strings",
+            size=50 * 1024,  # 50KB
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash2",
+        )
+        # Non-localized file that should be ignored
+        other_file = FileInfo(
+            full_path="assets/image.png",
+            path="assets/image.png",
+            size=1024,
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash3",
+        )
+
+        file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2, other_file])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LocalizedStringInsightResult)
+        assert len(result.files) == 2
+        assert result.total_savings == 110 * 1024  # 110KB total
+        assert result.files[0].path == "en.lproj/Localizable.strings"
+        assert result.files[1].path == "es.lproj/Localizable.strings"
+
+    def test_generate_with_small_localized_strings(self):
+        """Test that no insight is generated when total size is below 100KB threshold."""
+        # Create localized strings files that don't exceed 100KB total
+        localized_file_1 = FileInfo(
+            full_path="en.lproj/Localizable.strings",
+            path="en.lproj/Localizable.strings",
+            size=40 * 1024,  # 40KB
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash1",
+        )
+        localized_file_2 = FileInfo(
+            full_path="es.lproj/Localizable.strings",
+            path="es.lproj/Localizable.strings",
+            size=30 * 1024,  # 30KB
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash2",
+        )
+
+        file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert result is None  # Should return None when below threshold
+
+    def test_generate_with_exactly_threshold_size(self):
+        """Test that insight is generated when total size exactly equals 100KB threshold."""
+        localized_file = FileInfo(
+            full_path="en.lproj/Localizable.strings",
+            path="en.lproj/Localizable.strings",
+            size=100 * 1024,  # Exactly 100KB
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash1",
+        )
+
+        file_analysis = FileAnalysis(files=[localized_file])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert result is None  # Should return None when exactly at threshold
+
+    def test_generate_with_no_localized_strings(self):
+        """Test that no insight is generated when no localized strings files exist."""
+        other_file_1 = FileInfo(
+            full_path="assets/image.png",
+            path="assets/image.png",
+            size=1024,
+            file_type="png",
+            treemap_type=TreemapType.ASSETS,
+            hash_md5="hash1",
+        )
+        other_file_2 = FileInfo(
+            full_path="Info.plist",
+            path="Info.plist",
+            size=2048,
+            file_type="plist",
+            treemap_type=TreemapType.PLISTS,
+            hash_md5="hash2",
+        )
+
+        file_analysis = FileAnalysis(files=[other_file_1, other_file_2])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert result is None
+
+    def test_generate_with_empty_file_list(self):
+        """Test that no insight is generated with empty file list."""
+        file_analysis = FileAnalysis(files=[])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert result is None
+
+    def test_generate_ignores_non_localizable_strings(self):
+        """Test that only Localizable.strings files are considered, not other .strings files."""
+        localized_file = FileInfo(
+            full_path="en.lproj/Localizable.strings",
+            path="en.lproj/Localizable.strings",
+            size=150 * 1024,  # 150KB - should trigger insight
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash1",
+        )
+        other_strings_file = FileInfo(
+            full_path="en.lproj/Other.strings",
+            path="en.lproj/Other.strings",
+            size=50 * 1024,  # 50KB - should be ignored
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash2",
+        )
+
+        file_analysis = FileAnalysis(files=[localized_file, other_strings_file])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LocalizedStringInsightResult)
+        assert len(result.files) == 1
+        assert result.files[0].path == "en.lproj/Localizable.strings"
+        assert result.total_savings == 150 * 1024  # Only the Localizable.strings file
+
+    def test_generate_ignores_non_lproj_localizable_strings(self):
+        """Test that Localizable.strings files outside .lproj directories are ignored."""
+        valid_localized_file = FileInfo(
+            full_path="en.lproj/Localizable.strings",
+            path="en.lproj/Localizable.strings",
+            size=150 * 1024,  # 150KB - should be included
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash1",
+        )
+        invalid_localized_file = FileInfo(
+            full_path="Localizable.strings",  # Not in .lproj directory
+            path="Localizable.strings",
+            size=50 * 1024,  # 50KB - should be ignored
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash_md5="hash2",
+        )
+
+        file_analysis = FileAnalysis(files=[valid_localized_file, invalid_localized_file])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LocalizedStringInsightResult)
+        assert len(result.files) == 1
+        assert result.files[0].path == "en.lproj/Localizable.strings"
+        assert result.total_savings == 150 * 1024  # Only the valid file


### PR DESCRIPTION
This will trigger when the total size of the localized strings founds
exceeds 100KB to match the previous logic.

Happy to change the threshold or implement this in some other way.
For context, this is the action that should be performed to minimize the
strings: https://docs.emergetools.com/docs/minify-localized-strings