### PR TITLE
Return none for empty insights

### DIFF
--- a/src/launchpad/size/insights/common/hermes_debug_info.py
+++ b/src/launchpad/size/insights/common/hermes_debug_info.py
@@ -12,7 +12,7 @@ from launchpad.size.models.insights import (
 class HermesDebugInfoInsight(Insight[HermesDebugInfoInsightResult]):
     """Insight for identifying Hermes bytecode files with debug info that can be stripped."""
 
-    def generate(self, input: InsightsInput) -> HermesDebugInfoInsightResult:
+    def generate(self, input: InsightsInput) -> HermesDebugInfoInsightResult | None:
         """Generate insight for Hermes bytecode files with debug info.
 
         Identifies Hermes bytecode files that contain debug info sections
@@ -36,6 +36,9 @@ class HermesDebugInfoInsight(Insight[HermesDebugInfoInsightResult]):
                 if debug_info_size > 0:
                     files_with_debug_info.append(file_info)
                     total_savings += debug_info_size
+
+        if len(files_with_debug_info) == 0:
+            return None
 
         files_with_debug_info.sort(
             key=lambda f: input.hermes_reports[f.path]["sections"]["Debug info"]["bytes"]

--- a/src/launchpad/size/insights/common/large_audios.py
+++ b/src/launchpad/size/insights/common/large_audios.py
@@ -7,7 +7,7 @@ from launchpad.size.models.insights import (
 class LargeAudioFileInsight(Insight[LargeAudioFileInsightResult]):
     """Insight for identifying audio files larger than 5MB."""
 
-    def generate(self, input: InsightsInput) -> LargeAudioFileInsightResult:
+    def generate(self, input: InsightsInput) -> LargeAudioFileInsightResult | None:
         size_threshold_bytes = 5 * 1024 * 1024  # 5MB - chosen arbitrarily, we can change this later
 
         # Android supported audio types: https://developer.android.com/media/platform/supported-formats#audio-formats
@@ -30,6 +30,9 @@ class LargeAudioFileInsight(Insight[LargeAudioFileInsightResult]):
         audio_files = [file for file in input.file_analysis.files if file.file_type in audio_types]
 
         large_files = [file for file in audio_files if file.size > size_threshold_bytes]
+
+        if len(large_files) == 0:
+            return None
 
         # Sort by largest first
         large_files.sort(key=lambda f: f.size, reverse=True)

--- a/src/launchpad/size/insights/common/large_images.py
+++ b/src/launchpad/size/insights/common/large_images.py
@@ -5,7 +5,7 @@ from launchpad.size.models.insights import LargeImageFileInsightResult
 class LargeImageFileInsight(Insight[LargeImageFileInsightResult]):
     """Insight for identifying image files larger than 10MB."""
 
-    def generate(self, input: InsightsInput) -> LargeImageFileInsightResult:
+    def generate(self, input: InsightsInput) -> LargeImageFileInsightResult | None:
         size_threshold_bytes = 10 * 1024 * 1024  # 10MB - chosen arbitrarily, we can change this later
 
         # Android supported image types: https://developer.android.com/media/platform/supported-formats#image-formats
@@ -29,6 +29,9 @@ class LargeImageFileInsight(Insight[LargeImageFileInsightResult]):
         image_files = [file for file in input.file_analysis.files if file.file_type in image_types]
 
         large_files = [file for file in image_files if file.size > size_threshold_bytes]
+
+        if len(large_files) == 0:
+            return None
 
         # Sort by largest first
         large_files.sort(key=lambda f: f.size, reverse=True)

--- a/src/launchpad/size/insights/common/large_videos.py
+++ b/src/launchpad/size/insights/common/large_videos.py
@@ -7,7 +7,7 @@ from launchpad.size.models.insights import (
 class LargeVideoFileInsight(Insight[LargeVideoFileInsightResult]):
     """Insight for identifying video files larger than 10MB."""
 
-    def generate(self, input: InsightsInput) -> LargeVideoFileInsightResult:
+    def generate(self, input: InsightsInput) -> LargeVideoFileInsightResult | None:
         size_threshold_bytes = 10 * 1024 * 1024  # 10MB
 
         # Android supported video types: https://developer.android.com/media/platform/supported-formats#video-formats
@@ -16,6 +16,9 @@ class LargeVideoFileInsight(Insight[LargeVideoFileInsightResult]):
         video_files = [file for file in input.file_analysis.files if file.file_type in video_types]
 
         large_files = [file for file in video_files if file.size > size_threshold_bytes]
+
+        if len(large_files) == 0:
+            return None
 
         # Sort by largest first
         large_files.sort(key=lambda f: f.size, reverse=True)


### PR DESCRIPTION
Cleans up the response a bit, was seeing this for HackerNews:

```
  "large_images": {
    "total_savings": 0,
    "files": []
  },
  "large_videos": {
    "total_savings": 0,
    "files": []
  },
  "large_audio": {
    "total_savings": 0,
    "files": []
  },
```