### PR TITLE
Improve symbol stripping speed

### DIFF
--- a/src/launchpad/size/cli.py
+++ b/src/launchpad/size/cli.py
@@ -191,10 +191,10 @@ def _print_file_analysis_table(file_analysis: FileAnalysis) -> None:
 def _print_apple_summary(results: AppleAnalysisResults) -> None:
     """Print a brief summary of the analysis."""
     file_analysis = results.file_analysis
-    binary_analysis = results.binary_analysis
     insights = results.insights
 
     console.print("\n[bold]Summary:[/bold]")
+    console.print(f"• Duration: {results.analysis_duration:.2f} seconds")
     console.print(f"• App name: [cyan]{results.app_info.name}[/cyan]")
     console.print(f"• Total app size: [cyan]{_format_bytes(file_analysis.total_size)}[/cyan]")
     console.print(f"• File count: [cyan]{file_analysis.file_count:,}[/cyan]")
@@ -204,13 +204,6 @@ def _print_apple_summary(results: AppleAnalysisResults) -> None:
             f"• Potential savings from duplicates: "
             f"[yellow]{_format_bytes(insights.duplicate_files.total_savings)}[/yellow]"
         )
-
-    if binary_analysis:
-        for binary in binary_analysis:
-            console.print(f"\nExecutable Size: {binary.executable_size / 1024 / 1024:.1f} MB")
-            console.print(f"Architectures: {', '.join(binary.architectures)}")
-            console.print(f"Linked Libraries: {len(binary.linked_libraries)}")
-            console.print(f"Sections: {len(binary.sections)}")
 
 
 def _format_bytes(size: int) -> str:


### PR DESCRIPTION
So far improves from 52.659s -> 36.434s:
```
           INFO         │   └── apple.test_strip_symbols_removal: 35.803s (72.5 %)  [16×, avg 2.238s]        
           INFO         │       ├── strip_symbols.remove_symbols: 32.954s (66.8 %)  [16×, avg 2.060s]        
           INFO         │       ├── strip_symbols.create_binary_copy: 1.663s ( 3.4 %)  [16×, avg 0.104s]     
           INFO         │       ├── strip_symbols.write_and_measure: 0.896s ( 1.8 %)  [16×, avg 0.056s]      
           INFO         │       ├── strip_symbols.analyze_symbols: 0.243s ( 0.5 %)  [16×, avg 0.015s]        
           INFO         │       ├── strip_symbols.check_swift_imageinfo: 0.014s ( 0.0 %)  [16×, avg 0.001s]  
           INFO         │       └── strip_symbols.get_original_size: 0.002s ( 0.0 %)  [16×, avg 0.000s]  
```

Faster although still a lot slower than I hoped.