### PR TITLE
Remove optional path arg from bundletool/apksigner

### DIFF
--- a/src/launchpad/utils/android/apksigner.py
+++ b/src/launchpad/utils/android/apksigner.py
@@ -21,24 +21,17 @@ class ApksignerError(Exception):
 class Apksigner:
     """Wrapper around Android's apksigner CLI utility."""
 
-    def __init__(self, apksigner_path: str | Path | None = None) -> None:
+    apksigner_path: str
+
+    def __init__(self) -> None:
         """Initialize apksigner wrapper.
 
-        Args:
-            apksigner_path: Optional path to apksigner executable file. If not provided,
-                will attempt to find apksigner in PATH.
-
         Raises:
-            FileNotFoundError: If apksigner cannot be found at specified path or in PATH
+            AssertionError: If apksigner cannot be found on PATH
         """
-        if apksigner_path is None:
-            apksigner_path = shutil.which("apksigner")
-            if apksigner_path is None:
-                raise FileNotFoundError("apksigner not found in PATH.")
-
-        self.apksigner_path = Path(apksigner_path)
-        if not self.apksigner_path.exists():
-            raise FileNotFoundError(f"apksigner not found at {apksigner_path}")
+        apksigner_path = shutil.which("apksigner")
+        assert apksigner_path is not None
+        self.apksigner_path = apksigner_path
 
     def get_certs(self, apk_path: Path) -> str:
         """Get certificates for an APK.
@@ -49,7 +42,7 @@ class Apksigner:
         Returns:
             String containing certificate information
         """
-        cmd = [str(self.apksigner_path), "verify", "--print-certs", str(apk_path)]
+        cmd = [self.apksigner_path, "verify", "--print-certs", str(apk_path)]
 
         logger.debug("Running apksigner command: %s", " ".join(cmd))
 

--- a/src/launchpad/utils/android/bundletool.py
+++ b/src/launchpad/utils/android/bundletool.py
@@ -36,25 +36,17 @@ class BundletoolError(Exception):
 class Bundletool:
     """Wrapper around Android's bundletool CLI utility."""
 
-    def __init__(self, bundletool_path: str | Path | None = None) -> None:
+    bundletool_path: str
+
+    def __init__(self) -> None:
         """Initialize bundletool wrapper.
 
-        Args:
-            bundletool_path: Optional path to bundletool executable file. If not provided,
-                will attempt to find bundletool in PATH.
-
         Raises:
-            FileNotFoundError: If bundletool cannot be found at specified path or in PATH
+            AssertionError: If bundletool cannot be found on PATH
         """
-        if bundletool_path is None:
-            # TODO: Ensure packaged in docker image when productionizing
-            bundletool_path = shutil.which("bundletool")
-            if bundletool_path is None:
-                raise FileNotFoundError("bundletool not found in PATH. Install with `brew install bundletool`")
-
-        self.bundletool_path = Path(bundletool_path)
-        if not self.bundletool_path.exists():
-            raise FileNotFoundError(f"bundletool not found at {bundletool_path}")
+        bundletool_path = shutil.which("bundletool")
+        assert bundletool_path is not None
+        self.bundletool_path = bundletool_path
 
     def _run_command(self, command: list[str], **kwargs: Any) -> tuple[int, str, str]:
         """Run a bundletool command.


### PR DESCRIPTION
  We are not going to need that functionality for the forseeable and it
  complicates the code a bit.

  Also:
  - Remove empty file src/launchpad/utils/android/keystore.py
  - Add types for member variables