### PR TITLE
Add cursor rule to format imports using ruff.

### DIFF
--- a/.cursor/rules/launchpad.mdc
+++ b/.cursor/rules/launchpad.mdc
@@ -85,3 +85,4 @@ This is a Python CLI tool for analyzing iOS and Android app bundle sizes, simila
 3. Consider performance implications
 4. Follow existing patterns in the codebase
 5. Include relevant tests
+6. Format imports using ruff


### PR DESCRIPTION
I was still getting incorrectly ordered imports and after making this
change and testing this once, my imports were correctly formatted.
