### PR TITLE
Wireup app name and app id to update data

### DIFF
--- a/src/launchpad/api/update_api_models.py
+++ b/src/launchpad/api/update_api_models.py
@@ -1,0 +1,22 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class AppleAppInfo(BaseModel):
+    is_simulator: bool
+    codesigning_type: Optional[str] = None
+    profile_name: Optional[str] = None
+    is_code_signature_valid: Optional[bool] = None
+    code_signature_errors: Optional[List[str]] = None
+    # TODO: add "date_built" field once exposed in 'AppleAppInfo'
+
+
+class UpdateData(BaseModel):
+    app_name: str
+    app_id: str
+    build_version: str
+    build_number: Optional[int]
+    artifact_type: str
+    apple_app_info: Optional[AppleAppInfo] = None
+    # TODO: add "date_built" and custom android fields

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -401,7 +401,6 @@ class LaunchpadService:
                 self._safe_cleanup(temp_file, "temporary file")
             raise
 
-    # TODO
     def _prepare_update_data(self, app_info: AppleAppInfo | BaseAppInfo, artifact: Artifact) -> Dict[str, Any]:
         def _get_artifact_type(artifact: Artifact) -> ArtifactType:
             if isinstance(artifact, ZippedXCArchive):
@@ -418,9 +417,7 @@ class LaunchpadService:
             "build_number": (int(app_info.build) if app_info.build.isdigit() else None),
             "artifact_type": _get_artifact_type(artifact).value,
         }
-        logger.info(f"Update data: {update_data}")
 
-        """Prepare update data based on app platform and artifact type."""
         if isinstance(app_info, AppleAppInfo):
             # TODO: add "date_built" field once exposed in 'AppleAppInfo'
             update_data["apple_app_info"] = {
@@ -430,6 +427,7 @@ class LaunchpadService:
                 "is_code_signature_valid": app_info.is_code_signature_valid,
                 "code_signature_errors": app_info.code_signature_errors,
             }
+
         # TODO: add "date_built" and custom android fields
         return update_data
 

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -21,6 +21,7 @@ from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
 from launchpad.artifacts.android.aab import AAB
 from launchpad.artifacts.android.zipped_aab import ZippedAAB
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
+from launchpad.artifacts.artifact import Artifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.constants import (
     HEALTHCHECK_MAX_AGE_SECONDS,
@@ -221,7 +222,13 @@ class LaunchpadService:
             detailed_error = str(e)
 
             self._update_artifact_error(
-                sentry_client, artifact_id, project_id, organization_id, error_code, error_message, detailed_error
+                sentry_client,
+                artifact_id,
+                project_id,
+                organization_id,
+                error_code,
+                error_message,
+                detailed_error,
             )
             raise
 
@@ -260,21 +267,42 @@ class LaunchpadService:
     def _categorize_processing_error(self, exception: Exception) -> tuple[ProcessingErrorCode, ProcessingErrorMessage]:
         """Categorize an exception into error code and message."""
         if isinstance(exception, ValueError):
-            return ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR, ProcessingErrorMessage.ARTIFACT_PARSING_FAILED
+            return (
+                ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                ProcessingErrorMessage.ARTIFACT_PARSING_FAILED,
+            )
         elif isinstance(exception, NotImplementedError):
-            return ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR, ProcessingErrorMessage.UNSUPPORTED_ARTIFACT_TYPE
+            return (
+                ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                ProcessingErrorMessage.UNSUPPORTED_ARTIFACT_TYPE,
+            )
         elif isinstance(exception, FileNotFoundError):
-            return ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR, ProcessingErrorMessage.ARTIFACT_PARSING_FAILED
+            return (
+                ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                ProcessingErrorMessage.ARTIFACT_PARSING_FAILED,
+            )
         elif isinstance(exception, RuntimeError):
             error_str = str(exception).lower()
             if "timeout" in error_str:
-                return ProcessingErrorCode.ARTIFACT_PROCESSING_TIMEOUT, ProcessingErrorMessage.PROCESSING_TIMEOUT
+                return (
+                    ProcessingErrorCode.ARTIFACT_PROCESSING_TIMEOUT,
+                    ProcessingErrorMessage.PROCESSING_TIMEOUT,
+                )
             elif "preprocess" in error_str:
-                return ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR, ProcessingErrorMessage.PREPROCESSING_FAILED
+                return (
+                    ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                    ProcessingErrorMessage.PREPROCESSING_FAILED,
+                )
             elif "size" in error_str or "analysis" in error_str:
-                return ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR, ProcessingErrorMessage.SIZE_ANALYSIS_FAILED
+                return (
+                    ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                    ProcessingErrorMessage.SIZE_ANALYSIS_FAILED,
+                )
             else:
-                return ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR, ProcessingErrorMessage.UNKNOWN_ERROR
+                return (
+                    ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                    ProcessingErrorMessage.UNKNOWN_ERROR,
+                )
         else:
             return ProcessingErrorCode.UNKNOWN, ProcessingErrorMessage.UNKNOWN_ERROR
 
@@ -311,7 +339,10 @@ class LaunchpadService:
                 org=organization_id,
                 project=project_id,
                 artifact_id=artifact_id,
-                data={"error_code": error_code.value, "error_message": final_error_message},
+                data={
+                    "error_code": error_code.value,
+                    "error_message": final_error_message,
+                },
             )
 
             if isinstance(result, ErrorResult):
@@ -320,7 +351,10 @@ class LaunchpadService:
                 logger.info(f"Successfully updated artifact {artifact_id} with error information")
 
         except Exception as e:
-            logger.error(f"Failed to update artifact {artifact_id} with error information: {e}", exc_info=True)
+            logger.error(
+                f"Failed to update artifact {artifact_id} with error information: {e}",
+                exc_info=True,
+            )
 
     def _download_artifact_to_temp_file(
         self,
@@ -337,7 +371,10 @@ class LaunchpadService:
             with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as tf:
                 temp_file = tf.name
                 file_size = sentry_client.download_artifact_to_file(
-                    org=organization_id, project=project_id, artifact_id=artifact_id, out=tf
+                    org=organization_id,
+                    project=project_id,
+                    artifact_id=artifact_id,
+                    out=tf,
                 )
 
                 # Success case
@@ -364,30 +401,37 @@ class LaunchpadService:
                 self._safe_cleanup(temp_file, "temporary file")
             raise
 
-    def _prepare_update_data(self, app_info: AppleAppInfo | BaseAppInfo, artifact: Any) -> Dict[str, Any]:
+    # TODO
+    def _prepare_update_data(self, app_info: AppleAppInfo | BaseAppInfo, artifact: Artifact) -> Dict[str, Any]:
+        def _get_artifact_type(artifact: Artifact) -> ArtifactType:
+            if isinstance(artifact, ZippedXCArchive):
+                return ArtifactType.XCARCHIVE
+            elif isinstance(artifact, (AAB, ZippedAAB)):
+                return ArtifactType.AAB
+            else:
+                return ArtifactType.APK
+
+        update_data = {
+            "app_name": app_info.name,
+            "app_id": app_info.app_id,
+            "build_version": app_info.version,
+            "build_number": (int(app_info.build) if app_info.build.isdigit() else None),
+            "artifact_type": _get_artifact_type(artifact).value,
+        }
+        logger.info(f"Update data: {update_data}")
+
         """Prepare update data based on app platform and artifact type."""
         if isinstance(app_info, AppleAppInfo):
             # TODO: add "date_built" field once exposed in 'AppleAppInfo'
-            return {
-                "build_version": app_info.version,
-                "build_number": (int(app_info.build) if str(app_info.build).isdigit() else app_info.build),
-                "artifact_type": ArtifactType.XCARCHIVE.value,
-                "apple_app_info": {
-                    "is_simulator": app_info.is_simulator,
-                    "codesigning_type": app_info.codesigning_type,
-                    "profile_name": app_info.profile_name,
-                    "is_code_signature_valid": app_info.is_code_signature_valid,
-                    "code_signature_errors": app_info.code_signature_errors,
-                },
+            update_data["apple_app_info"] = {
+                "is_simulator": app_info.is_simulator,
+                "codesigning_type": app_info.codesigning_type,
+                "profile_name": app_info.profile_name,
+                "is_code_signature_valid": app_info.is_code_signature_valid,
+                "code_signature_errors": app_info.code_signature_errors,
             }
-        else:
-            artifact_type = ArtifactType.AAB if isinstance(artifact, (AAB, ZippedAAB)) else ArtifactType.APK
-            # TODO: add "date_built" and custom android fields
-            return {
-                "build_version": app_info.version,
-                "build_number": (int(app_info.build) if app_info.build.isdigit() else None),
-                "artifact_type": artifact_type.value,
-            }
+        # TODO: add "date_built" and custom android fields
+        return update_data
 
     def _create_analyzer(self, app_info: AppleAppInfo | BaseAppInfo) -> AndroidAnalyzer | AppleAppAnalyzer:
         """Create analyzer with preprocessed app info."""

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -19,7 +19,9 @@ from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
 )
 
 from launchpad.artifacts.android.aab import AAB
+from launchpad.artifacts.android.apk import APK
 from launchpad.artifacts.android.zipped_aab import ZippedAAB
+from launchpad.artifacts.android.zipped_apk import ZippedAPK
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import Artifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
@@ -407,8 +409,10 @@ class LaunchpadService:
                 return ArtifactType.XCARCHIVE
             elif isinstance(artifact, (AAB, ZippedAAB)):
                 return ArtifactType.AAB
-            else:
+            elif isinstance(artifact, (APK, ZippedAPK)):
                 return ArtifactType.APK
+            else:
+                raise ValueError(f"Unsupported artifact type: {type(artifact)}")
 
         update_data = {
             "app_name": app_info.name,

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -101,6 +101,7 @@ class AndroidAnalyzer:
             hermes_reports=hermes_reports,
         )
 
+        logger.debug("Building file treemap")
         treemap = treemap_builder.build_file_treemap(file_analysis)
 
         insights: AndroidInsightResults | None = None
@@ -133,6 +134,7 @@ class AndroidAnalyzer:
         )
 
     def _get_file_analysis(self, apks: list[APK]) -> FileAnalysis:
+        logger.debug("Getting file analysis")
         file_infos: list[FileInfo] = []
         total_size = 0
         path_to_file_info: dict[str, FileInfo] = {}
@@ -245,6 +247,7 @@ class AndroidAnalyzer:
         )
 
     def _get_class_definitions(self, apks: list[APK]) -> list[ClassDefinition]:
+        logger.debug("Getting class definitions")
         class_definitions: list[ClassDefinition] = []
         for apk in apks:
             class_definitions.extend(apk.get_class_definitions())
@@ -252,6 +255,7 @@ class AndroidAnalyzer:
 
     def _get_hermes_reports(self, apks: list[APK]) -> dict[str, HermesReport]:
         """Get Hermes reports from all APKs and combine them."""
+        logger.debug("Getting Hermes reports")
         all_reports: dict[str, HermesReport] = {}
         for apk in apks:
             extract_path = apk.get_extract_path()


### PR DESCRIPTION
Realized when working on the frontend that we weren't uploading app_name and app_id from the /update call. This wires up launchpad to send those fields and additionally shares the update logic between iOS and Android a bit better.