### PR TITLE
Remove customer-3 from gocd deployment for initial testing

### DIFF
--- a/gocd/templates/launchpad.jsonnet
+++ b/gocd/templates/launchpad.jsonnet
@@ -9,6 +9,7 @@ local pipedream_config = {
     'us',
     'customer-1',
     'customer-2',
+    'customer-3',
     'customer-4',
     'customer-7',
   ],


### PR DESCRIPTION
<img width="1836" height="582" alt="image" src="https://github.com/user-attachments/assets/f9eab256-31e5-4b10-8909-0a41cf926863" />
We only want s4s and s4s2 for now. I want to make sure we don't accidentally deploy to any single tenant prod regions and cause issues while we're still testing