### PR TITLE
Fix various insights

### DIFF
--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -16,6 +16,7 @@ from launchpad.parsers.apple.macho_size_analyzer import MachOSizeAnalyzer
 from launchpad.parsers.apple.macho_symbol_sizes import MachOSymbolSizes
 from launchpad.parsers.apple.objc_symbol_type_aggregator import ObjCSymbolTypeAggregator
 from launchpad.parsers.apple.swift_symbol_type_aggregator import SwiftSymbolTypeAggregator
+from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.hermes.utils import make_hermes_reports
 from launchpad.size.insights.apple.image_optimization import ImageOptimizationInsight
 from launchpad.size.insights.apple.localized_strings import LocalizedStringsInsight
@@ -37,7 +38,7 @@ from launchpad.size.models.treemap import FILE_TYPE_TO_TREEMAP_TYPE, TreemapType
 from launchpad.size.treemap.treemap_builder import TreemapBuilder
 from launchpad.size.utils.apple_bundle_size import calculate_bundle_sizes
 from launchpad.utils.apple.code_signature_validator import CodeSignatureValidator
-from launchpad.utils.file_utils import calculate_file_hash, get_file_size
+from launchpad.utils.file_utils import calculate_file_hash, get_file_size, to_nearest_block_size
 from launchpad.utils.logging import get_logger
 from launchpad.utils.performance import trace, trace_ctx
 
@@ -338,7 +339,7 @@ class AppleAppAnalyzer:
                 continue
 
             relative_path = file_path.relative_to(app_bundle_path)
-            file_size = get_file_size(file_path)
+            file_size = to_nearest_block_size(get_file_size(file_path), APPLE_FILESYSTEM_BLOCK_SIZE)
 
             # Get file type from extension first
             # If no extension or unknown type, use file command

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -134,7 +134,7 @@ class AppleAppAnalyzer:
                 logger.info(f"Analyzing binary {binary_info.name} at {binary_info.path}")
                 if binary_info.dsym_path:
                     logger.debug(f"Found dSYM file for {binary_info.name} at {binary_info.dsym_path}")
-                binary = self._analyze_binary(binary_info)
+                binary = self._analyze_binary(binary_info, app_bundle_path)
                 if binary and binary.binary_analysis is not None:
                     binary_analysis.append(binary)
                     binary_analysis_map[str(binary_info.path.relative_to(app_bundle_path))] = binary
@@ -412,7 +412,9 @@ class AppleAppAnalyzer:
             return insight_class().generate(insights_input)
 
     @trace("apple.analyze_binary")
-    def _analyze_binary(self, binary_info: BinaryInfo, skip_swift_metadata: bool = False) -> MachOBinaryAnalysis | None:
+    def _analyze_binary(
+        self, binary_info: BinaryInfo, app_bundle_path: Path, skip_swift_metadata: bool = False
+    ) -> MachOBinaryAnalysis | None:
         binary_path = binary_info.path
         dwarf_binary_path = binary_info.dsym_path
         is_main_binary = binary_info.is_main_binary
@@ -486,7 +488,8 @@ class AppleAppAnalyzer:
             binary_analysis = analyzer.analyze()
 
         return MachOBinaryAnalysis(
-            binary_path=binary_path,
+            binary_absolute_path=binary_path,
+            binary_relative_path=str(binary_path.relative_to(app_bundle_path)),
             executable_size=executable_size,
             architectures=architectures,
             linked_libraries=linked_libraries,

--- a/src/launchpad/size/insights/apple/loose_images.py
+++ b/src/launchpad/size/insights/apple/loose_images.py
@@ -3,15 +3,13 @@ import re
 
 from collections import defaultdict
 
-from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.apple import LooseImageGroup, LooseImagesInsightResult
 from launchpad.size.models.common import FileInfo
-from launchpad.utils.file_utils import to_nearest_block_size
 
 
 class LooseImagesInsight(Insight[LooseImagesInsightResult]):
-    """Insight for analyzing loose images that are not included in iOS asset catalogs."""
+    """Insight for analyzing loose images that can benefit from app thinning via asset catalogs."""
 
     IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "pdf", "webp", "heif", "heic", "tiff", "tif", "bmp"}
 
@@ -19,11 +17,10 @@ class LooseImagesInsight(Insight[LooseImagesInsightResult]):
     CANONICAL_NAME_PATTERN = re.compile(r"^(.+?)(?:[@~][^.]*)?(\.[^.]+)$")
 
     def generate(self, input: InsightsInput) -> LooseImagesInsightResult | None:
-        """Generate insight for raw images analysis.
+        """Generate insight for loose images that can benefit from app thinning.
 
-        Finds all image files that are not in asset catalogs,
-        excludes system images like AppIcon and iMessage App Icon,
-        groups them by canonical name, and calculates potential savings.
+        Only includes image groups with multiple scale variants (e.g., @1x, @2x, @3x)
+        since these are the ones that can benefit from being moved to asset catalogs.
         """
 
         # Find all image files that are not in asset catalogs
@@ -41,44 +38,31 @@ class LooseImagesInsight(Insight[LooseImagesInsightResult]):
             canonical_name = self._get_canonical_image_name(image_file.path)
             image_groups_dict[canonical_name].append(image_file)
 
-        image_groups = [
+        # Only include groups with multiple images (multiple scale variants)
+        # Single images can't benefit from app thinning
+        multi_scale_groups = [
             LooseImageGroup(canonical_name=canonical_name, images=images)
             for canonical_name, images in image_groups_dict.items()
+            if len(images) > 1
         ]
 
-        image_groups.sort(key=lambda group: group.total_size, reverse=True)
+        if not multi_scale_groups:
+            return None
 
-        # Calculate total savings and avoid double-counting:
-        # 1. Files eliminated via app thinning: full block-aligned disk usage saved
-        # 2. Files that remain: only block alignment waste saved
-        # TODO: calculate code-signing overhead savings
+        multi_scale_groups.sort(key=lambda group: group.total_savings, reverse=True)
 
-        total_savings = 0
-        eliminated_files: set[str] = set()
-
-        # First pass: identify files that would be eliminated via app thinning
-        for group in image_groups:
-            eliminated_files.update(self._get_eliminated_files(group))
-
-        # Second pass: calculate savings for each file
-        for image_file in raw_image_files:
-            block_aligned_size = to_nearest_block_size(image_file.size, APPLE_FILESYSTEM_BLOCK_SIZE)
-
-            if image_file.path in eliminated_files:
-                # File eliminated via app thinning: save full block-aligned size
-                total_savings += block_aligned_size
-            else:
-                # File remains: save only block alignment waste
-                total_savings += block_aligned_size - image_file.size
+        # Calculate total savings: sum of savings from all groups
+        total_savings = sum(group.total_savings for group in multi_scale_groups)
+        total_file_count = sum(len(group.images) for group in multi_scale_groups)
 
         return LooseImagesInsightResult(
-            image_groups=image_groups,
-            total_file_count=len(raw_image_files),
+            image_groups=multi_scale_groups,
+            total_file_count=total_file_count,
             total_savings=total_savings,
         )
 
     def _is_loose_image_file(self, file_info: FileInfo) -> bool:
-        """Check if a file is a raw image that should be moved to an asset catalog."""
+        """Check if a file is a loose image that should be moved to an asset catalog."""
         # Must be an image file
         if file_info.file_type not in self.IMAGE_EXTENSIONS:
             return False

--- a/src/launchpad/size/insights/apple/main_binary_export_metadata.py
+++ b/src/launchpad/size/insights/apple/main_binary_export_metadata.py
@@ -5,6 +5,8 @@ from launchpad.size.models.apple import MachOBinaryAnalysis, MainBinaryExportMet
 class MainBinaryExportMetadataInsight(Insight[MainBinaryExportMetadataResult]):
     """Insight for analyzing the exported symbols metadata in the main binary."""
 
+    MIN_EXPORTS_THRESHOLD = 1024
+
     def generate(self, input: InsightsInput) -> MainBinaryExportMetadataResult | None:
         """Generate insight for main binary exported symbols analysis."""
 
@@ -23,7 +25,7 @@ class MainBinaryExportMetadataInsight(Insight[MainBinaryExportMetadataResult]):
                 dyld_exports_trie_component = component
                 break
 
-        if not dyld_exports_trie_component:
+        if not dyld_exports_trie_component or dyld_exports_trie_component.size < self.MIN_EXPORTS_THRESHOLD:
             return None
 
         return MainBinaryExportMetadataResult(total_savings=dyld_exports_trie_component.size)

--- a/src/launchpad/size/insights/apple/small_files.py
+++ b/src/launchpad/size/insights/apple/small_files.py
@@ -20,6 +20,9 @@ class SmallFilesInsight(Insight[SmallFilesInsightResult]):
         small_files: list[FileInfo] = []
         total_savings = 0
 
+        if len(input.file_analysis.files) < self.TOTAL_FILES_THRESHOLD:
+            return None
+
         for file_info in input.file_analysis.files:
             if file_info.size < APPLE_FILESYSTEM_BLOCK_SIZE:
                 small_files.append(file_info)
@@ -27,7 +30,7 @@ class SmallFilesInsight(Insight[SmallFilesInsightResult]):
                 wasted_space = APPLE_FILESYSTEM_BLOCK_SIZE - file_info.size
                 total_savings += wasted_space
 
-        if len(input.file_analysis.files) > self.TOTAL_FILES_THRESHOLD:
+        if len(small_files) > 0:
             return SmallFilesInsightResult(
                 files=small_files,
                 file_count=len(small_files),

--- a/src/launchpad/size/insights/apple/strip_symbols.py
+++ b/src/launchpad/size/insights/apple/strip_symbols.py
@@ -45,7 +45,7 @@ class StripSymbolsInsight(Insight[StripBinaryInsightResult]):
             strippable_size = debug_section_size + symbol_savings
             if strippable_size > 0:
                 strip_file_info = StripBinaryFileInfo(
-                    file_path=str(binary_analysis.binary_path),
+                    file_path=binary_analysis.binary_relative_path,
                     debug_sections_savings=debug_section_size,
                     symbol_table_savings=symbol_savings,
                     total_savings=strippable_size,

--- a/src/launchpad/size/insights/apple/strip_symbols.py
+++ b/src/launchpad/size/insights/apple/strip_symbols.py
@@ -57,7 +57,7 @@ class StripSymbolsInsight(Insight[StripBinaryInsightResult]):
 
         strip_files.sort(key=lambda x: x.total_savings, reverse=True)
 
-        if strip_files:
+        if len(strip_files) > 0:
             return StripBinaryInsightResult(
                 files=strip_files,
                 total_savings=total_savings,

--- a/src/launchpad/size/insights/common/duplicate_files.py
+++ b/src/launchpad/size/insights/common/duplicate_files.py
@@ -32,12 +32,12 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
                     group = DuplicateFileGroup(
                         filename=group_filename,
                         files=sorted_files,
-                        savings=savings_for_this_group,
+                        total_savings=savings_for_this_group,
                     )
                     groups.append(group)
                     total_savings += savings_for_this_group
 
-        groups = sorted(groups, key=lambda g: (-g.savings, g.filename))
+        groups = sorted(groups, key=lambda g: (-g.total_savings, g.filename))
 
         return DuplicateFilesInsightResult(
             groups=groups,

--- a/src/launchpad/size/insights/common/duplicate_files.py
+++ b/src/launchpad/size/insights/common/duplicate_files.py
@@ -1,9 +1,11 @@
+import os
+
 from collections import defaultdict
 from typing import Dict, List
 
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.common import FileInfo
-from launchpad.size.models.insights import DuplicateFilesInsightResult
+from launchpad.size.models.insights import DuplicateFileGroup, DuplicateFilesInsightResult
 
 
 class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
@@ -13,20 +15,31 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
             if file.hash_md5:
                 files_by_hash[file.hash_md5].append(file)
 
-        duplicate_files: List[FileInfo] = []
+        groups: List[DuplicateFileGroup] = []
         total_savings = 0
 
         for file_list in files_by_hash.values():
             if len(file_list) > 1:
+                # Calculate savings: total size - size of one copy we keep
                 total_file_size = sum(f.size for f in file_list)
-                savings = total_file_size - file_list[0].size
+                savings_for_this_group = total_file_size - file_list[0].size
 
-                if savings > 0:  # Only include if there are actual savings
-                    # Add all files except the first one (which we'll keep)
-                    duplicate_files.extend(file_list[1:])
-                    total_savings += savings
+                if savings_for_this_group > 0:  # Only include if there are actual savings
+                    sorted_files = sorted(file_list, key=lambda f: (-f.size, f.path))
+                    filenames = sorted(set(os.path.basename(f.path) for f in sorted_files))
+                    group_filename = filenames[0]
+
+                    group = DuplicateFileGroup(
+                        filename=group_filename,
+                        files=sorted_files,
+                        savings=savings_for_this_group,
+                    )
+                    groups.append(group)
+                    total_savings += savings_for_this_group
+
+        groups = sorted(groups, key=lambda g: (-g.savings, g.filename))
 
         return DuplicateFilesInsightResult(
-            files=duplicate_files,
+            groups=groups,
             total_savings=total_savings,
         )

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -27,29 +27,6 @@ from .insights import (
 )
 
 
-class LooseImageGroup(BaseModel):
-    """Group of loose image files with the same canonical name."""
-
-    canonical_name: str
-    images: List[FileInfo]
-
-    @property
-    def total_size(self) -> int:
-        """Total size of all images in this group."""
-        return sum(img.size for img in self.images)
-
-    @computed_field
-    @property
-    def total_savings(self) -> int:
-        """Size savings by moving to asset catalog (excluding largest image that would be kept)."""
-        if len(self.images) <= 1:
-            return 0
-
-        # Sort by size descending, exclude the largest (highest scale) image
-        sorted_images = sorted(self.images, key=lambda img: img.size, reverse=True)
-        return sum(img.size for img in sorted_images[1:])  # Skip the largest image
-
-
 class AppleAnalysisResults(BaseAnalysisResults):
     """Complete Apple analysis results."""
 
@@ -81,6 +58,29 @@ class SmallFilesInsightResult(BaseInsightResult):
     file_count: int = Field(..., description="Number of small files found")
 
 
+class LooseImageGroup(BaseModel):
+    """Group of loose image files with the same canonical name."""
+
+    canonical_name: str
+    images: List[FileInfo]
+
+    @property
+    def total_size(self) -> int:
+        """Total size of all images in this group."""
+        return sum(img.size for img in self.images)
+
+    @computed_field
+    @property
+    def total_savings(self) -> int:
+        """Size savings by moving to asset catalog (excluding largest image that would be kept)."""
+        if len(self.images) <= 1:
+            return 0
+
+        # Sort by size descending, exclude the largest (highest scale) image
+        sorted_images = sorted(self.images, key=lambda img: img.size, reverse=True)
+        return sum(img.size for img in sorted_images[1:])  # Skip the largest image
+
+
 class LooseImagesInsightResult(BaseInsightResult):
     """Results from loose images analysis."""
 
@@ -94,21 +94,21 @@ class MainBinaryExportMetadataResult(BaseInsightResult):
     """Results from main binary exported symbols metadata analysis."""
 
 
-@dataclass
-class OptimizableImageFile:
+class OptimizableImageFile(BaseModel):
     """Information about an image file that can be optimized."""
 
-    file_info: FileInfo
+    model_config = ConfigDict(frozen=True)
 
-    current_size: int
+    file_info: FileInfo = Field(..., description="File information")
+    current_size: int = Field(..., description="Current file size in bytes")
 
     # Minification savings (optimizing current format)
-    minify_savings: int = 0
-    minified_size: int | None = None
+    minify_savings: int = Field(default=0, ge=0, description="Potential savings from minification")
+    minified_size: int | None = Field(default=None, description="Size after minification")
 
     # HEIC conversion savings (converting to HEIC format)
-    conversion_savings: int = 0
-    heic_size: int | None = None
+    conversion_savings: int = Field(default=0, ge=0, description="Potential savings from HEIC conversion")
+    heic_size: int | None = Field(default=None, description="Size after HEIC conversion")
 
     @property
     def potential_savings(self) -> int:

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -8,7 +8,7 @@ from typing import List
 
 import lief
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from launchpad.parsers.apple.macho_symbol_sizes import SymbolSize
 from launchpad.parsers.apple.objc_symbol_type_aggregator import ObjCSymbolTypeGroup
@@ -27,8 +27,7 @@ from .insights import (
 )
 
 
-@dataclass
-class LooseImageGroup:
+class LooseImageGroup(BaseModel):
     """Group of loose image files with the same canonical name."""
 
     canonical_name: str
@@ -38,6 +37,17 @@ class LooseImageGroup:
     def total_size(self) -> int:
         """Total size of all images in this group."""
         return sum(img.size for img in self.images)
+
+    @computed_field
+    @property
+    def total_savings(self) -> int:
+        """Size savings by moving to asset catalog (excluding largest image that would be kept)."""
+        if len(self.images) <= 1:
+            return 0
+
+        # Sort by size descending, exclude the largest (highest scale) image
+        sorted_images = sorted(self.images, key=lambda img: img.size, reverse=True)
+        return sum(img.size for img in sorted_images[1:])  # Skip the largest image
 
 
 class AppleAnalysisResults(BaseAnalysisResults):

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -76,9 +76,9 @@ class LooseImageGroup(BaseModel):
         if len(self.images) <= 1:
             return 0
 
-        # Sort by size descending, exclude the largest (highest scale) image
-        sorted_images = sorted(self.images, key=lambda img: img.size, reverse=True)
-        return sum(img.size for img in sorted_images[1:])  # Skip the largest image
+        # TODO: this doesn't handle some edge cases yet like when there are iphone/ipad variants
+        max_size = max(img.size for img in self.images)
+        return sum(img.size for img in self.images) - max_size
 
 
 class LooseImagesInsightResult(BaseInsightResult):
@@ -159,7 +159,10 @@ class MachOBinaryAnalysis(BaseBinaryAnalysis):
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
-    binary_path: Path = Field(..., description="Fully qualified path to the binary within the app bundle")
+    binary_absolute_path: Path = Field(
+        ..., description="Fully qualified path to the binary within the app bundle", exclude=True
+    )
+    binary_relative_path: str = Field(..., description="Path to the binary within the app bundle")
     swift_metadata: SwiftMetadata | None = Field(None, description="Swift-specific metadata")
     binary_analysis: BinaryAnalysis | None = Field(
         None,

--- a/src/launchpad/size/models/insights.py
+++ b/src/launchpad/size/models/insights.py
@@ -13,15 +13,35 @@ class BaseInsightResult(BaseModel):
     total_savings: int = Field(..., ge=0, description="Total potential savings in bytes")
 
 
-class DuplicateFilesInsightResult(BaseInsightResult):
-    """Results from duplicate files analysis."""
+class DuplicateFileGroup(BaseModel):
+    """Group of duplicate files with the same filename."""
 
-    files: List[FileInfo] = Field(..., description="Files in the group")
+    model_config = ConfigDict(frozen=True)
+
+    filename: str = Field(..., description="The filename (without path)")
+    files: List[FileInfo] = Field(..., description="All duplicate files with this filename")
+    savings: int = Field(..., ge=0, description="Total savings for this filename group")
 
     @property
     def duplicate_count(self) -> int:
         """Number of duplicate files (excluding the original)."""
         return len(self.files) - 1
+
+
+class DuplicateFilesInsightResult(BaseInsightResult):
+    """Results from duplicate files analysis."""
+
+    groups: List[DuplicateFileGroup] = Field(..., description="Groups of duplicate files by filename")
+
+    @property
+    def duplicate_count(self) -> int:
+        """Total number of duplicate files across all groups."""
+        return sum(group.duplicate_count for group in self.groups)
+
+    @property
+    def total_files(self) -> int:
+        """Total number of files across all groups."""
+        return sum(len(group.files) for group in self.groups)
 
 
 class LargeImageFileInsightResult(BaseInsightResult):

--- a/src/launchpad/size/models/insights.py
+++ b/src/launchpad/size/models/insights.py
@@ -20,7 +20,7 @@ class DuplicateFileGroup(BaseModel):
 
     filename: str = Field(..., description="The filename (without path)")
     files: List[FileInfo] = Field(..., description="All duplicate files with this filename")
-    savings: int = Field(..., ge=0, description="Total savings for this filename group")
+    total_savings: int = Field(..., ge=0, description="Total savings for this filename group")
 
     @property
     def duplicate_count(self) -> int:

--- a/tests/integration/size/test_treemap_generation.py
+++ b/tests/integration/size/test_treemap_generation.py
@@ -422,9 +422,9 @@ class TestTreemapGeneration:
         sentry_binary = find_node_by_path(treemap.root, "Frameworks/Sentry.framework/Sentry")
         assert sentry_binary is not None
         sentry_binary_install_size = sentry_binary.install_size
-        assert sentry_binary_install_size == 51456
+        assert sentry_binary_install_size == 53248
         sentry_binary_download_size = sentry_binary.download_size
-        assert sentry_binary_download_size == 51456
+        assert sentry_binary_download_size == 53248
         sentry_binary_element_type = sentry_binary.element_type
         assert sentry_binary_element_type == "executables"
 

--- a/tests/unit/test_android_analyzer.py
+++ b/tests/unit/test_android_analyzer.py
@@ -33,7 +33,7 @@ class TestAndroidAnalyzer:
         assert results.insights.duplicate_files is not None
 
         duplicate_insight = results.insights.duplicate_files
-        assert hasattr(duplicate_insight, "files")
+        assert hasattr(duplicate_insight, "groups")
         assert hasattr(duplicate_insight, "total_savings")
         assert hasattr(duplicate_insight, "duplicate_count")
         assert isinstance(duplicate_insight.total_savings, int)

--- a/tests/unit/test_android_analyzer.py
+++ b/tests/unit/test_android_analyzer.py
@@ -1,9 +1,11 @@
 """Tests for Android analyzer with duplicate file detection."""
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
+from launchpad.artifacts.artifact import AndroidArtifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.size.analyzers.android import AndroidAnalyzer
 
@@ -22,7 +24,8 @@ class TestAndroidAnalyzer:
     def test_analyze_with_duplicate_detection(self, test_apk_path: Path, android_analyzer: AndroidAnalyzer) -> None:
         """Test that Android analyzer includes duplicate file detection."""
         artifact = ArtifactFactory.from_path(test_apk_path)
-        results = android_analyzer.analyze(artifact)
+        android_artifact = cast(AndroidArtifact, artifact)
+        results = android_analyzer.analyze(android_artifact)
 
         assert results.app_info.name == "Hacker News"
         assert results.app_info.app_id == "com.emergetools.hackernews"
@@ -39,12 +42,13 @@ class TestAndroidAnalyzer:
         assert isinstance(duplicate_insight.total_savings, int)
         assert isinstance(duplicate_insight.duplicate_count, int)
         assert duplicate_insight.total_savings == 51709
-        assert duplicate_insight.duplicate_count == 52
+        assert duplicate_insight.duplicate_count == 53
 
     def test_duplicate_files_have_hashes(self, test_apk_path: Path, android_analyzer: AndroidAnalyzer) -> None:
         """Test that all files have MD5 hashes for duplicate detection."""
         artifact = ArtifactFactory.from_path(test_apk_path)
-        results = android_analyzer.analyze(artifact)
+        android_artifact = cast(AndroidArtifact, artifact)
+        results = android_analyzer.analyze(android_artifact)
 
         for file_info in results.file_analysis.files:
             assert file_info.hash_md5 is not None

--- a/tests/unit/test_loose_images_insight.py
+++ b/tests/unit/test_loose_images_insight.py
@@ -1,13 +1,10 @@
 from pathlib import Path
 from unittest.mock import Mock
 
-from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.insights.apple.loose_images import LooseImagesInsight
 from launchpad.size.insights.insight import InsightsInput
 from launchpad.size.models.apple import LooseImagesInsightResult
-from launchpad.size.models.common import BaseAppInfo, FileAnalysis, FileInfo
-from launchpad.size.models.treemap import TreemapType
-from launchpad.utils.file_utils import to_nearest_block_size
+from launchpad.size.models.common import BaseAppInfo, FileAnalysis, FileInfo, TreemapType
 
 
 class TestLooseImagesInsight:
@@ -73,32 +70,22 @@ class TestLooseImagesInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LooseImagesInsightResult)
-        assert result.total_file_count == 3  # 3 raw image files
-        assert len(result.image_groups) == 2  # 2 canonical groups: "home.png" and "submit.jpg"
+        assert result.total_file_count == 2  # Only 2 files from the multi-scale group
+        assert len(result.image_groups) == 1  # Only 1 group: "home.png" (submit.jpg is single file, excluded)
 
         # Verify home group has both @1x and @2x variants
         home_group = next((g for g in result.image_groups if g.canonical_name == "home.png"), None)
         assert home_group is not None
         assert len(home_group.images) == 2
         assert home_group.total_size == 10240 + 20480
+        # The home group's total_savings should be 10240 (excluding the larger @2x image)
+        assert home_group.total_savings == 10240
 
-        # Verify submit group has one image
-        submit_group = next((g for g in result.image_groups if g.canonical_name == "submit.jpg"), None)
-        assert submit_group is not None
-        assert len(submit_group.images) == 1
-        assert submit_group.total_size == 15360
-
-        # Check total savings calculation (block waste + app thinning)
-        # For this test case:
-        # - home.png (10240) and home@2x.png (20480): home.png would be eliminated via app thinning
-        # - submit.jpg (15360): no scale indicators, so only block waste saved
-
-        home_1x_block_size = to_nearest_block_size(10240, APPLE_FILESYSTEM_BLOCK_SIZE)  # eliminated completely
-        home_2x_block_waste = to_nearest_block_size(20480, APPLE_FILESYSTEM_BLOCK_SIZE) - 20480  # remains, only waste
-        submit_block_waste = to_nearest_block_size(15360, APPLE_FILESYSTEM_BLOCK_SIZE) - 15360  # no scale, only waste
-
-        expected_savings = home_1x_block_size + home_2x_block_waste + submit_block_waste
-        assert result.total_savings == expected_savings
+        # Check total savings calculation
+        # For this test case, only the home.png group qualifies (has multiple scale variants)
+        # - home.png (10240) would be eliminated, home@2x.png (20480) would be kept
+        # - submit.jpg is excluded because it's a single file with no scale variants
+        assert result.total_savings == 10240
 
     def test_excludes_app_icons(self):
         """Test that AppIcon and iMessage App Icon files are excluded."""
@@ -127,6 +114,14 @@ class TestLooseImagesInsight:
                 treemap_type=TreemapType.ASSETS,
                 hash_md5="hash_regular",
             ),
+            FileInfo(
+                full_path=Path("regular_icon@2x.png"),
+                path="regular_icon@2x.png",
+                size=6144,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="hash_regular_2x",
+            ),
         ]
 
         file_analysis = FileAnalysis(files=files)
@@ -140,9 +135,11 @@ class TestLooseImagesInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LooseImagesInsightResult)
-        assert result.total_file_count == 1  # Only regular_icon.png
+        assert result.total_file_count == 2  # Both regular_icon files
         assert len(result.image_groups) == 1
         assert result.image_groups[0].canonical_name == "regular_icon.png"
+        # Should exclude smaller image size from savings
+        assert result.image_groups[0].total_savings == 3072
 
     def test_excludes_stickerpack_images(self):
         """Test that images in .stickerpack directories are excluded."""
@@ -163,6 +160,14 @@ class TestLooseImagesInsight:
                 treemap_type=TreemapType.ASSETS,
                 hash_md5="hash_regular",
             ),
+            FileInfo(
+                full_path=Path("regular/image@2x.png"),
+                path="regular/image@2x.png",
+                size=6144,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="hash_regular_2x",
+            ),
         ]
 
         file_analysis = FileAnalysis(files=files)
@@ -176,9 +181,11 @@ class TestLooseImagesInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LooseImagesInsightResult)
-        assert result.total_file_count == 1  # Only regular image
+        assert result.total_file_count == 2  # Both regular images
         assert len(result.image_groups) == 1
         assert result.image_groups[0].canonical_name == "image.png"
+        # Should exclude smaller image size from savings
+        assert result.image_groups[0].total_savings == 3072
 
     def test_no_raw_images_returns_none(self):
         """Test that no insight is generated when there are no raw images."""
@@ -262,17 +269,15 @@ class TestLooseImagesInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LooseImagesInsightResult)
-        assert result.total_file_count == 4
-        assert len(result.image_groups) == 2
+        assert result.total_file_count == 3  # Only icon group (different.jpg is single file, excluded)
+        assert len(result.image_groups) == 1
 
         # Find the icon group
         icon_group = next((g for g in result.image_groups if g.canonical_name == "icon.png"), None)
         assert icon_group is not None
         assert len(icon_group.images) == 3  # @1x, @2x, @3x
         assert icon_group.total_size == 30000  # 5000 + 10000 + 15000
+        # Should exclude the largest image (@3x = 15000) from savings
+        assert icon_group.total_savings == 15000  # 5000 + 10000
 
-        # Find the different group
-        diff_group = next((g for g in result.image_groups if g.canonical_name == "different.jpg"), None)
-        assert diff_group is not None
-        assert len(diff_group.images) == 1
-        assert diff_group.total_size == 8000
+        # different.jpg is excluded because it's a single file with no scale variants

--- a/tests/unit/test_main_binary_export_metadata_insight.py
+++ b/tests/unit/test_main_binary_export_metadata_insight.py
@@ -249,5 +249,4 @@ class TestMainBinaryExportMetadataInsight:
 
         result = self.insight.generate(insights_input)
 
-        assert isinstance(result, MainBinaryExportMetadataResult)
-        assert result.total_savings == 0
+        assert result is None

--- a/tests/unit/test_main_binary_export_metadata_insight.py
+++ b/tests/unit/test_main_binary_export_metadata_insight.py
@@ -26,7 +26,8 @@ class TestMainBinaryExportMetadataInsight:
         )
 
         main_binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=100000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -62,7 +63,8 @@ class TestMainBinaryExportMetadataInsight:
         )
 
         main_binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=100000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -87,7 +89,8 @@ class TestMainBinaryExportMetadataInsight:
     def test_generate_with_no_main_binary(self):
         """Test that no insight is generated when there is no main binary."""
         framework_binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("Frameworks/MyFramework.framework/MyFramework"),
+            binary_absolute_path=Path("Frameworks/MyFramework.framework/MyFramework"),
+            binary_relative_path="Frameworks/MyFramework.framework/MyFramework",
             executable_size=50000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -112,7 +115,8 @@ class TestMainBinaryExportMetadataInsight:
     def test_generate_with_main_binary_but_no_binary_analysis(self):
         """Test that no insight is generated when main binary has no binary_analysis."""
         main_binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=100000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -159,7 +163,8 @@ class TestMainBinaryExportMetadataInsight:
         )
 
         main_binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=150000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -172,7 +177,8 @@ class TestMainBinaryExportMetadataInsight:
 
         # Create framework binary (non-main)
         framework_binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("Frameworks/MyFramework.framework/MyFramework"),
+            binary_absolute_path=Path("Frameworks/MyFramework.framework/MyFramework"),
+            binary_relative_path="Frameworks/MyFramework.framework/MyFramework",
             executable_size=50000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -229,7 +235,8 @@ class TestMainBinaryExportMetadataInsight:
         binary_analysis = BinaryAnalysis(file_path="MyApp", total_size=100000, components=[dyld_exports_trie_component])
 
         main_binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=100000,
             architectures=["arm64"],
             linked_libraries=[],

--- a/tests/unit/test_small_files_insight.py
+++ b/tests/unit/test_small_files_insight.py
@@ -64,10 +64,10 @@ class TestSmallFilesInsight:
             assert file.size < APPLE_FILESYSTEM_BLOCK_SIZE
 
     def test_generate_with_few_total_files(self):
-        """Test that no insight is generated when app has <= 100 total files."""
-        # Create exactly 100 files (should not trigger insight)
+        """Test that no insight is generated when app has < 100 total files."""
+        # Create exactly 99 files (should not trigger insight)
         files: list[FileInfo] = []
-        for i in range(100):
+        for i in range(99):
             file = FileInfo(
                 full_path=Path(f"assets/file{i}.png"),
                 path=f"assets/file{i}.png",
@@ -150,10 +150,7 @@ class TestSmallFilesInsight:
 
         result = self.insight.generate(insights_input)
 
-        assert isinstance(result, SmallFilesInsightResult)
-        assert len(result.files) == 0  # No small files
-        assert result.file_count == 0
-        assert result.total_savings == 0
+        assert result is None
 
     def test_generate_with_empty_file_list(self):
         """Test that no insight is generated when there are no files."""

--- a/tests/unit/test_strip_symbols_insight.py
+++ b/tests/unit/test_strip_symbols_insight.py
@@ -25,7 +25,8 @@ class TestStripSymbolsInsight:
         )
 
         binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("Frameworks/MyFramework.framework/MyFramework"),
+            binary_absolute_path=Path("Frameworks/MyFramework.framework/MyFramework"),
+            binary_relative_path="Frameworks/MyFramework.framework/MyFramework",
             executable_size=100000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -67,7 +68,8 @@ class TestStripSymbolsInsight:
     def test_generate_with_debug_sections_only(self):
         """Test that insight is generated when binaries have only debug sections."""
         binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=50000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -117,7 +119,8 @@ class TestStripSymbolsInsight:
         )
 
         binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=80000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -167,7 +170,8 @@ class TestStripSymbolsInsight:
         )
 
         binary_analysis_1 = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=100000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -185,7 +189,8 @@ class TestStripSymbolsInsight:
 
         # Binary 2: Only debug sections
         binary_analysis_2 = MachOBinaryAnalysis(
-            binary_path=Path("Frameworks/TestFramework.framework/TestFramework"),
+            binary_absolute_path=Path("Frameworks/TestFramework.framework/TestFramework"),
+            binary_relative_path="Frameworks/TestFramework.framework/TestFramework",
             executable_size=50000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -211,7 +216,8 @@ class TestStripSymbolsInsight:
         )
 
         binary_analysis_3 = MachOBinaryAnalysis(
-            binary_path=Path("Frameworks/AnotherFramework.framework/AnotherFramework"),
+            binary_absolute_path=Path("Frameworks/AnotherFramework.framework/AnotherFramework"),
+            binary_relative_path="Frameworks/AnotherFramework.framework/AnotherFramework",
             executable_size=60000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -267,7 +273,8 @@ class TestStripSymbolsInsight:
     def test_generate_with_no_strippable_content(self):
         """Test that no insight is generated when binaries have no strippable content."""
         binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=50000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -305,7 +312,8 @@ class TestStripSymbolsInsight:
         )
 
         binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=50000,
             architectures=["arm64"],
             linked_libraries=[],
@@ -357,7 +365,8 @@ class TestStripSymbolsInsight:
     def test_debug_sections_detection(self):
         """Test that all debug sections are correctly detected."""
         binary_analysis = MachOBinaryAnalysis(
-            binary_path=Path("MyApp"),
+            binary_absolute_path=Path("MyApp"),
+            binary_relative_path="MyApp",
             executable_size=100000,
             architectures=["arm64"],
             linked_libraries=[],

--- a/web/src/components/InsightsDisplay.tsx
+++ b/web/src/components/InsightsDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { FileAnalysisReport, InsightResult } from '../utils/dataConverter';
+import type { DuplicateFilesInsightResult, FileAnalysisReport, InsightResult, StripBinaryInsightResult } from '../utils/dataConverter';
 
 interface InsightsDisplayProps {
   data: FileAnalysisReport;
@@ -66,7 +66,7 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
     return icons[key] || '💡';
   };
 
-  const insightEntries = Object.entries(insights).filter(([, value]) => {
+  const insightEntries = Object.entries(insights).filter(([key, value]) => {
     // Skip null, undefined, or invalid insights
     if (!value || typeof value !== 'object') {
       return false;
@@ -74,11 +74,27 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
 
     // Skip insights that don't have meaningful data
     const hasValidSavings = typeof value.total_savings === 'number' && value.total_savings >= 0;
-    const hasFiles = value.files && Array.isArray(value.files) && value.files.length > 0;
+
+    // Handle duplicate files differently (has groups instead of files)
+    if (key === 'duplicate_files') {
+      const duplicateInsight = value as DuplicateFilesInsightResult;
+      const hasGroups = duplicateInsight.groups && Array.isArray(duplicateInsight.groups) && duplicateInsight.groups.length > 0;
+      return hasValidSavings || hasGroups;
+    }
+
+    // Handle strip binary differently (has custom file format)
+    if (key === 'strip_binary') {
+      const stripInsight = value as StripBinaryInsightResult;
+      const hasFiles = stripInsight.files && Array.isArray(stripInsight.files) && stripInsight.files.length > 0;
+      return hasValidSavings || hasFiles;
+    }
+
+    const regularInsight = value as InsightResult;
+    const hasFiles = regularInsight.files && Array.isArray(regularInsight.files) && regularInsight.files.length > 0;
 
     // Include insights that either have savings or have files to show
     return hasValidSavings || hasFiles;
-  }) as [string, InsightResult][];
+  }) as [string, InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult][];
 
   if (insightEntries.length === 0) {
     return null;
@@ -187,59 +203,274 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
               </div>
             </div>
 
-            {insight.files && insight.files.length > 0 && (
-              <div>
-                <h4 style={{
-                  margin: '0 0 0.75rem 0',
-                  color: '#495057',
-                  fontSize: '1rem',
-                  fontWeight: '600'
-                }}>
-                  Affected Files ({insight.files.length})
-                </h4>
-                <div style={{
-                  backgroundColor: '#f8f9fa',
-                  borderRadius: '6px',
-                  padding: '0.75rem',
-                  maxHeight: '200px',
-                  overflowY: 'auto'
-                }}>
-                  {insight.files.map((file, index) => (
-                    <div
-                      key={index}
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        padding: '0.4rem 0',
-                        borderBottom: index < insight.files!.length - 1 ? '1px solid #e9ecef' : 'none',
-                        fontSize: '0.85rem'
-                      }}
-                    >
+            {key === 'duplicate_files' ? (
+              // Handle duplicate files with groups
+              (() => {
+                const duplicateInsight = insight as DuplicateFilesInsightResult;
+                const totalFiles = duplicateInsight.groups?.reduce((sum, group) => sum + group.files.length, 0) || 0;
+
+                return duplicateInsight.groups && duplicateInsight.groups.length > 0 && (
+                  <div>
+                    <h4 style={{
+                      margin: '0 0 0.75rem 0',
+                      color: '#495057',
+                      fontSize: '1rem',
+                      fontWeight: '600'
+                    }}>
+                      Duplicate File Groups ({duplicateInsight.groups.length} groups, {totalFiles} files)
+                    </h4>
+                    <div style={{
+                      backgroundColor: '#f8f9fa',
+                      borderRadius: '6px',
+                      padding: '0.75rem',
+                      maxHeight: '400px',
+                      overflowY: 'auto'
+                    }}>
+                      {duplicateInsight.groups.map((group, groupIndex) => (
+                        <div
+                          key={groupIndex}
+                          style={{
+                            marginBottom: groupIndex < duplicateInsight.groups!.length - 1 ? '1rem' : '0',
+                            padding: '0.75rem',
+                            backgroundColor: '#ffffff',
+                            borderRadius: '4px',
+                            border: '1px solid #e9ecef'
+                          }}
+                        >
+                          <div style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            marginBottom: '0.5rem',
+                            paddingBottom: '0.5rem',
+                            borderBottom: '1px solid #f0f0f0'
+                          }}>
+                            <div style={{
+                              color: '#343a40',
+                              fontWeight: '600',
+                              fontSize: '0.9rem'
+                            }}>
+                              📄 {group.filename}
+                            </div>
+                            <div style={{
+                              color: '#28a745',
+                              fontSize: '0.85rem',
+                              fontWeight: '600'
+                            }}>
+                              {formatSize(group.savings)} savings
+                            </div>
+                          </div>
+                          {group.files.map((file, fileIndex) => (
+                            <div
+                              key={fileIndex}
+                              style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                                padding: '0.3rem 0',
+                                borderBottom: fileIndex < group.files.length - 1 ? '1px solid #f0f0f0' : 'none',
+                                fontSize: '0.8rem'
+                              }}
+                            >
+                              <div style={{
+                                flex: 1,
+                                color: '#6c757d',
+                                fontFamily: 'monospace',
+                                fontSize: '0.75rem',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                marginRight: '1rem'
+                              }}>
+                                {file.path}
+                              </div>
+                              <div style={{
+                                color: '#6c757d',
+                                fontSize: '0.75rem',
+                                fontWeight: '500',
+                                flexShrink: 0
+                              }}>
+                                {formatSize(file.size)}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()
+            ) : key === 'strip_binary' ? (
+              // Handle strip binary with custom file format
+              (() => {
+                const stripInsight = insight as StripBinaryInsightResult;
+                return stripInsight.files && stripInsight.files.length > 0 && (
+                  <div>
+                    <h4 style={{
+                      margin: '0 0 0.75rem 0',
+                      color: '#495057',
+                      fontSize: '1rem',
+                      fontWeight: '600'
+                    }}>
+                      Binary Files ({stripInsight.files.length})
+                    </h4>
+                    <div style={{
+                      backgroundColor: '#f8f9fa',
+                      borderRadius: '6px',
+                      padding: '0.75rem',
+                      marginBottom: '1rem'
+                    }}>
                       <div style={{
-                        flex: 1,
-                        color: '#495057',
-                        fontFamily: 'monospace',
-                        fontSize: '0.8rem',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        marginRight: '1rem'
+                        display: 'grid',
+                        gridTemplateColumns: '1fr 1fr',
+                        gap: '0.75rem',
+                        marginBottom: '0.75rem',
+                        padding: '0.75rem',
+                        backgroundColor: '#e3f2fd',
+                        borderRadius: '4px'
                       }}>
-                        {file.path}
-                      </div>
-                      <div style={{
-                        color: '#6c757d',
-                        fontSize: '0.8rem',
-                        fontWeight: '500',
-                        flexShrink: 0
-                      }}>
-                        {formatSize(file.size)}
+                        <div style={{ textAlign: 'center' }}>
+                          <div style={{ fontSize: '0.8rem', color: '#6c757d', marginBottom: '0.25rem' }}>
+                            Debug Sections Savings
+                          </div>
+                          <div style={{ fontSize: '1rem', fontWeight: '600', color: '#1976d2' }}>
+                            {formatSize(stripInsight.total_debug_sections_savings)}
+                          </div>
+                        </div>
+                        <div style={{ textAlign: 'center' }}>
+                          <div style={{ fontSize: '0.8rem', color: '#6c757d', marginBottom: '0.25rem' }}>
+                            Symbol Table Savings
+                          </div>
+                          <div style={{ fontSize: '1rem', fontWeight: '600', color: '#1976d2' }}>
+                            {formatSize(stripInsight.total_symbol_table_savings)}
+                          </div>
+                        </div>
                       </div>
                     </div>
-                  ))}
-                </div>
-              </div>
+                    <div style={{
+                      backgroundColor: '#f8f9fa',
+                      borderRadius: '6px',
+                      padding: '0.75rem',
+                      maxHeight: '200px',
+                      overflowY: 'auto'
+                    }}>
+                      {stripInsight.files.map((file, index) => (
+                        <div
+                          key={index}
+                          style={{
+                            padding: '0.75rem',
+                            marginBottom: index < stripInsight.files.length - 1 ? '0.5rem' : '0',
+                            backgroundColor: '#ffffff',
+                            borderRadius: '4px',
+                            border: '1px solid #e9ecef'
+                          }}
+                        >
+                          <div style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            marginBottom: '0.5rem'
+                          }}>
+                            <div style={{
+                              flex: 1,
+                              color: '#495057',
+                              fontFamily: 'monospace',
+                              fontSize: '0.8rem',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                              marginRight: '1rem'
+                            }}>
+                              {file.file_path}
+                            </div>
+                            <div style={{
+                              color: '#28a745',
+                              fontSize: '0.8rem',
+                              fontWeight: '600',
+                              flexShrink: 0
+                            }}>
+                              {formatSize(file.total_savings)} total
+                            </div>
+                          </div>
+                          <div style={{
+                            display: 'grid',
+                            gridTemplateColumns: '1fr 1fr',
+                            gap: '0.5rem',
+                            fontSize: '0.75rem',
+                            color: '#6c757d'
+                          }}>
+                            <div>
+                              Debug sections: {formatSize(file.debug_sections_savings)}
+                            </div>
+                            <div>
+                              Symbol table: {formatSize(file.symbol_table_savings)}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()
+            ) : (
+              // Handle regular insights with files array
+              (() => {
+                const regularInsight = insight as InsightResult;
+                return regularInsight.files && regularInsight.files.length > 0 && (
+                  <div>
+                    <h4 style={{
+                      margin: '0 0 0.75rem 0',
+                      color: '#495057',
+                      fontSize: '1rem',
+                      fontWeight: '600'
+                    }}>
+                      Affected Files ({regularInsight.files.length})
+                    </h4>
+                    <div style={{
+                      backgroundColor: '#f8f9fa',
+                      borderRadius: '6px',
+                      padding: '0.75rem',
+                      maxHeight: '200px',
+                      overflowY: 'auto'
+                    }}>
+                      {regularInsight.files.map((file, index) => (
+                        <div
+                          key={index}
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            padding: '0.4rem 0',
+                            borderBottom: index < regularInsight.files!.length - 1 ? '1px solid #e9ecef' : 'none',
+                            fontSize: '0.85rem'
+                          }}
+                        >
+                          <div style={{
+                            flex: 1,
+                            color: '#495057',
+                            fontFamily: 'monospace',
+                            fontSize: '0.8rem',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            marginRight: '1rem'
+                          }}>
+                            {file.path}
+                          </div>
+                          <div style={{
+                            color: '#6c757d',
+                            fontSize: '0.8rem',
+                            fontWeight: '500',
+                            flexShrink: 0
+                          }}>
+                            {formatSize(file.size)}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()
             )}
           </div>
         ))}

--- a/web/src/components/InsightsDisplay.tsx
+++ b/web/src/components/InsightsDisplay.tsx
@@ -264,7 +264,7 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
                               fontSize: '0.85rem',
                               fontWeight: '600'
                             }}>
-                              {formatSize(group.savings)} savings
+                              {formatSize(group.total_savings)} savings
                             </div>
                           </div>
                           {group.files.map((file, fileIndex) => (
@@ -471,7 +471,7 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
                               fontSize: '0.85rem',
                               fontWeight: '600'
                             }}>
-                              {formatSize(group.images.reduce((sum, img) => sum + img.size, 0))}
+                              {formatSize(group.total_savings)}
                             </div>
                           </div>
                           {group.images.map((image, imageIndex) => (

--- a/web/src/components/InsightsDisplay.tsx
+++ b/web/src/components/InsightsDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { DuplicateFilesInsightResult, FileAnalysisReport, InsightResult, StripBinaryInsightResult } from '../utils/dataConverter';
+import type { DuplicateFilesInsightResult, FileAnalysisReport, InsightResult, LooseImagesInsightResult, StripBinaryInsightResult } from '../utils/dataConverter';
 
 interface InsightsDisplayProps {
   data: FileAnalysisReport;
@@ -89,12 +89,19 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       return hasValidSavings || hasFiles;
     }
 
+    // Handle loose images differently (has image_groups instead of files)
+    if (key === 'loose_images') {
+      const looseImagesInsight = value as LooseImagesInsightResult;
+      const hasImageGroups = looseImagesInsight.image_groups && Array.isArray(looseImagesInsight.image_groups) && looseImagesInsight.image_groups.length > 0;
+      return hasValidSavings || hasImageGroups;
+    }
+
     const regularInsight = value as InsightResult;
     const hasFiles = regularInsight.files && Array.isArray(regularInsight.files) && regularInsight.files.length > 0;
 
     // Include insights that either have savings or have files to show
     return hasValidSavings || hasFiles;
-  }) as [string, InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult][];
+  }) as [string, InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | LooseImagesInsightResult][];
 
   if (insightEntries.length === 0) {
     return null;
@@ -406,6 +413,101 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
                               Symbol table: {formatSize(file.symbol_table_savings)}
                             </div>
                           </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()
+            ) : key === 'loose_images' ? (
+              // Handle loose images with image groups
+              (() => {
+                const looseImagesInsight = insight as LooseImagesInsightResult;
+                return looseImagesInsight.image_groups && looseImagesInsight.image_groups.length > 0 && (
+                  <div>
+                    <h4 style={{
+                      margin: '0 0 0.75rem 0',
+                      color: '#495057',
+                      fontSize: '1rem',
+                      fontWeight: '600'
+                    }}>
+                      Loose Image Groups ({looseImagesInsight.image_groups.length} groups, {looseImagesInsight.total_file_count} files)
+                    </h4>
+                    <div style={{
+                      backgroundColor: '#f8f9fa',
+                      borderRadius: '6px',
+                      padding: '0.75rem',
+                      maxHeight: '400px',
+                      overflowY: 'auto'
+                    }}>
+                      {looseImagesInsight.image_groups.map((group, groupIndex) => (
+                        <div
+                          key={groupIndex}
+                          style={{
+                            marginBottom: groupIndex < looseImagesInsight.image_groups.length - 1 ? '1rem' : '0',
+                            padding: '0.75rem',
+                            backgroundColor: '#ffffff',
+                            borderRadius: '4px',
+                            border: '1px solid #e9ecef'
+                          }}
+                        >
+                          <div style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            marginBottom: '0.5rem',
+                            paddingBottom: '0.5rem',
+                            borderBottom: '1px solid #f0f0f0'
+                          }}>
+                            <div style={{
+                              color: '#343a40',
+                              fontWeight: '600',
+                              fontSize: '0.9rem'
+                            }}>
+                              🖼️ {group.canonical_name}
+                            </div>
+                            <div style={{
+                              color: '#28a745',
+                              fontSize: '0.85rem',
+                              fontWeight: '600'
+                            }}>
+                              {formatSize(group.images.reduce((sum, img) => sum + img.size, 0))}
+                            </div>
+                          </div>
+                          {group.images.map((image, imageIndex) => (
+                            <div
+                              key={imageIndex}
+                              style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                                padding: '0.3rem 0',
+                                borderBottom: imageIndex < group.images.length - 1 ? '1px solid #f0f0f0' : 'none',
+                                fontSize: '0.8rem'
+                              }}
+                            >
+                              <div style={{
+                                flex: 1,
+                                color: '#6c757d',
+                                fontFamily: 'monospace',
+                                fontSize: '0.75rem',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                marginRight: '1rem'
+                              }}>
+                                {image.path}
+                              </div>
+                              <div style={{
+                                color: '#6c757d',
+                                fontSize: '0.75rem',
+                                fontWeight: '500',
+                                flexShrink: 0
+                              }}>
+                                {formatSize(image.size)}
+                              </div>
+                            </div>
+                          ))}
                         </div>
                       ))}
                     </div>

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -37,8 +37,37 @@ export interface InsightResult {
   files?: {
     path: string;
     size: number;
-    file_type: number;
+    file_type: string;
   }[];
+}
+
+export interface StripBinaryFileInfo {
+  file_path: string;
+  debug_sections_savings: number;
+  symbol_table_savings: number;
+  total_savings: number;
+}
+
+export interface StripBinaryInsightResult {
+  total_savings: number;
+  files: StripBinaryFileInfo[];
+  total_debug_sections_savings: number;
+  total_symbol_table_savings: number;
+}
+
+export interface DuplicateFileGroup {
+  filename: string;
+  files: {
+    path: string;
+    size: number;
+    file_type: string;
+  }[];
+  savings: number;
+}
+
+export interface DuplicateFilesInsightResult {
+  total_savings: number;
+  groups: DuplicateFileGroup[];
 }
 
 export interface FileAnalysisReport {
@@ -50,15 +79,15 @@ export interface FileAnalysisReport {
     [key: string]: unknown;
   };
   insights?: {
-    duplicate_files?: InsightResult | null;
+    duplicate_files?: DuplicateFilesInsightResult | null;
     large_images?: InsightResult | null;
     large_videos?: InsightResult | null;
     large_audio?: InsightResult | null;
     hermes_debug_info?: InsightResult | null;
     webp_optimization?: InsightResult | null;
-    strip_binary?: InsightResult | null;
+    strip_binary?: StripBinaryInsightResult | null;
     localized_strings?: InsightResult | null;
-    [key: string]: InsightResult | null | undefined;
+    [key: string]: InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | null | undefined;
   };
   generated_at: string;
   use_si_units: boolean;

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -62,7 +62,7 @@ export interface DuplicateFileGroup {
     size: number;
     file_type: string;
   }[];
-  savings: number;
+  total_savings: number;
 }
 
 export interface DuplicateFilesInsightResult {

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -78,6 +78,7 @@ export interface LooseImageGroup {
     file_type: string;
     hash_md5: string;
   }[];
+  total_savings: number;
 }
 
 export interface LooseImagesInsightResult {

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -70,6 +70,22 @@ export interface DuplicateFilesInsightResult {
   groups: DuplicateFileGroup[];
 }
 
+export interface LooseImageGroup {
+  canonical_name: string;
+  images: {
+    path: string;
+    size: number;
+    file_type: string;
+    hash_md5: string;
+  }[];
+}
+
+export interface LooseImagesInsightResult {
+  total_savings: number;
+  image_groups: LooseImageGroup[];
+  total_file_count: number;
+}
+
 export interface FileAnalysisReport {
   file_analysis: FileAnalysisData;
   treemap: TreemapResults;
@@ -87,7 +103,8 @@ export interface FileAnalysisReport {
     webp_optimization?: InsightResult | null;
     strip_binary?: StripBinaryInsightResult | null;
     localized_strings?: InsightResult | null;
-    [key: string]: InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | null | undefined;
+    loose_images?: LooseImagesInsightResult | null;
+    [key: string]: InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | LooseImagesInsightResult | null | undefined;
   };
   generated_at: string;
   use_si_units: boolean;


### PR DESCRIPTION
Testing against some existing client apps and found a number of discrepancies that should be fixed now:

- fixes FileAnalysis to store the file size adjusted for the block size, this was causing a number of insight savings to be wrong
- fixes Loose Images to only report images that have at least one scale
- fixes binary export metadata to only report if over 1024 byte savings
- fixes various insights to return None when there is no data
- fixes the Duplicate Files insight to group by the filename so it's easier to display in the frontend
- adds a new insights UI for debugging
- use relative paths for binary strip results