### PR TITLE
Use uv provided by devenv

### DIFF
--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -14,3 +14,15 @@ linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/down
 linux_x86_64_sha256 = bb4696825039a2b5dc7fea2c6aeb085c89fd397016b44165ec73b4224ccc83e2
 linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20250106/cpython-3.13.1+20250106-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = d37aef7bdf5c27f7d006918f7cedb31f4ba07c88f61baac4ffbe0bee6d4b5248
+
+[uv]
+darwin_arm64 = https://github.com/astral-sh/uv/releases/download/0.7.21/uv-aarch64-apple-darwin.tar.gz
+darwin_arm64_sha256 = c73af7a4e0bcea9b5b593a0c7e5c025ee78d8be3f7cd60bfeadc8614a16c92ef
+darwin_x86_64 = https://github.com/astral-sh/uv/releases/download/0.7.21/uv-x86_64-apple-darwin.tar.gz
+darwin_x86_64_sha256 = f8a9b4f4a80a44653344d36b53e148134176e8f7cc99f8e823676a57c884595e
+linux_arm64 = https://github.com/astral-sh/uv/releases/download/0.7.21/uv-aarch64-unknown-linux-gnu.tar.gz
+linux_arm64_sha256 = 1dae18211605b9d00767d913da5108aea50200a88372bf8a2e1f56abdbe509f0
+linux_x86_64 = https://github.com/astral-sh/uv/releases/download/0.7.21/uv-x86_64-unknown-linux-gnu.tar.gz
+linux_x86_64_sha256 = ca3e8898adfce5fcc891d393a079013fa4bd0d9636cef11aded8a7485bcba312
+# used for autoupdate
+version = 0.7.21


### PR DESCRIPTION
As of https://github.com/getsentry/devenv/pull/198 (1.22.0)
devenv includes support for `uv`. This switches us to use that version
of 'uv'. It doesn't yet unleash the full power of `uv` (uv sync,
uv lock, etc) but it cuts down on the amount of custom bits we have.

If you get an error like:

ImportError: cannot import name 'uv' from 'devenv.lib'

You need to update your version of devenv. Run:

rm -rf .venv
devenv update
devenv sync
