### PR TITLE
Add app_id as common between Android and iOS, wireup frontend to use it

### DIFF
--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -63,7 +63,7 @@ class AndroidAnalyzer:
             name=manifest_dict["application"]["label"] or "Unknown",
             version=manifest_dict["version_name"] or "Unknown",
             build=manifest_dict["version_code"] or "Unknown",
-            package_name=manifest_dict["package_name"],
+            app_id=manifest_dict["package_name"],
         )
 
         return self.app_info

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -21,10 +21,9 @@ from launchpad.size.insights.common.large_videos import LargeVideoFileInsight
 from launchpad.size.insights.insight import InsightsInput
 from launchpad.size.models.android import (
     AndroidAnalysisResults,
-    AndroidAppInfo,
     AndroidInsightResults,
 )
-from launchpad.size.models.common import FileAnalysis, FileInfo
+from launchpad.size.models.common import BaseAppInfo, FileAnalysis, FileInfo
 from launchpad.size.models.treemap import FILE_TYPE_TO_TREEMAP_TYPE, TreemapType
 from launchpad.size.treemap.treemap_builder import TreemapBuilder
 from launchpad.utils.file_utils import calculate_file_hash
@@ -46,9 +45,9 @@ class AndroidAnalyzer:
         **kwargs,
     ) -> None:
         self.skip_insights = skip_insights
-        self.app_info: AndroidAppInfo | None = None
+        self.app_info: BaseAppInfo | None = None
 
-    def preprocess(self, artifact: AndroidArtifact) -> AndroidAppInfo:
+    def preprocess(self, artifact: AndroidArtifact) -> BaseAppInfo:
         """Extract basic app information from the manifest.
 
         Args:
@@ -59,7 +58,7 @@ class AndroidAnalyzer:
         """
         manifest_dict = artifact.get_manifest().model_dump()
 
-        self.app_info = AndroidAppInfo(
+        self.app_info = BaseAppInfo(
             name=manifest_dict["application"]["label"] or "Unknown",
             version=manifest_dict["version_name"] or "Unknown",
             build=manifest_dict["version_code"] or "Unknown",

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -220,7 +220,7 @@ class AppleAppAnalyzer:
 
         return AppleAppInfo(
             name=plist.get("CFBundleName", "Unknown"),
-            bundle_id=plist.get("CFBundleIdentifier", "unknown.bundle.id"),
+            app_id=plist.get("CFBundleIdentifier", "unknown.bundle.id"),
             version=plist.get("CFBundleShortVersionString", "Unknown"),
             build=plist.get("CFBundleVersion", "Unknown"),
             executable=plist.get("CFBundleExecutable", "Unknown"),

--- a/src/launchpad/size/cli.py
+++ b/src/launchpad/size/cli.py
@@ -41,12 +41,22 @@ from launchpad.utils.performance import GLOBAL_REGISTRY
     type=click.Path(path_type=Path),
     help="Working directory for temporary files (default: system temp).",
 )
-@click.option("--skip-swift-metadata", is_flag=True, help="Skip Swift metadata parsing for faster analysis.")
+@click.option(
+    "--skip-swift-metadata",
+    is_flag=True,
+    help="Skip Swift metadata parsing for faster analysis.",
+)
 @click.option("--skip-symbols", is_flag=True, help="Skip symbol extraction and analysis.")
 @click.option(
-    "--skip-component-analysis", is_flag=True, help="Skip detailed binary component analysis for faster processing."
+    "--skip-component-analysis",
+    is_flag=True,
+    help="Skip detailed binary component analysis for faster processing.",
 )
-@click.option("--skip-treemap", is_flag=True, help="Skip treemap generation for hierarchical size analysis.")
+@click.option(
+    "--skip-treemap",
+    is_flag=True,
+    help="Skip treemap generation for hierarchical size analysis.",
+)
 def size_command(
     input_path: Path,
     output: TextIO,
@@ -130,7 +140,7 @@ def _print_apple_table_output(results: AppleAnalysisResults) -> None:
 
     app_info = results.app_info
     app_table.add_row("Name", app_info.name)
-    app_table.add_row("Bundle ID", app_info.bundle_id)
+    app_table.add_row("Bundle ID", app_info.app_id)
     app_table.add_row("Version", f"{app_info.version} ({app_info.build})")
     app_table.add_row("Min OS", app_info.minimum_os_version)
     app_table.add_row("Platforms", ", ".join(app_info.supported_platforms))
@@ -167,7 +177,7 @@ def _print_android_table_output(results: AndroidAnalysisResults) -> None:
 
     app_info = results.app_info
     app_table.add_row("Name", app_info.name)
-    app_table.add_row("Package Name", app_info.package_name)
+    app_table.add_row("Package Name", app_info.app_id)
     app_table.add_row("Version", f"{app_info.version} ({app_info.build})")
 
     console.print(app_table)

--- a/src/launchpad/size/models/android.py
+++ b/src/launchpad/size/models/android.py
@@ -10,10 +10,6 @@ from .insights import (
 )
 
 
-class AndroidAppInfo(BaseAppInfo):
-    model_config = ConfigDict(frozen=True)
-
-
 class OptimizeableImageFile(BaseModel):
     model_config = ConfigDict(frozen=True)
     file_info: FileInfo = Field(..., description="File info")
@@ -39,7 +35,7 @@ class AndroidInsightResults(BaseModel):
 
 class AndroidAnalysisResults(BaseAnalysisResults):
     model_config = ConfigDict(frozen=True)
-    app_info: AndroidAppInfo = Field(..., description="Android app information")
+    app_info: BaseAppInfo = Field(..., description="Android app information")
     insights: AndroidInsightResults | None = Field(
         description="Generated insights from the analysis",
     )

--- a/src/launchpad/size/models/android.py
+++ b/src/launchpad/size/models/android.py
@@ -12,7 +12,6 @@ from .insights import (
 
 class AndroidAppInfo(BaseAppInfo):
     model_config = ConfigDict(frozen=True)
-    package_name: str = Field(..., description="Android package name")
 
 
 class OptimizeableImageFile(BaseModel):

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -60,7 +60,6 @@ class AppleAppInfo(BaseAppInfo):
     model_config = ConfigDict(frozen=True)
 
     executable: str = Field(..., description="Main executable name")
-    bundle_id: str = Field(..., description="Bundle identifier")
     minimum_os_version: str = Field(..., description="Minimum app version")
     supported_platforms: List[str] = Field(default_factory=list, description="Supported platforms")
     sdk_version: str | None = Field(None, description="App SDK version used for build")

--- a/src/launchpad/size/models/common.py
+++ b/src/launchpad/size/models/common.py
@@ -19,6 +19,7 @@ class BaseAppInfo(BaseModel):
     name: str = Field(..., description="App display name")
     version: str = Field(..., description="App version")
     build: str = Field(..., description="Build number")
+    app_id: str = Field(..., description="App ID (bundle id on iOS, package name on Android)")
 
 
 class BaseBinaryAnalysis(BaseModel):
@@ -62,7 +63,11 @@ class FileInfo(BaseModel):
 
     path: str = Field(..., description="Relative path in the bundle")
     full_path: Path = Field(..., exclude=True, description="Fully qualified path to the file")
-    size: int = Field(..., ge=0, description="Raw file size in bytes with no filesystem block size adjustments")
+    size: int = Field(
+        ...,
+        ge=0,
+        description="Raw file size in bytes with no filesystem block size adjustments",
+    )
     file_type: str = Field(..., description="File type/extension")
     hash_md5: str = Field(..., description="MD5 hash of file contents")
     treemap_type: TreemapType = Field(..., description="Type for treemap visualization")

--- a/src/launchpad/size/runner.py
+++ b/src/launchpad/size/runner.py
@@ -8,12 +8,11 @@ from launchpad.artifacts.artifact import AndroidArtifact, AppleArtifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.size.analyzers.android import AndroidAnalyzer
 from launchpad.size.analyzers.apple import AppleAppAnalyzer
-from launchpad.size.models.android import AndroidAppInfo
 from launchpad.size.models.apple import AppleAppInfo
-from launchpad.size.models.common import BaseAnalysisResults
+from launchpad.size.models.common import BaseAnalysisResults, BaseAppInfo
 
 
-def do_preprocess(path: Path, **flags: Any) -> AndroidAppInfo | AppleAppInfo:
+def do_preprocess(path: Path, **flags: Any) -> BaseAppInfo | AppleAppInfo:
     """Perform preprocessing step only to extract basic app info.
 
     Args:

--- a/tests/integration/size/test_treemap_generation.py
+++ b/tests/integration/size/test_treemap_generation.py
@@ -73,8 +73,8 @@ class TestTreemapGeneration:
         # Verify app info
         app_info_name = results.app_info.name
         assert app_info_name == "Hacker News"
-        app_info_package_name = results.app_info.package_name
-        assert app_info_package_name == "com.emergetools.hackernews"
+        app_info_app_id = results.app_info.app_id
+        assert app_info_app_id == "com.emergetools.hackernews"
         app_info_version = results.app_info.version
         assert app_info_version == "1.0.2"
         app_info_build = results.app_info.build
@@ -163,8 +163,8 @@ class TestTreemapGeneration:
         # Verify app info
         app_info_name = results.app_info.name
         assert app_info_name == "Hacker News"
-        app_info_package_name = results.app_info.package_name
-        assert app_info_package_name == "com.emergetools.hackernews"
+        app_info_app_id = results.app_info.app_id
+        assert app_info_app_id == "com.emergetools.hackernews"
         app_info_version = results.app_info.version
         assert app_info_version == "1.0.2"
         app_info_build = results.app_info.build

--- a/tests/unit/test_android_analyzer.py
+++ b/tests/unit/test_android_analyzer.py
@@ -25,7 +25,7 @@ class TestAndroidAnalyzer:
         results = android_analyzer.analyze(artifact)
 
         assert results.app_info.name == "Hacker News"
-        assert results.app_info.package_name == "com.emergetools.hackernews"
+        assert results.app_info.app_id == "com.emergetools.hackernews"
         assert results.file_analysis is not None
         assert len(results.file_analysis.files) > 0
 

--- a/tests/unit/test_strip_symbols_insight.py
+++ b/tests/unit/test_strip_symbols_insight.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 from launchpad.size.insights.apple.strip_symbols import StripSymbolsInsight
 from launchpad.size.insights.insight import InsightsInput
-from launchpad.size.models.apple import MachOBinaryAnalysis, StripBinaryInsightResult, SymbolInfo
+from launchpad.size.models.apple import (
+    MachOBinaryAnalysis,
+    StripBinaryInsightResult,
+    SymbolInfo,
+)
 from launchpad.size.models.common import BaseAppInfo, FileAnalysis
 
 
@@ -36,7 +40,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
@@ -77,7 +81,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
@@ -123,7 +127,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
@@ -209,7 +213,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[binary_analysis_1, binary_analysis_2, binary_analysis_3],
@@ -265,7 +269,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
@@ -300,7 +304,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
@@ -322,7 +326,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[non_macho_binary],
@@ -362,7 +366,7 @@ class TestStripSymbolsInsight:
         )
 
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
@@ -387,7 +391,7 @@ class TestStripSymbolsInsight:
     def test_generate_with_empty_binary_analysis(self):
         """Test that no insight is generated when binary_analysis is empty."""
         insights_input = InsightsInput(
-            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1"),
+            app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
             file_analysis=FileAnalysis(files=[]),
             treemap=None,
             binary_analysis=[],  # Empty list

--- a/web/src/components/AppInfoDisplay.tsx
+++ b/web/src/components/AppInfoDisplay.tsx
@@ -43,20 +43,23 @@ const AppInfoDisplay: React.FC<AppInfoDisplayProps> = ({ data }) => {
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
           gap: '0.75rem',
-          marginBottom: '1rem'
+          marginBottom: '1rem',
+          color: '#6c757d'
         }}>
           <div>
-            <strong style={{ color: '#6c757d' }}>Version:</strong> {data.app_info.version}
+            <strong>Version:</strong> {data.app_info.version}
           </div>
           <div>
-            <strong style={{ color: '#6c757d' }}>Build:</strong> {data.app_info.build}
+            <strong>Build:</strong> {data.app_info.build}
           </div>
           <div>
-            <strong style={{ color: '#6c757d' }}>Bundle ID:</strong> {data.app_info.bundle_id}
+            <strong>App ID:</strong> {data.app_info.app_id}
           </div>
-          <div>
-            <strong style={{ color: '#6c757d' }}>Executable:</strong> {data.app_info.executable}
-          </div>
+          {data.app_info.executable && (
+            <div>
+              <strong>Executable:</strong> {data.app_info.executable}
+            </div>
+          )}
         </div>
       </div>
 

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -17,10 +17,11 @@ interface FileAnalysisData {
 
 interface AppInfo {
   name: string;
+  app_id: string;
   version: string;
   build: string;
-  executable: string;
-  bundle_id: string;
+  // iOS-specific
+  executable?: string;
   minimum_os_version?: string;
   supported_platforms?: string[];
   sdk_version?: string;


### PR DESCRIPTION
Set our universal `app_id` terminology rather than use separate `bundle_id` and `package_name` on iOS

<img width="906" height="401" alt="Screenshot 2025-07-16 at 1 41 33 PM" src="https://github.com/user-attachments/assets/701a5eb0-1aab-4b6b-97de-4573e6cf1c21" />
