### PR TITLE
Add Strip Symbols analysis for xcarchives.

### DIFF
--- a/src/launchpad/size/insights/apple/strip_symbols.py
+++ b/src/launchpad/size/insights/apple/strip_symbols.py
@@ -1,7 +1,78 @@
+import os
+import shutil
+import subprocess
+import tempfile
+
+from pathlib import Path
+from typing import List
+
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.apple import StripBinaryInsightResult
+from launchpad.size.models.apple import MachOBinaryAnalysis, StripBinaryFileInfo, StripBinaryInsightResult
+from launchpad.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class StripSymbolsInsight(Insight[StripBinaryInsightResult]):
-    def generate(self, insights_input: InsightsInput) -> StripBinaryInsightResult:
-        return StripBinaryInsightResult(files=[], total_savings=0)
+    """Insight for analyzing potential savings from stripping Mach-O binaries.
+
+    This insight identifies how much space could be saved by stripping debug symbols
+    and other unnecessary data from Mach-O binaries, matching the Swift BundleAnalyzer.
+    """
+
+    MIN_STRIPPED_SAVINGS = 2 * 1024  # 2KB
+
+    def generate(self, insights_input: InsightsInput) -> StripBinaryInsightResult | None:
+        strip_files: List[StripBinaryFileInfo] = []
+        total_savings = 0
+
+        for binary_analysis in insights_input.binary_analysis:
+            if not isinstance(binary_analysis, MachOBinaryAnalysis):
+                continue
+            binary_path = Path(binary_analysis.binary_path)
+            if "Watch" in str(binary_path) or "watch" in str(binary_path).lower():
+                logger.debug(f"Skipping Watch app binary: {binary_path}")
+                continue
+            try:
+                savings = self._calculate_actual_strip_savings(binary_path)
+            except Exception as e:
+                logger.warning(f"Failed to calculate strip savings for {binary_path}: {e}")
+                continue
+            if savings > self.MIN_STRIPPED_SAVINGS:
+                strip_file_info = StripBinaryFileInfo(
+                    macho_binary=binary_analysis,
+                    size_saved=savings,
+                )
+                strip_files.append(strip_file_info)
+                total_savings += savings
+                logger.debug(f"Found strip savings for {binary_path}: {savings} bytes")
+        if strip_files:
+            return StripBinaryInsightResult(
+                files=strip_files,
+                total_savings=total_savings,
+            )
+        return None
+
+    def _calculate_actual_strip_savings(self, binary_path: Path) -> int:
+        """Actually strip a temp copy of the binary and return the size savings, using correct flags."""
+        orig_size = os.stat(binary_path).st_size
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            shutil.copy2(binary_path, tmp_path)
+            is_dylib = binary_path.suffix == ".dylib"
+            if is_dylib:
+                strip_cmd = ["strip", "-rSTx", "-no_code_signature_warning", tmp_path]
+            else:
+                strip_cmd = ["strip", "-STx", "-no_code_signature_warning", tmp_path]
+            result = subprocess.run(strip_cmd, capture_output=True)
+            if result.returncode != 0:
+                raise RuntimeError(f"strip failed: {result.stderr.decode().strip()}")
+            stripped_size = os.stat(tmp_path).st_size
+            savings = orig_size - stripped_size
+            return savings if savings > 0 else 0
+        finally:
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -81,8 +81,7 @@ class StripBinaryFileInfo(BaseModel):
     """Savings information from stripping a Mach-O binary."""
 
     macho_binary: MachOBinaryAnalysis = Field(..., description="Mach-O binary analysis")
-    install_size_saved: int = Field(..., description="Install size saved by stripping the binary")
-    download_size_saved: int = Field(..., description="Download size saved by stripping the binary")
+    size_saved: int = Field(..., description="Size saved by stripping the binary")
 
 
 class StripBinaryInsightResult(BaseInsightResult):

--- a/tests/integration/size/test_strip_symbols_insight.py
+++ b/tests/integration/size/test_strip_symbols_insight.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
+from launchpad.size.analyzers.apple import AppleAppAnalyzer
+
+
+class TestStripSymbolsInsightIntegration:
+    def test_strip_symbols_with_hackernews_analyzer(self):
+        artifact_path = Path("tests/_fixtures/ios/HackerNews-Debug.xcarchive.zip")
+
+        analyzer = AppleAppAnalyzer(
+            skip_swift_metadata=True,
+            skip_symbols=True,
+            skip_image_analysis=True,
+            skip_insights=False,
+        )
+
+        artifact = ZippedXCArchive(artifact_path)
+        results = analyzer.analyze(artifact)
+
+        assert results is not None
+        assert results.app_info is not None
+        assert results.file_analysis is not None
+        assert results.binary_analysis is not None
+        assert len(results.binary_analysis) > 0
+
+        assert results.insights is not None
+
+        strip_insight = results.insights.strip_binary
+
+        assert strip_insight.total_savings == 97552
+        assert len(strip_insight.files) == 2
+        assert strip_insight.files[0].size_saved == 85696
+        assert strip_insight.files[1].size_saved == 11856


### PR DESCRIPTION
This is based on the logic in `BundleAnalyzer.swift`.

I created a test fixture from the hacker news app by deleting the strip
symbols script. This was useful for testing but adds a lot of size to
this PR.
