### PR TITLE
Update treemap totalSize to be size vs sum of children

### DIFF
--- a/web/src/components/TreemapVisualization.tsx
+++ b/web/src/components/TreemapVisualization.tsx
@@ -86,19 +86,10 @@ function convertToEChartsData(
   const color = element.element_type ? TYPE_COLORS[element.element_type] : TYPE_COLORS[TreemapType.OTHER];
 
   let children: EChartsTreemapData[] | undefined;
-  let totalSize = size;
-
-  if (element.children && element.children.length > 0) {
-    children = element.children.map(child => convertToEChartsData(child, sizeMode));
-    // Calculate total size from children for directories
-    if (element.is_directory) {
-      totalSize = children.reduce((sum, child) => sum + (child.value || 0), 0);
-    }
-  }
 
   const data: EChartsTreemapData = {
     name: element.name,
-    value: totalSize,
+    value: size,
     itemStyle: {
       color: 'transparent',
       borderColor: color,


### PR DESCRIPTION
Overall Dex node will need to show `install_size` rather than sum of children due to the nature of how we show private size for individual dex nodes, but overall size for dex (will document this in our future docs). This removes the aggregate `totalSize` calculation and just uses the user's selected size.