### PR TITLE
Another batch of insight fixes

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -22,6 +22,8 @@ The iOS analysis code ONLY has to work with `.xcarchive.zip` files as input.
 
 # Python rules
 
+ALWAYS USE THE `.venv/bin/python` VERSION WHEN RUNNING COMMANDS.
+
 For the Python code make sure to follow all of Sentry's best practices, as well as modern Python best practices. Try to use types as much as possible. If standard repo setup is not present, feel free to configure it and add it to the repo since this is currently a bare setup.
 
 For the CLI, make sure to use the `click` library.

--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -61,7 +61,7 @@ class ZippedXCArchive(AppleArtifact):
                 plist_data = plistlib.load(f)
 
             self._plist = plist_data
-            return self._plist
+            return plist_data  # Return plist_data directly to fix typing issue
         except Exception as e:
             raise RuntimeError(f"Failed to parse Info.plist: {e}")
 
@@ -223,11 +223,42 @@ class ZippedXCArchive(AppleArtifact):
                                     extension_name,
                                     extension_binary_path,
                                     extension_dsym_path,
-                                    is_main_binary=False,
+                                    is_main_binary=True,  # App extension main executables are main binaries
                                 )
                             )
                     except Exception as e:
                         logger.warning(f"Failed to read extension Info.plist at {extension_path}: {e}")
+
+        # Find Watch app binaries
+        for watch_path in app_bundle_path.rglob("Watch/*.app"):
+            if watch_path.is_dir():
+                watch_plist_path = watch_path / "Info.plist"
+                if watch_plist_path.exists():
+                    try:
+                        import plistlib
+
+                        with open(watch_plist_path, "rb") as f:
+                            watch_plist = plistlib.load(f)
+                        watch_executable = watch_plist.get("CFBundleExecutable")
+                        if watch_executable:
+                            watch_binary_path = watch_path / watch_executable
+                            # Use the full watch app name as the key to avoid conflicts
+                            watch_name = f"Watch/{watch_path.stem}/{watch_executable}"
+
+                            # Find corresponding dSYM for watch app
+                            watch_uuid = self._extract_binary_uuid(watch_binary_path)
+                            watch_dsym_path = dsym_files.get(watch_uuid) if watch_uuid else None
+
+                            binaries.append(
+                                BinaryInfo(
+                                    watch_name,
+                                    watch_binary_path,
+                                    watch_dsym_path,
+                                    is_main_binary=True,  # Watch app main executables are main binaries
+                                )
+                            )
+                    except Exception as e:
+                        logger.warning(f"Failed to read Watch app Info.plist at {watch_path}: {e}")
 
         return binaries
 

--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -61,7 +61,7 @@ class ZippedXCArchive(AppleArtifact):
                 plist_data = plistlib.load(f)
 
             self._plist = plist_data
-            return plist_data  # Return plist_data directly to fix typing issue
+            return plist_data
         except Exception as e:
             raise RuntimeError(f"Failed to parse Info.plist: {e}")
 
@@ -242,10 +242,8 @@ class ZippedXCArchive(AppleArtifact):
                         watch_executable = watch_plist.get("CFBundleExecutable")
                         if watch_executable:
                             watch_binary_path = watch_path / watch_executable
-                            # Use the full watch app name as the key to avoid conflicts
                             watch_name = f"Watch/{watch_path.stem}/{watch_executable}"
 
-                            # Find corresponding dSYM for watch app
                             watch_uuid = self._extract_binary_uuid(watch_binary_path)
                             watch_dsym_path = dsym_files.get(watch_uuid) if watch_uuid else None
 

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -170,7 +170,7 @@ class AndroidAnalyzer:
                                 size=file_size,
                                 file_type=file_type,
                                 treemap_type=treemap_type,
-                                hash_md5=file_hash,
+                                hash=file_hash,
                             )
                             path_to_file_info["Dex"] = merged_dex_info
                             logger.debug("Created merged DEX representation: %s", relative_path)
@@ -190,7 +190,7 @@ class AndroidAnalyzer:
                                 size=merged_size,
                                 file_type=file_type,
                                 treemap_type=treemap_type,
-                                hash_md5="",
+                                hash="",
                             )
                             path_to_file_info["Dex"] = merged_dex_info
                         continue
@@ -216,7 +216,7 @@ class AndroidAnalyzer:
                             size=merged_size,
                             file_type=file_type,
                             treemap_type=treemap_type,
-                            hash_md5="",
+                            hash="",
                         )
                         path_to_file_info[relative_path] = merged_file_info
                     else:
@@ -228,7 +228,7 @@ class AndroidAnalyzer:
                             size=file_size,
                             file_type=file_type,
                             treemap_type=treemap_type,
-                            hash_md5=file_hash,
+                            hash=file_hash,
                         )
                         path_to_file_info[relative_path] = file_info
 

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -171,6 +171,7 @@ class AndroidAnalyzer:
                                 file_type=file_type,
                                 treemap_type=treemap_type,
                                 hash=file_hash,
+                                is_dir=False,
                             )
                             path_to_file_info["Dex"] = merged_dex_info
                             logger.debug("Created merged DEX representation: %s", relative_path)
@@ -191,6 +192,7 @@ class AndroidAnalyzer:
                                 file_type=file_type,
                                 treemap_type=treemap_type,
                                 hash="",
+                                is_dir=False,
                             )
                             path_to_file_info["Dex"] = merged_dex_info
                         continue
@@ -217,6 +219,7 @@ class AndroidAnalyzer:
                             file_type=file_type,
                             treemap_type=treemap_type,
                             hash="",
+                            is_dir=False,
                         )
                         path_to_file_info[relative_path] = merged_file_info
                     else:
@@ -229,6 +232,7 @@ class AndroidAnalyzer:
                             file_type=file_type,
                             treemap_type=treemap_type,
                             hash=file_hash,
+                            is_dir=False,
                         )
                         path_to_file_info[relative_path] = file_info
 
@@ -242,8 +246,12 @@ class AndroidAnalyzer:
                 files_by_type[file_info.file_type] = []
             files_by_type[file_info.file_type].append(file_info)
 
+        # Separate directories from files (though APKs typically don't have directory entries)
+        directories = [f for f in file_infos if f.is_dir]
+
         return FileAnalysis(
             files=file_infos,
+            directories=directories,
         )
 
     def _get_class_definitions(self, apks: list[APK]) -> list[ClassDefinition]:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
-
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -16,7 +14,6 @@ from launchpad.parsers.apple.macho_size_analyzer import MachOSizeAnalyzer
 from launchpad.parsers.apple.macho_symbol_sizes import MachOSymbolSizes
 from launchpad.parsers.apple.objc_symbol_type_aggregator import ObjCSymbolTypeAggregator
 from launchpad.parsers.apple.swift_symbol_type_aggregator import SwiftSymbolTypeAggregator
-from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.hermes.utils import make_hermes_reports
 from launchpad.size.insights.apple.image_optimization import ImageOptimizationInsight
 from launchpad.size.insights.apple.localized_strings import LocalizedStringsInsight
@@ -33,12 +30,11 @@ from launchpad.size.insights.common.large_audios import LargeAudioFileInsight
 from launchpad.size.insights.common.large_images import LargeImageFileInsight
 from launchpad.size.insights.common.large_videos import LargeVideoFileInsight
 from launchpad.size.insights.insight import InsightsInput
-from launchpad.size.models.common import FileAnalysis, FileInfo
-from launchpad.size.models.treemap import FILE_TYPE_TO_TREEMAP_TYPE, TreemapType
 from launchpad.size.treemap.treemap_builder import TreemapBuilder
 from launchpad.size.utils.apple_bundle_size import calculate_bundle_sizes
+from launchpad.size.utils.file_analysis import analyze_apple_files
 from launchpad.utils.apple.code_signature_validator import CodeSignatureValidator
-from launchpad.utils.file_utils import calculate_file_hash, get_file_size, to_nearest_block_size
+from launchpad.utils.file_utils import get_file_size
 from launchpad.utils.logging import get_logger
 from launchpad.utils.performance import trace, trace_ctx
 
@@ -114,7 +110,7 @@ class AppleAppAnalyzer:
         app_info = self.app_info
         logger.info(f"Analyzing app: {app_info.name} v{app_info.version}")
 
-        file_analysis = self._analyze_files(artifact)
+        file_analysis = analyze_apple_files(artifact)
         logger.info(f"Found {file_analysis.file_count} files, total size: {file_analysis.total_size} bytes")
 
         app_bundle_path = artifact.get_app_bundle_path()
@@ -249,46 +245,6 @@ class AppleAppAnalyzer:
             code_signature_errors=code_signature_errors,
         )
 
-    @trace("apple.detect_file_type")
-    def _detect_file_type(self, file_path: Path) -> str:
-        """Detect file type using the file command.
-
-        Args:
-            file_path: Path to the file to analyze
-
-        Returns:
-            File type string from file command output, normalized to common types
-        """
-        try:
-            result = subprocess.run(["file", str(file_path)], capture_output=True, text=True, check=True)
-            # Extract just the file type description after the colon
-            file_type = result.stdout.split(":", 1)[1].strip().lower()
-            logger.debug(f"Detected file type for {file_path}: {file_type}")
-
-            # Normalize common file types
-            if "mach-o" in file_type:
-                return "macho"
-            elif "executable" in file_type:
-                return "executable"
-            elif "text" in file_type:
-                return "text"
-            elif "directory" in file_type:
-                return "directory"
-            elif "symbolic link" in file_type:
-                return "symlink"
-            elif "hermes javascript bytecode" in file_type:
-                return "hermes"
-            elif "empty" in file_type:
-                return "empty"
-
-            return file_type
-        except subprocess.CalledProcessError as e:
-            logger.warning(f"Failed to detect file type for {file_path}: {e}")
-            return "unknown"
-        except Exception as e:
-            logger.warning(f"Unexpected error detecting file type for {file_path}: {e}")
-            return "unknown"
-
     def _get_profile_type(self, profile_data: dict[str, Any]) -> Tuple[str, str]:
         """Determine the type of provisioning profile and its name.
         Args:
@@ -324,86 +280,6 @@ class AppleAppAnalyzer:
 
         # If no devices are provisioned, it's an app store profile
         return "appstore", profile_name
-
-    @trace("apple.analyze_files")
-    def _analyze_files(self, xcarchive: ZippedXCArchive) -> FileAnalysis:
-        """Analyze all files in the app bundle."""
-        logger.debug("Analyzing files in app bundle")
-
-        files: List[FileInfo] = []
-        app_bundle_path = xcarchive.get_app_bundle_path()
-
-        # Walk through all files in the bundle
-        for file_path in app_bundle_path.rglob("*"):
-            if not file_path.is_file():
-                continue
-
-            relative_path = file_path.relative_to(app_bundle_path)
-            file_size = to_nearest_block_size(get_file_size(file_path), APPLE_FILESYSTEM_BLOCK_SIZE)
-
-            # Get file type from extension first
-            # If no extension or unknown type, use file command
-            file_type = file_path.suffix.lower().lstrip(".")
-            if not file_type or file_type == "unknown":
-                file_type = self._detect_file_type(file_path)
-
-            # Calculate hash for duplicate detection
-            file_hash = calculate_file_hash(file_path, algorithm="md5")
-
-            children: List[FileInfo] = []
-            if file_type == "car":
-                children = self._analyze_asset_catalog(xcarchive, relative_path)
-                children_size = sum([child.size for child in children])
-                children.append(
-                    FileInfo(
-                        full_path=file_path,
-                        path=str(relative_path) + "/Other",
-                        size=file_size - children_size,
-                        file_type="unknown",
-                        hash_md5=file_hash,
-                        treemap_type=TreemapType.ASSETS,
-                        children=[],
-                    )
-                )
-
-            file_info = FileInfo(
-                full_path=file_path,
-                path=str(relative_path),
-                size=file_size,
-                file_type=file_type or "unknown",
-                hash_md5=file_hash,
-                treemap_type=FILE_TYPE_TO_TREEMAP_TYPE.get(file_type, TreemapType.FILES),
-                children=children,
-            )
-
-            files.append(file_info)
-
-        return FileAnalysis(files=files)
-
-    @trace("apple.analyze_asset_catalog")
-    def _analyze_asset_catalog(self, xcarchive: ZippedXCArchive, relative_path: Path) -> List[FileInfo]:
-        """Analyze an asset catalog file."""
-        catalog_details = xcarchive.get_asset_catalog_details(relative_path)
-        result: List[FileInfo] = []
-        for element in catalog_details:
-            if element.full_path and element.full_path.exists() and element.full_path.is_file():
-                file_hash = calculate_file_hash(element.full_path, algorithm="md5")
-            else:
-                # not every element is backed by a file, so use imageId as hash
-                file_hash = element.image_id
-
-            result.append(
-                FileInfo(
-                    full_path=element.full_path,
-                    path=str(relative_path) + "/" + element.name,
-                    size=element.size,
-                    file_type=Path(element.full_path).suffix.lstrip(".") if element.full_path else "other",
-                    hash_md5=file_hash,
-                    treemap_type=TreemapType.ASSETS,
-                    children=[],
-                )
-            )
-        return result
 
     def _generate_insight_with_tracing(
         self, insight_class: type, insights_input: InsightsInput, insight_name: str
@@ -505,6 +381,8 @@ class AppleAppAnalyzer:
     def _test_strip_symbols_removal(self, parser: MachOParser, binary_path: Path) -> int:
         """Test actual symbol removal using LIEF to get real size savings, similar to what strip does."""
         import tempfile
+
+        return 0
 
         try:
             with trace_ctx("strip_symbols.get_original_size"):

--- a/src/launchpad/size/insights/apple/localized_strings.py
+++ b/src/launchpad/size/insights/apple/localized_strings.py
@@ -1,6 +1,7 @@
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.apple import LocalizedStringInsightResult
 from launchpad.size.models.common import FileInfo
+from launchpad.size.models.insights import FileSavingsResult
 
 
 class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
@@ -25,10 +26,11 @@ class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
                 localized_files.append(file_info)
                 total_size += file_info.size
 
-        # Only return insight if total size exceeds threshold
         if total_size > self.THRESHOLD_BYTES:
+            file_savings = [FileSavingsResult(file_path=file.path, total_savings=file.size) for file in localized_files]
+
             return LocalizedStringInsightResult(
-                files=localized_files,
+                files=file_savings,
                 total_savings=total_size,
             )
 

--- a/src/launchpad/size/insights/apple/main_binary_export_metadata.py
+++ b/src/launchpad/size/insights/apple/main_binary_export_metadata.py
@@ -1,31 +1,41 @@
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.apple import MachOBinaryAnalysis, MainBinaryExportMetadataResult
+from launchpad.size.models.apple import FileSavingsResult, MachOBinaryAnalysis, MainBinaryExportMetadataResult
 
 
 class MainBinaryExportMetadataInsight(Insight[MainBinaryExportMetadataResult]):
-    """Insight for analyzing the exported symbols metadata in the main binary."""
+    """Insight for analyzing the exported symbols metadata in all main binaries."""
 
     MIN_EXPORTS_THRESHOLD = 1024
 
     def generate(self, input: InsightsInput) -> MainBinaryExportMetadataResult | None:
-        """Generate insight for main binary exported symbols analysis."""
+        """Generate insight for all main binary exported symbols analysis."""
 
-        main_binary_analysis = None
+        export_files: list[FileSavingsResult] = []
+
+        # Analyze all main binaries (main app, app extensions, watch apps)
         for analysis in input.binary_analysis:
             if isinstance(analysis, MachOBinaryAnalysis) and analysis.is_main_binary:
-                main_binary_analysis = analysis
-                break
+                if not analysis.binary_analysis:
+                    continue
 
-        if not main_binary_analysis or not main_binary_analysis.binary_analysis:
+                # Look for dyld_exports_trie component in this main binary
+                for component in analysis.binary_analysis.components:
+                    if component.name == "dyld_exports_trie":
+                        if component.size >= self.MIN_EXPORTS_THRESHOLD:
+                            export_files.append(
+                                FileSavingsResult(
+                                    file_path=analysis.binary_relative_path,
+                                    total_savings=component.size,
+                                )
+                            )
+                        break
+
+        if not export_files:
             return None
 
-        dyld_exports_trie_component = None
-        for component in main_binary_analysis.binary_analysis.components:
-            if component.name == "dyld_exports_trie":
-                dyld_exports_trie_component = component
-                break
+        total_savings = sum(file.total_savings for file in export_files)
 
-        if not dyld_exports_trie_component or dyld_exports_trie_component.size < self.MIN_EXPORTS_THRESHOLD:
-            return None
-
-        return MainBinaryExportMetadataResult(total_savings=dyld_exports_trie_component.size)
+        return MainBinaryExportMetadataResult(
+            total_savings=total_savings,
+            files=export_files,
+        )

--- a/src/launchpad/size/insights/apple/main_binary_export_metadata.py
+++ b/src/launchpad/size/insights/apple/main_binary_export_metadata.py
@@ -1,5 +1,6 @@
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.apple import FileSavingsResult, MachOBinaryAnalysis, MainBinaryExportMetadataResult
+from launchpad.size.models.apple import MachOBinaryAnalysis, MainBinaryExportMetadataResult
+from launchpad.size.models.insights import FileSavingsResult
 
 
 class MainBinaryExportMetadataInsight(Insight[MainBinaryExportMetadataResult]):

--- a/src/launchpad/size/insights/apple/small_files.py
+++ b/src/launchpad/size/insights/apple/small_files.py
@@ -33,7 +33,7 @@ class SmallFilesInsight(Insight[SmallFilesInsightResult]):
             file_savings = [
                 FileSavingsResult(
                     file_path=file.path,
-                    total_savings=APPLE_FILESYSTEM_BLOCK_SIZE - file.size,  # Wasted space savings
+                    total_savings=APPLE_FILESYSTEM_BLOCK_SIZE - file.size,
                 )
                 for file in small_files
             ]

--- a/src/launchpad/size/insights/apple/small_files.py
+++ b/src/launchpad/size/insights/apple/small_files.py
@@ -2,6 +2,7 @@ from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.apple import SmallFilesInsightResult
 from launchpad.size.models.common import FileInfo
+from launchpad.size.models.insights import FileSavingsResult
 
 
 class SmallFilesInsight(Insight[SmallFilesInsightResult]):
@@ -26,13 +27,19 @@ class SmallFilesInsight(Insight[SmallFilesInsightResult]):
         for file_info in input.file_analysis.files:
             if file_info.size < APPLE_FILESYSTEM_BLOCK_SIZE:
                 small_files.append(file_info)
-                # Calculate wasted space due to block size alignment
-                wasted_space = APPLE_FILESYSTEM_BLOCK_SIZE - file_info.size
-                total_savings += wasted_space
+                total_savings += APPLE_FILESYSTEM_BLOCK_SIZE - file_info.size
 
         if len(small_files) > 0:
+            file_savings = [
+                FileSavingsResult(
+                    file_path=file.path,
+                    total_savings=APPLE_FILESYSTEM_BLOCK_SIZE - file.size,  # Wasted space savings
+                )
+                for file in small_files
+            ]
+
             return SmallFilesInsightResult(
-                files=small_files,
+                files=file_savings,
                 file_count=len(small_files),
                 total_savings=total_savings,
             )

--- a/src/launchpad/size/insights/apple/unnecessary_files.py
+++ b/src/launchpad/size/insights/apple/unnecessary_files.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.common import FileInfo
-from launchpad.size.models.insights import UnnecessaryFilesInsightResult
+from launchpad.size.models.insights import FileSavingsResult, UnnecessaryFilesInsightResult
 
 
 class UnnecessaryFilesInsight(Insight[UnnecessaryFilesInsightResult]):
@@ -48,9 +48,10 @@ class UnnecessaryFilesInsight(Insight[UnnecessaryFilesInsightResult]):
 
         if unnecessary_files:
             unnecessary_files.sort(key=lambda f: f.size, reverse=True)
+            files = [FileSavingsResult(file_path=file.path, total_savings=file.size) for file in unnecessary_files]
 
             return UnnecessaryFilesInsightResult(
-                files=unnecessary_files,
+                files=files,
                 total_savings=total_size,
             )
 

--- a/src/launchpad/size/insights/common/duplicate_files.py
+++ b/src/launchpad/size/insights/common/duplicate_files.py
@@ -1,12 +1,11 @@
-import hashlib
 import os
 
 from collections import defaultdict
-from pathlib import Path
-from typing import Dict, List
+from pathlib import PurePosixPath
+from typing import Dict, List, Set
 
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.common import FileInfo, TreemapType
+from launchpad.size.models.common import FileInfo
 from launchpad.size.models.insights import (
     DuplicateFileGroup,
     DuplicateFilesInsightResult,
@@ -16,41 +15,60 @@ from launchpad.size.models.insights import (
 class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
     EXTENSION_ALLOWLIST = [".xcprivacy"]
 
-    # Make sure to group all duplicates in a directory that has one of these extensions
-    DIRECTORY_EXTENSIONS = [".bundle"]
+    MIN_DIR_SIZE_BYTES = 0
 
     def generate(self, input: InsightsInput) -> DuplicateFilesInsightResult | None:
+        files = input.file_analysis.files
+
         groups: List[DuplicateFileGroup] = []
         total_savings = 0
+        covered_dirs: Set[str] = set()
 
-        covered_containers: set[str] = set()
-        for infos in self._duplicate_directories(input.file_analysis.files).values():
-            if len(infos) < 2:
+        # -----------------------------
+        # 1) Duplicate DIRECTORIES
+        # -----------------------------
+        dir_groups = self._directory_duplicate_candidates(files)
+
+        # Process shallower (outer) groups first so we can suppress nested ones
+        dir_groups.sort(key=lambda ds: self._min_depth([d.path for d in ds]))
+
+        for dirs in dir_groups:
+            # If any member of this group is under an already covered dir, skip whole group
+            if self._any_path_under_any([d.path for d in dirs], covered_dirs):
                 continue
 
-            infos.sort(key=lambda f: (-f.size, f.path))
-            group_size = sum(fi.size for fi in infos)
-            savings = group_size - infos[0].size
+            # Savings if we keep the largest one and dedupe the rest
+            dirs.sort(key=lambda d: (-d.size, d.path))
+            if len(dirs) < 2:
+                continue
+
+            group_size = sum(d.size for d in dirs)
+            savings = group_size - dirs[0].size
             if savings <= 0:
                 continue
 
             groups.append(
                 DuplicateFileGroup(
-                    filename=os.path.basename(infos[0].path),
-                    files=infos,
+                    filename=os.path.basename(dirs[0].path) or "/",
+                    files=dirs,
                     total_savings=savings,
                 )
             )
             total_savings += savings
-            for info in infos:
-                covered_containers.add(info.path)
 
+            for d in dirs:
+                covered_dirs.add(d.path)
+
+        # -----------------------------
+        # 2) Duplicate FILES
+        # -----------------------------
         files_by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
-        for f in input.file_analysis.files:
+        for f in files:
             if (
-                f.hash_md5
+                not self._is_dir(f)
+                and f.hash_md5
                 and not self._is_allowed_extension(f.path)
-                and not any(f.path.startswith(c + "/") or f.path == c for c in covered_containers)  # ← NEW GUARD
+                and not self._is_under_any(f.path, covered_dirs)
             ):
                 files_by_hash[f.hash_md5].append(f)
 
@@ -63,12 +81,9 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
             if savings <= 0:
                 continue
 
-            container = self._directory_grouping(dup_files[0].path)
-            name = os.path.basename(container) if container else os.path.basename(dup_files[0].path)
-
             groups.append(
                 DuplicateFileGroup(
-                    filename=name,
+                    filename=os.path.basename(dup_files[0].path),
                     files=dup_files,
                     total_savings=savings,
                 )
@@ -77,50 +92,50 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
 
         groups.sort(key=lambda g: (-g.total_savings, g.filename))
 
-        if len(groups) > 0:
+        if groups:
             return DuplicateFilesInsightResult(groups=groups, total_savings=total_savings)
-
         return None
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _directory_duplicate_candidates(self, files: List[FileInfo]) -> List[List[FileInfo]]:
+        """
+        Returns a list of duplicate-directory groups (lists of FileInfo) where
+        each group shares the same already-computed directory hash and has >= 2 members.
+        """
+        by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
+        for f in files:
+            if self._is_dir(f) and f.hash_md5 and f.size >= self.MIN_DIR_SIZE_BYTES:
+                by_hash[f.hash_md5].append(f)
+
+        return [dirs for dirs in by_hash.values() if len(dirs) > 1]
 
     def _is_allowed_extension(self, file_path: str) -> bool:
         return any(file_path.endswith(ext) for ext in self.EXTENSION_ALLOWLIST)
 
-    def _directory_grouping(self, file_path: str) -> str | None:
-        p = Path(file_path)
-        for i, part in enumerate(p.parts):
-            if any(part.endswith(ext) for ext in self.DIRECTORY_EXTENSIONS):
-                return str(Path(*p.parts[: i + 1]))
-        return None
+    @staticmethod
+    def _is_under_any(path: str, containers: Set[str]) -> bool:
+        for c in containers:
+            if path == c or path.startswith(c + "/"):
+                return True
+        return False
 
-    def _duplicate_directories(self, files: List[FileInfo]) -> Dict[str, List[FileInfo]]:
-        dir_to_children: Dict[str, List[FileInfo]] = defaultdict(list)
-        for f in files:
-            if f.hash_md5:
-                root = self._directory_grouping(f.path)
-                if root:
-                    dir_to_children[root].append(f)
+    @staticmethod
+    def _any_path_under_any(paths: List[str], containers: Set[str]) -> bool:
+        for p in paths:
+            if DuplicateFilesInsight._is_under_any(p, containers):
+                return True
+        return False
 
-        dup_dirs: Dict[str, List[FileInfo]] = defaultdict(list)
-        for root, children in dir_to_children.items():
-            if not children:
-                continue
+    @staticmethod
+    def _min_depth(paths: List[str]) -> int:
+        def depth(p: str) -> int:
+            return 0 if not p else len(PurePosixPath(p).parts)
 
-            md5 = hashlib.md5()
-            for h in sorted(c.hash_md5 for c in children if c.hash_md5):
-                md5.update(h.encode())
-            folder_hash = md5.hexdigest()
+        return min(depth(p) for p in paths) if paths else 0
 
-            dup_dirs[folder_hash].append(
-                FileInfo(
-                    full_path=(
-                        children[0].full_path.parent / root if children[0].full_path is not None else Path(root)
-                    ),
-                    path=root,
-                    size=sum(c.size for c in children),
-                    file_type="directory",
-                    hash_md5=folder_hash,
-                    treemap_type=TreemapType.FILES,
-                    children=children,
-                )
-            )
-        return dup_dirs
+    @staticmethod
+    def _is_dir(f: FileInfo) -> bool:
+        return f.is_dir or f.file_type == "directory"

--- a/src/launchpad/size/insights/common/duplicate_files.py
+++ b/src/launchpad/size/insights/common/duplicate_files.py
@@ -1,45 +1,126 @@
+import hashlib
 import os
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Dict, List
 
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.common import FileInfo
-from launchpad.size.models.insights import DuplicateFileGroup, DuplicateFilesInsightResult
+from launchpad.size.models.common import FileInfo, TreemapType
+from launchpad.size.models.insights import (
+    DuplicateFileGroup,
+    DuplicateFilesInsightResult,
+)
 
 
 class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
-    def generate(self, input: InsightsInput) -> DuplicateFilesInsightResult:
-        files_by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
-        for file in input.file_analysis.files:
-            if file.hash_md5:
-                files_by_hash[file.hash_md5].append(file)
+    EXTENSION_ALLOWLIST = [".xcprivacy"]
 
+    # Make sure to group all duplicates in a directory that has one of these extensions
+    DIRECTORY_EXTENSIONS = [".bundle"]
+
+    def generate(self, input: InsightsInput) -> DuplicateFilesInsightResult | None:
         groups: List[DuplicateFileGroup] = []
         total_savings = 0
 
-        for file_list in files_by_hash.values():
-            if len(file_list) > 1:
-                # Calculate savings: total size - size of one copy we keep
-                total_file_size = sum(f.size for f in file_list)
-                savings_for_this_group = total_file_size - file_list[0].size
+        covered_containers: set[str] = set()
+        for infos in self._duplicate_directories(input.file_analysis.files).values():
+            if len(infos) < 2:
+                continue
 
-                if savings_for_this_group > 0:  # Only include if there are actual savings
-                    sorted_files = sorted(file_list, key=lambda f: (-f.size, f.path))
-                    filenames = sorted(set(os.path.basename(f.path) for f in sorted_files))
-                    group_filename = filenames[0]
+            infos.sort(key=lambda f: (-f.size, f.path))
+            group_size = sum(fi.size for fi in infos)
+            savings = group_size - infos[0].size
+            if savings <= 0:
+                continue
 
-                    group = DuplicateFileGroup(
-                        filename=group_filename,
-                        files=sorted_files,
-                        total_savings=savings_for_this_group,
-                    )
-                    groups.append(group)
-                    total_savings += savings_for_this_group
+            groups.append(
+                DuplicateFileGroup(
+                    filename=os.path.basename(infos[0].path),
+                    files=infos,
+                    total_savings=savings,
+                )
+            )
+            total_savings += savings
+            for info in infos:
+                covered_containers.add(info.path)
 
-        groups = sorted(groups, key=lambda g: (-g.total_savings, g.filename))
+        files_by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
+        for f in input.file_analysis.files:
+            if (
+                f.hash_md5
+                and not self._is_allowed_extension(f.path)
+                and not any(f.path.startswith(c + "/") or f.path == c for c in covered_containers)  # ← NEW GUARD
+            ):
+                files_by_hash[f.hash_md5].append(f)
 
-        return DuplicateFilesInsightResult(
-            groups=groups,
-            total_savings=total_savings,
-        )
+        for dup_files in files_by_hash.values():
+            if len(dup_files) < 2:
+                continue
+
+            dup_files.sort(key=lambda f: (-f.size, f.path))
+            savings = sum(f.size for f in dup_files) - dup_files[0].size
+            if savings <= 0:
+                continue
+
+            container = self._directory_grouping(dup_files[0].path)
+            name = os.path.basename(container) if container else os.path.basename(dup_files[0].path)
+
+            groups.append(
+                DuplicateFileGroup(
+                    filename=name,
+                    files=dup_files,
+                    total_savings=savings,
+                )
+            )
+            total_savings += savings
+
+        groups.sort(key=lambda g: (-g.total_savings, g.filename))
+
+        if len(groups) > 0:
+            return DuplicateFilesInsightResult(groups=groups, total_savings=total_savings)
+
+        return None
+
+    def _is_allowed_extension(self, file_path: str) -> bool:
+        return any(file_path.endswith(ext) for ext in self.EXTENSION_ALLOWLIST)
+
+    def _directory_grouping(self, file_path: str) -> str | None:
+        p = Path(file_path)
+        for i, part in enumerate(p.parts):
+            if any(part.endswith(ext) for ext in self.DIRECTORY_EXTENSIONS):
+                return str(Path(*p.parts[: i + 1]))
+        return None
+
+    def _duplicate_directories(self, files: List[FileInfo]) -> Dict[str, List[FileInfo]]:
+        dir_to_children: Dict[str, List[FileInfo]] = defaultdict(list)
+        for f in files:
+            if f.hash_md5:
+                root = self._directory_grouping(f.path)
+                if root:
+                    dir_to_children[root].append(f)
+
+        dup_dirs: Dict[str, List[FileInfo]] = defaultdict(list)
+        for root, children in dir_to_children.items():
+            if not children:
+                continue
+
+            md5 = hashlib.md5()
+            for h in sorted(c.hash_md5 for c in children if c.hash_md5):
+                md5.update(h.encode())
+            folder_hash = md5.hexdigest()
+
+            dup_dirs[folder_hash].append(
+                FileInfo(
+                    full_path=(
+                        children[0].full_path.parent / root if children[0].full_path is not None else Path(root)
+                    ),
+                    path=root,
+                    size=sum(c.size for c in children),
+                    file_type="directory",
+                    hash_md5=folder_hash,
+                    treemap_type=TreemapType.FILES,
+                    children=children,
+                )
+            )
+        return dup_dirs

--- a/src/launchpad/size/insights/common/duplicate_files.py
+++ b/src/launchpad/size/insights/common/duplicate_files.py
@@ -19,6 +19,7 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
 
     def generate(self, input: InsightsInput) -> DuplicateFilesInsightResult | None:
         files = input.file_analysis.files
+        directories = input.file_analysis.directories
 
         groups: List[DuplicateFileGroup] = []
         total_savings = 0
@@ -27,7 +28,7 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
         # -----------------------------
         # 1) Duplicate DIRECTORIES
         # -----------------------------
-        dir_groups = self._directory_duplicate_candidates(files)
+        dir_groups = self._directory_duplicate_candidates(directories)
 
         # Process shallower (outer) groups first so we can suppress nested ones
         dir_groups.sort(key=lambda ds: self._min_depth([d.path for d in ds]))
@@ -64,13 +65,8 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
         # -----------------------------
         files_by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
         for f in files:
-            if (
-                not self._is_dir(f)
-                and f.hash_md5
-                and not self._is_allowed_extension(f.path)
-                and not self._is_under_any(f.path, covered_dirs)
-            ):
-                files_by_hash[f.hash_md5].append(f)
+            if f.hash and not self._is_allowed_extension(f.path) and not self._is_under_any(f.path, covered_dirs):
+                files_by_hash[f.hash].append(f)
 
         for dup_files in files_by_hash.values():
             if len(dup_files) < 2:
@@ -100,15 +96,15 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
     # Helpers
     # -------------------------------------------------------------------------
 
-    def _directory_duplicate_candidates(self, files: List[FileInfo]) -> List[List[FileInfo]]:
+    def _directory_duplicate_candidates(self, directories: List[FileInfo]) -> List[List[FileInfo]]:
         """
         Returns a list of duplicate-directory groups (lists of FileInfo) where
         each group shares the same already-computed directory hash and has >= 2 members.
         """
         by_hash: Dict[str, List[FileInfo]] = defaultdict(list)
-        for f in files:
-            if self._is_dir(f) and f.hash_md5 and f.size >= self.MIN_DIR_SIZE_BYTES:
-                by_hash[f.hash_md5].append(f)
+        for f in directories:
+            if f.hash and f.size >= self.MIN_DIR_SIZE_BYTES:
+                by_hash[f.hash].append(f)
 
         return [dirs for dirs in by_hash.values() if len(dirs) > 1]
 
@@ -135,7 +131,3 @@ class DuplicateFilesInsight(Insight[DuplicateFilesInsightResult]):
             return 0 if not p else len(PurePosixPath(p).parts)
 
         return min(depth(p) for p in paths) if paths else 0
-
-    @staticmethod
-    def _is_dir(f: FileInfo) -> bool:
-        return f.is_dir or f.file_type == "directory"

--- a/src/launchpad/size/insights/common/hermes_debug_info.py
+++ b/src/launchpad/size/insights/common/hermes_debug_info.py
@@ -5,6 +5,7 @@ from typing import List
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.common import FileInfo
 from launchpad.size.models.insights import (
+    FileSavingsResult,
     HermesDebugInfoInsightResult,
 )
 
@@ -47,7 +48,9 @@ class HermesDebugInfoInsight(Insight[HermesDebugInfoInsightResult]):
             reverse=True,
         )
 
+        files = [FileSavingsResult(file_path=file.path, total_savings=file.size) for file in files_with_debug_info]
+
         return HermesDebugInfoInsightResult(
-            files=files_with_debug_info,
+            files=files,
             total_savings=total_savings,
         )

--- a/src/launchpad/size/insights/common/large_audios.py
+++ b/src/launchpad/size/insights/common/large_audios.py
@@ -1,7 +1,5 @@
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.insights import (
-    LargeAudioFileInsightResult,
-)
+from launchpad.size.models.insights import FileSavingsResult, LargeAudioFileInsightResult
 
 
 class LargeAudioFileInsight(Insight[LargeAudioFileInsightResult]):
@@ -34,10 +32,16 @@ class LargeAudioFileInsight(Insight[LargeAudioFileInsightResult]):
         if len(large_files) == 0:
             return None
 
-        # Sort by largest first
         large_files.sort(key=lambda f: f.size, reverse=True)
 
-        # Calculate total potential savings (assuming files can be optimized to 50% of their size)
-        total_savings = sum(file.size // 2 for file in large_files)
+        file_savings = [
+            FileSavingsResult(
+                file_path=file.path,
+                total_savings=file.size // 2,  # Assuming files can be optimized to 50% of their size
+            )
+            for file in large_files
+        ]
 
-        return LargeAudioFileInsightResult(files=large_files, total_savings=total_savings)
+        total_savings = sum(savings.total_savings for savings in file_savings)
+
+        return LargeAudioFileInsightResult(files=file_savings, total_savings=total_savings)

--- a/src/launchpad/size/insights/common/large_images.py
+++ b/src/launchpad/size/insights/common/large_images.py
@@ -1,5 +1,5 @@
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.insights import LargeImageFileInsightResult
+from launchpad.size.models.insights import FileSavingsResult, LargeImageFileInsightResult
 
 
 class LargeImageFileInsight(Insight[LargeImageFileInsightResult]):
@@ -33,10 +33,16 @@ class LargeImageFileInsight(Insight[LargeImageFileInsightResult]):
         if len(large_files) == 0:
             return None
 
-        # Sort by largest first
         large_files.sort(key=lambda f: f.size, reverse=True)
 
-        # Calculate total potential savings (assuming files can be optimized to 50% of their size)
-        total_savings = sum(file.size // 2 for file in large_files)
+        file_savings = [
+            FileSavingsResult(
+                file_path=file.path,
+                total_savings=file.size // 2,  # Assuming files can be optimized to 50% of their size
+            )
+            for file in large_files
+        ]
 
-        return LargeImageFileInsightResult(files=large_files, total_savings=total_savings)
+        total_savings = sum(savings.total_savings for savings in file_savings)
+
+        return LargeImageFileInsightResult(files=file_savings, total_savings=total_savings)

--- a/src/launchpad/size/insights/common/large_videos.py
+++ b/src/launchpad/size/insights/common/large_videos.py
@@ -1,7 +1,5 @@
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.insights import (
-    LargeVideoFileInsightResult,
-)
+from launchpad.size.models.insights import FileSavingsResult, LargeVideoFileInsightResult
 
 
 class LargeVideoFileInsight(Insight[LargeVideoFileInsightResult]):
@@ -20,10 +18,10 @@ class LargeVideoFileInsight(Insight[LargeVideoFileInsightResult]):
         if len(large_files) == 0:
             return None
 
-        # Sort by largest first
         large_files.sort(key=lambda f: f.size, reverse=True)
 
-        # Calculate total potential savings (assuming files can be optimized to 50% of their size)
-        total_savings = sum(file.size // 2 for file in large_files)
+        file_savings = [FileSavingsResult(file_path=file.path, total_savings=file.size // 2) for file in large_files]
 
-        return LargeVideoFileInsightResult(files=large_files, total_savings=total_savings)
+        total_savings = sum(savings.total_savings for savings in file_savings)
+
+        return LargeVideoFileInsightResult(files=file_savings, total_savings=total_savings)

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -19,6 +19,7 @@ from .common import BaseAnalysisResults, BaseAppInfo, BaseBinaryAnalysis, FileIn
 from .insights import (
     BaseInsightResult,
     DuplicateFilesInsightResult,
+    FileSavingsResult,
     HermesDebugInfoInsightResult,
     LargeAudioFileInsightResult,
     LargeImageFileInsightResult,
@@ -48,13 +49,15 @@ class AppleAnalysisResults(BaseAnalysisResults):
 class LocalizedStringInsightResult(BaseInsightResult):
     """Results from localized string analysis."""
 
-    files: List[FileInfo] = Field(..., description="Localized strings files exceeding 100KB threshold")
+    files: List[FileSavingsResult] = Field(
+        ..., description="Localized strings files exceeding 100KB threshold with their sizes"
+    )
 
 
 class SmallFilesInsightResult(BaseInsightResult):
     """Results from small files analysis."""
 
-    files: List[FileInfo] = Field(..., description="Files smaller than filesystem block size")
+    files: List[FileSavingsResult] = Field(..., description="Files smaller than filesystem block size with their sizes")
     file_count: int = Field(..., description="Number of small files found")
 
 
@@ -88,15 +91,6 @@ class LooseImagesInsightResult(BaseInsightResult):
         ..., description="Groups of loose images that could be moved to asset catalogs"
     )
     total_file_count: int = Field(..., description="Total number of loose image files found")
-
-
-class FileSavingsResult(BaseModel):
-    """File savings information."""
-
-    model_config = ConfigDict(frozen=True)
-
-    file_path: str = Field(..., description="Path to the binary file within the app bundle")
-    total_savings: int = Field(..., ge=0, description="Size of the dyld_exports_trie component in bytes")
 
 
 class MainBinaryExportMetadataResult(BaseInsightResult):

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -90,8 +90,19 @@ class LooseImagesInsightResult(BaseInsightResult):
     total_file_count: int = Field(..., description="Total number of loose image files found")
 
 
+class FileSavingsResult(BaseModel):
+    """File savings information."""
+
+    model_config = ConfigDict(frozen=True)
+
+    file_path: str = Field(..., description="Path to the binary file within the app bundle")
+    total_savings: int = Field(..., ge=0, description="Size of the dyld_exports_trie component in bytes")
+
+
 class MainBinaryExportMetadataResult(BaseInsightResult):
     """Results from main binary exported symbols metadata analysis."""
+
+    files: List[FileSavingsResult] = Field(..., description="Main binaries with export metadata that could be reduced")
 
 
 class OptimizableImageFile(BaseModel):

--- a/src/launchpad/size/models/common.py
+++ b/src/launchpad/size/models/common.py
@@ -34,21 +34,31 @@ class BaseBinaryAnalysis(BaseModel):
 
 
 class FileAnalysis(BaseModel):
-    """Analysis results for files in the app bundle."""
+    """Analysis results for files and directories in the app bundle."""
 
     model_config = ConfigDict(frozen=True)
 
-    files: List[FileInfo] = Field(..., description="List of all files in the bundle")
+    files: List[FileInfo] = Field(..., description="List of all files and directories in the bundle")
 
     @property
     def total_size(self) -> int:
-        """Total bundle size in bytes."""
+        """Total bundle size in bytes (directories have size 0)."""
         return sum(f.size for f in self.files)
 
     @property
     def file_count(self) -> int:
-        """Total number of files."""
+        """Total number of files and directories."""
         return len(self.files)
+
+    @property
+    def files_only_count(self) -> int:
+        """Total number of files (excluding directories)."""
+        return len([f for f in self.files if not f.is_dir])
+
+    @property
+    def directory_count(self) -> int:
+        """Total number of directories."""
+        return len([f for f in self.files if f.is_dir])
 
     @property
     def file_type_sizes(self) -> Dict[str, int]:
@@ -57,22 +67,23 @@ class FileAnalysis(BaseModel):
 
 
 class FileInfo(BaseModel):
-    """Information about a file in the app bundle."""
+    """Information about a file or directory in the app bundle."""
 
     model_config = ConfigDict(frozen=True)
 
     path: str = Field(..., description="Relative path in the bundle")
 
     # Some FileInfo objects are not always backed by a file (e.g. asset catalog elements), so full_path is None
-    full_path: Path | None = Field(..., exclude=True, description="Fully qualified path to the file")
+    full_path: Path | None = Field(..., exclude=True, description="Fully qualified path to the file or directory")
     size: int = Field(
         ...,
         ge=0,
-        description="Raw file size in bytes with no filesystem block size adjustments",
+        description="Raw file size in bytes with no filesystem block size adjustments (0 for directories)",
     )
-    file_type: str = Field(..., description="File type/extension")
-    hash_md5: str = Field(..., description="MD5 hash of file contents")
+    file_type: str = Field(..., description="File type/extension or 'directory'")
+    hash_md5: str = Field(..., description="MD5 hash of file contents or directory identifier")
     treemap_type: TreemapType = Field(..., description="Type for treemap visualization")
+    is_dir: bool = Field(..., description="True if this is a directory, False if it's a file")
     # Some files can be further broken down, even though it's children are not files
     children: List[FileInfo] = Field(default_factory=list, description="Children of the file")
 

--- a/src/launchpad/size/models/common.py
+++ b/src/launchpad/size/models/common.py
@@ -39,6 +39,7 @@ class FileAnalysis(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     files: List[FileInfo] = Field(..., description="List of all files and directories in the bundle")
+    directories: List[FileInfo] = Field(..., description="List of all directories in the bundle")
 
     @property
     def total_size(self) -> int:
@@ -81,7 +82,7 @@ class FileInfo(BaseModel):
         description="Raw file size in bytes with no filesystem block size adjustments (0 for directories)",
     )
     file_type: str = Field(..., description="File type/extension or 'directory'")
-    hash_md5: str = Field(..., description="MD5 hash of file contents or directory identifier")
+    hash: str = Field(..., description="MD5 hash of file contents or directory identifier")
     treemap_type: TreemapType = Field(..., description="Type for treemap visualization")
     is_dir: bool = Field(..., description="True if this is a directory, False if it's a file")
     # Some files can be further broken down, even though it's children are not files

--- a/src/launchpad/size/models/insights.py
+++ b/src/launchpad/size/models/insights.py
@@ -5,6 +5,15 @@ from pydantic import BaseModel, ConfigDict, Field
 from .common import FileInfo
 
 
+class FileSavingsResult(BaseModel):
+    """File savings information."""
+
+    model_config = ConfigDict(frozen=True)
+
+    file_path: str = Field(..., description="Path to the file within the app bundle")
+    total_savings: int = Field(..., ge=0, description="Potential size savings or file size in bytes")
+
+
 class BaseInsightResult(BaseModel):
     """Base class for all insight results."""
 
@@ -47,28 +56,28 @@ class DuplicateFilesInsightResult(BaseInsightResult):
 class LargeImageFileInsightResult(BaseInsightResult):
     """Results from large image files analysis."""
 
-    files: List[FileInfo] = Field(..., description="Image files larger than 10MB")
+    files: List[FileSavingsResult] = Field(..., description="Image files larger than 10MB with their sizes")
 
 
 class LargeVideoFileInsightResult(BaseInsightResult):
     """Results from large video files analysis."""
 
-    files: List[FileInfo] = Field(..., description="Video files larger than 10MB")
+    files: List[FileSavingsResult] = Field(..., description="Video files larger than 10MB with their sizes")
 
 
 class LargeAudioFileInsightResult(BaseInsightResult):
     """Results from large audio files analysis."""
 
-    files: List[FileInfo] = Field(..., description="Audio files larger than 5MB")
+    files: List[FileSavingsResult] = Field(..., description="Audio files larger than 5MB with their sizes")
 
 
 class HermesDebugInfoInsightResult(BaseInsightResult):
     """Results from Hermes debug info analysis."""
 
-    files: List[FileInfo] = Field(..., description="Hermes bytecode files with debug info")
+    files: List[FileSavingsResult] = Field(..., description="Hermes bytecode files with potential debug info savings")
 
 
 class UnnecessaryFilesInsightResult(BaseInsightResult):
     """Results from unnecessary files analysis."""
 
-    files: List[FileInfo] = Field(..., description="Unnecessary files that are not needed for the app to run")
+    files: List[FileSavingsResult] = Field(..., description="Unnecessary files with their sizes that could be removed")

--- a/src/launchpad/size/treemap/default_file_element_builder.py
+++ b/src/launchpad/size/treemap/default_file_element_builder.py
@@ -12,7 +12,7 @@ class DefaultFileElementBuilder(TreemapElementBuilder):
         download_size = int(file_info.size * self.download_compression_ratio)
 
         details: dict[str, object] = {
-            "hash": file_info.hash_md5,  # File hash for deduplication
+            "hash": file_info.hash,  # File hash for deduplication
         }
 
         # Add file extension only for actual files (not binary subsections)

--- a/src/launchpad/size/utils/file_analysis.py
+++ b/src/launchpad/size/utils/file_analysis.py
@@ -1,0 +1,252 @@
+import hashlib
+import logging
+
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Dict, List
+
+from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
+from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
+from launchpad.size.models.common import FileAnalysis, FileInfo
+from launchpad.size.models.treemap import FILE_TYPE_TO_TREEMAP_TYPE, TreemapType
+from launchpad.utils.file_utils import calculate_file_hash, get_file_size, to_nearest_block_size
+from launchpad.utils.performance import trace
+
+logger = logging.getLogger(__name__)
+
+
+@trace("apple.analyze_files")
+def analyze_apple_files(
+    xcarchive: ZippedXCArchive,
+    *,
+    algo: str = "sha256",
+    follow_symlinks: bool = False,
+) -> FileAnalysis:
+    """
+    Analyze all files in the app bundle, computing content hashes for files
+    and content-only hashes for directories (based on their children's hashes).
+    """
+    logger.debug("Analyzing files in app bundle")
+
+    app_bundle_path = xcarchive.get_app_bundle_path()
+
+    # These are filled during the walk (single pass for files/dirs)
+    files: Dict[str, FileInfo] = {}
+    dirs: Dict[str, FileInfo] = {}
+    # Parent -> [child paths] (relative, posix)
+    children_by_dir: Dict[str, List[str]] = defaultdict(list)
+
+    # Ensure we include the root directory explicitly
+    root_rel = ""  # represent root with empty string
+    dirs[root_rel] = _make_directory_info(app_bundle_path, root_rel)
+
+    # Walk everything
+    for file_path in app_bundle_path.rglob("*"):
+        # Optionally ignore symlinks (often safer for bundle analysis)
+        try:
+            if file_path.is_symlink() and not follow_symlinks:
+                continue
+        except OSError:
+            # Broken symlink etc
+            logger.warning("Skipping path due to OSError: %s", file_path)
+            continue
+
+        rel = file_path.relative_to(app_bundle_path).as_posix()  # "" for root not produced by rglob
+        parent_rel = PurePosixPath(rel).parent.as_posix() if rel else root_rel
+
+        if file_path.is_dir():
+            di = _make_directory_info(file_path, rel)
+            dirs[rel] = di
+            children_by_dir[parent_rel].append(rel)
+        elif file_path.is_file():
+            size = to_nearest_block_size(get_file_size(file_path), APPLE_FILESYSTEM_BLOCK_SIZE)
+
+            file_type = file_path.suffix.lower().lstrip(".")
+            if not file_type:
+                file_type = _detect_file_type(file_path)
+
+            # File content hash
+            file_hash = calculate_file_hash(file_path, algorithm=algo)
+
+            children: List[FileInfo] = []
+            if file_type == "car":
+                children = _analyze_asset_catalog(xcarchive, Path(rel))
+                children_size = sum(child.size for child in children)
+                children.append(
+                    FileInfo(
+                        full_path=file_path,
+                        path=f"{rel}/Other",
+                        size=size - children_size,
+                        file_type="unknown",
+                        hash_md5=file_hash,  # keep the same field name for BC, even if algo != md5
+                        treemap_type=TreemapType.ASSETS,
+                        is_dir=False,
+                        children=[],
+                    )
+                )
+
+            fi = FileInfo(
+                full_path=file_path,
+                path=rel,
+                size=size,
+                file_type=file_type or "unknown",
+                hash_md5=file_hash,
+                treemap_type=FILE_TYPE_TO_TREEMAP_TYPE.get(file_type, TreemapType.FILES),
+                is_dir=False,
+                children=children,
+            )
+            files[rel] = fi
+            children_by_dir[parent_rel].append(rel)
+        else:
+            # Neither file nor dir (fifo, socket, etc.) -> skip
+            continue
+
+    # Bottom-up hash all directories from deepest to root
+    directories_with_hashes = _hash_directories_bottom_up(dirs, files, children_by_dir, algo=algo)
+
+    # Merge files + updated dirs
+    all_items = list(files.values()) + list(directories_with_hashes.values())
+
+    return FileAnalysis(files=all_items)
+
+
+def _make_directory_info(full_path: Path, rel: str) -> FileInfo:
+    # size will be filled later as sum(children)
+    return FileInfo(
+        full_path=full_path,
+        path=rel,
+        size=0,
+        file_type="directory",
+        hash_md5="",  # to be filled
+        treemap_type=TreemapType.FILES,
+        is_dir=True,
+        children=[],
+    )
+
+
+def _hash_directories_bottom_up(
+    dirs: Dict[str, FileInfo],
+    files: Dict[str, FileInfo],
+    children_by_dir: Dict[str, List[str]],
+    *,
+    algo: str,
+) -> Dict[str, FileInfo]:
+    # Sort dirs by depth (deepest first)
+    def depth(p: str) -> int:
+        return 0 if p == "" else len(PurePosixPath(p).parts)
+
+    sorted_dirs = sorted(dirs.values(), key=lambda d: depth(d.path), reverse=True)
+    updated: Dict[str, FileInfo] = {}
+
+    # Pre-populate lookup for file hashes/sizes
+    file_hash_lookup = {f.path: f.hash_md5 for f in files.values()}
+    file_size_lookup = {f.path: f.size for f in files.values()}
+    dir_hash_lookup: Dict[str, str] = {}
+    dir_size_lookup: Dict[str, int] = {}
+
+    for d in sorted_dirs:
+        child_paths = children_by_dir.get(d.path, [])
+
+        child_hashes: List[str] = []
+        total_size = 0
+
+        for child in child_paths:
+            if child in files:
+                child_hashes.append(file_hash_lookup[child])
+                total_size += file_size_lookup[child]
+            else:
+                # child is a directory
+                # If we visit deepest-first, the child dir hash should already be computed
+                child_hashes.append(dir_hash_lookup[child])
+                total_size += dir_size_lookup[child]
+
+        # Empty dir -> stable, shared hash
+        if not child_hashes:
+            digest = hashlib.new(algo, b"empty_directory").hexdigest()
+        else:
+            # Only content hashes, sorted, so directory name changes don't matter
+            h = hashlib.new(algo)
+            for hexd in sorted(child_hashes):
+                h.update(hexd.encode("utf-8"))
+                h.update(b";")
+            digest = h.hexdigest()
+
+        updated_dir = FileInfo(
+            full_path=d.full_path,
+            path=d.path,
+            size=total_size,
+            file_type=d.file_type,
+            hash_md5=digest,
+            treemap_type=d.treemap_type,
+            is_dir=True,
+            children=d.children,
+        )
+        updated[d.path] = updated_dir
+        dir_hash_lookup[d.path] = digest
+        dir_size_lookup[d.path] = total_size
+
+    return updated
+
+
+@trace("apple.analyze_asset_catalog")
+def _analyze_asset_catalog(xcarchive: ZippedXCArchive, relative_path: Path) -> List[FileInfo]:
+    """Analyze an asset catalog file."""
+    catalog_details = xcarchive.get_asset_catalog_details(relative_path)
+    result: List[FileInfo] = []
+    for element in catalog_details:
+        if element.full_path and element.full_path.exists() and element.full_path.is_file():
+            # keep md5 field name for BC even if algo set to sha256 above
+            file_hash = calculate_file_hash(element.full_path, algorithm="sha256")
+        else:
+            # not every element is backed by a file, so use imageId as hash
+            file_hash = element.image_id
+
+        result.append(
+            FileInfo(
+                full_path=element.full_path,
+                path=str(relative_path / element.name),
+                size=element.size,
+                file_type=Path(element.full_path).suffix.lstrip(".") if element.full_path else "other",
+                hash_md5=file_hash,
+                treemap_type=TreemapType.ASSETS,
+                is_dir=False,
+                children=[],
+            )
+        )
+    return result
+
+
+@trace("apple.detect_file_type")
+def _detect_file_type(file_path: Path) -> str:
+    """
+    Detect file type using the `file` command only as a fallback.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(["file", str(file_path)], capture_output=True, text=True, check=True)
+        file_type = result.stdout.split(":", 1)[1].strip().lower()
+        logger.debug("Detected file type for %s: %s", file_path, file_type)
+
+        if "mach-o" in file_type:
+            return "macho"
+        if "executable" in file_type:
+            return "executable"
+        if "text" in file_type:
+            return "text"
+        if "directory" in file_type:
+            return "directory"
+        if "symbolic link" in file_type:
+            return "symlink"
+        if "hermes javascript bytecode" in file_type:
+            return "hermes"
+        if "empty" in file_type:
+            return "empty"
+
+        return file_type
+    except subprocess.CalledProcessError as e:
+        logger.warning("Failed to detect file type for %s: %s", file_path, e)
+        return "unknown"
+    except Exception as e:  # pragma: no cover – defensive
+        logger.warning("Unexpected error detecting file type for %s: %s", file_path, e)
+        return "unknown"

--- a/src/launchpad/size/utils/file_analysis.py
+++ b/src/launchpad/size/utils/file_analysis.py
@@ -78,7 +78,7 @@ def analyze_apple_files(
                         path=f"{rel}/Other",
                         size=size - children_size,
                         file_type="unknown",
-                        hash_md5=file_hash,  # keep the same field name for BC, even if algo != md5
+                        hash=file_hash,  # keep the same field name for BC, even if algo != md5
                         treemap_type=TreemapType.ASSETS,
                         is_dir=False,
                         children=[],
@@ -90,7 +90,7 @@ def analyze_apple_files(
                 path=rel,
                 size=size,
                 file_type=file_type or "unknown",
-                hash_md5=file_hash,
+                hash=file_hash,
                 treemap_type=FILE_TYPE_TO_TREEMAP_TYPE.get(file_type, TreemapType.FILES),
                 is_dir=False,
                 children=children,
@@ -104,10 +104,7 @@ def analyze_apple_files(
     # Bottom-up hash all directories from deepest to root
     directories_with_hashes = _hash_directories_bottom_up(dirs, files, children_by_dir, algo=algo)
 
-    # Merge files + updated dirs
-    all_items = list(files.values()) + list(directories_with_hashes.values())
-
-    return FileAnalysis(files=all_items)
+    return FileAnalysis(files=list(files.values()), directories=list(directories_with_hashes.values()))
 
 
 def _make_directory_info(full_path: Path, rel: str) -> FileInfo:
@@ -117,7 +114,7 @@ def _make_directory_info(full_path: Path, rel: str) -> FileInfo:
         path=rel,
         size=0,
         file_type="directory",
-        hash_md5="",  # to be filled
+        hash="",  # to be filled
         treemap_type=TreemapType.FILES,
         is_dir=True,
         children=[],
@@ -139,7 +136,7 @@ def _hash_directories_bottom_up(
     updated: Dict[str, FileInfo] = {}
 
     # Pre-populate lookup for file hashes/sizes
-    file_hash_lookup = {f.path: f.hash_md5 for f in files.values()}
+    file_hash_lookup = {f.path: f.hash for f in files.values()}
     file_size_lookup = {f.path: f.size for f in files.values()}
     dir_hash_lookup: Dict[str, str] = {}
     dir_size_lookup: Dict[str, int] = {}
@@ -176,7 +173,7 @@ def _hash_directories_bottom_up(
             path=d.path,
             size=total_size,
             file_type=d.file_type,
-            hash_md5=digest,
+            hash=digest,
             treemap_type=d.treemap_type,
             is_dir=True,
             children=d.children,
@@ -207,7 +204,7 @@ def _analyze_asset_catalog(xcarchive: ZippedXCArchive, relative_path: Path) -> L
                 path=str(relative_path / element.name),
                 size=element.size,
                 file_type=Path(element.full_path).suffix.lstrip(".") if element.full_path else "other",
-                hash_md5=file_hash,
+                hash=file_hash,
                 treemap_type=TreemapType.ASSETS,
                 is_dir=False,
                 children=[],

--- a/tests/integration/test_image_optimization_insight.py
+++ b/tests/integration/test_image_optimization_insight.py
@@ -87,10 +87,11 @@ class TestImageOptimizationInsightIntegration:
                     hash=calculate_file_hash(path),
                     treemap_type=TreemapType.ASSETS,
                     children=[],
+                    is_dir=False,
                 )
                 files.append(file_info)
 
-        return FileAnalysis(files=files)
+        return FileAnalysis(files=files, directories=[])
 
     @pytest.fixture
     def insights_input(self, sample_file_analysis: FileAnalysis) -> InsightsInput:
@@ -165,11 +166,12 @@ class TestImageOptimizationInsightIntegration:
             hash=calculate_file_hash(large_png),
             treemap_type=TreemapType.ASSETS,
             children=[],
+            is_dir=False,
         )
 
         png_only_input = InsightsInput(
             app_info=insights_input.app_info,
-            file_analysis=FileAnalysis(files=[file_info]),
+            file_analysis=FileAnalysis(files=[file_info], directories=[]),
             binary_analysis=[],
             treemap=None,
             hermes_reports={},
@@ -199,11 +201,12 @@ class TestImageOptimizationInsightIntegration:
             hash=calculate_file_hash(large_jpeg),
             treemap_type=TreemapType.ASSETS,
             children=[],
+            is_dir=False,
         )
 
         jpeg_only_input = InsightsInput(
             app_info=insights_input.app_info,
-            file_analysis=FileAnalysis(files=[file_info]),
+            file_analysis=FileAnalysis(files=[file_info], directories=[]),
             binary_analysis=[],
             treemap=None,
             hermes_reports={},
@@ -240,11 +243,12 @@ class TestImageOptimizationInsightIntegration:
             hash=calculate_file_hash(corrupted_file),
             treemap_type=TreemapType.ASSETS,
             children=[],
+            is_dir=False,
         )
 
         corrupted_input = InsightsInput(
             app_info=insights_input.app_info,
-            file_analysis=FileAnalysis(files=[file_info]),
+            file_analysis=FileAnalysis(files=[file_info], directories=[]),
             binary_analysis=[],
             treemap=None,
             hermes_reports={},
@@ -272,7 +276,7 @@ class TestImageOptimizationInsightIntegration:
                 is_code_signature_valid=True,
                 code_signature_errors=[],
             ),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             binary_analysis=[],
             treemap=None,
             hermes_reports={},
@@ -297,8 +301,10 @@ class TestImageOptimizationInsightIntegration:
                     hash=calculate_file_hash(small_png),
                     treemap_type=TreemapType.ASSETS,
                     children=[],
+                    is_dir=False,
                 )
-            ]
+            ],
+            directories=[],
         )
 
         small_input = InsightsInput(

--- a/tests/integration/test_image_optimization_insight.py
+++ b/tests/integration/test_image_optimization_insight.py
@@ -84,7 +84,7 @@ class TestImageOptimizationInsightIntegration:
                     full_path=path,
                     size=path.stat().st_size,
                     file_type=path.suffix[1:].lower() if path.suffix else "unknown",
-                    hash_md5=calculate_file_hash(path),
+                    hash=calculate_file_hash(path),
                     treemap_type=TreemapType.ASSETS,
                     children=[],
                 )
@@ -162,7 +162,7 @@ class TestImageOptimizationInsightIntegration:
             full_path=large_png,
             size=large_png.stat().st_size,
             file_type="png",
-            hash_md5=calculate_file_hash(large_png),
+            hash=calculate_file_hash(large_png),
             treemap_type=TreemapType.ASSETS,
             children=[],
         )
@@ -196,7 +196,7 @@ class TestImageOptimizationInsightIntegration:
             full_path=large_jpeg,
             size=large_jpeg.stat().st_size,
             file_type="jpg",
-            hash_md5=calculate_file_hash(large_jpeg),
+            hash=calculate_file_hash(large_jpeg),
             treemap_type=TreemapType.ASSETS,
             children=[],
         )
@@ -237,7 +237,7 @@ class TestImageOptimizationInsightIntegration:
             full_path=corrupted_file,
             size=corrupted_file.stat().st_size,
             file_type="png",
-            hash_md5=calculate_file_hash(corrupted_file),
+            hash=calculate_file_hash(corrupted_file),
             treemap_type=TreemapType.ASSETS,
             children=[],
         )
@@ -294,7 +294,7 @@ class TestImageOptimizationInsightIntegration:
                     full_path=small_png,
                     size=small_png.stat().st_size,
                     file_type="png",
-                    hash_md5=calculate_file_hash(small_png),
+                    hash=calculate_file_hash(small_png),
                     treemap_type=TreemapType.ASSETS,
                     children=[],
                 )

--- a/tests/unit/test_android_analyzer.py
+++ b/tests/unit/test_android_analyzer.py
@@ -51,5 +51,5 @@ class TestAndroidAnalyzer:
         results = android_analyzer.analyze(android_artifact)
 
         for file_info in results.file_analysis.files:
-            assert file_info.hash_md5 is not None
-            assert len(file_info.hash_md5) > 0
+            assert file_info.hash is not None
+            assert len(file_info.hash) > 0

--- a/tests/unit/test_duplicate_files_insight.py
+++ b/tests/unit/test_duplicate_files_insight.py
@@ -42,7 +42,8 @@ class TestDuplicateFilesInsight:
                 size=5000,
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
-                hash_md5="plist_hash_1",
+                hash="plist_hash_1",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont.plist"),
@@ -50,7 +51,8 @@ class TestDuplicateFilesInsight:
                 size=4000,
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
-                hash_md5="plist_hash_2",
+                hash="plist_hash_2",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("SwiftMath_SwiftMath.bundle/Resources/config.json"),
@@ -58,7 +60,8 @@ class TestDuplicateFilesInsight:
                 size=3000,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="json_hash_1",
+                hash="json_hash_1",
+                is_dir=False,
             ),
         ]
 
@@ -71,7 +74,8 @@ class TestDuplicateFilesInsight:
                 size=5000,
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
-                hash_md5="plist_hash_1",  # Same hash as bundle1
+                hash="plist_hash_1",  # Same hash as bundle1
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path(
@@ -81,7 +85,8 @@ class TestDuplicateFilesInsight:
                 size=4000,
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
-                hash_md5="plist_hash_2",  # Same hash as bundle1
+                hash="plist_hash_2",  # Same hash as bundle1
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path(
@@ -91,7 +96,8 @@ class TestDuplicateFilesInsight:
                 size=3000,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="json_hash_1",  # Same hash as bundle1
+                hash="json_hash_1",  # Same hash as bundle1
+                is_dir=False,
             ),
         ]
 
@@ -103,7 +109,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="icon_hash",
+                hash="icon_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Backup/icon.png"),
@@ -111,7 +118,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="icon_hash",  # Same hash - these should be detected
+                hash="icon_hash",  # Same hash - these should be detected
+                is_dir=False,
             ),
         ]
 
@@ -161,7 +169,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="strings",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="strings_hash",
+                hash="strings_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Frameworks/MyFramework.framework/Resources.bundle/es.lproj/Localizable.strings"),
@@ -169,7 +178,8 @@ class TestDuplicateFilesInsight:
                 size=1500,
                 file_type="strings",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="strings_hash_es",
+                hash="strings_hash_es",
+                is_dir=False,
             ),
             # Duplicate of the same bundle in a different location
             FileInfo(
@@ -178,7 +188,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="strings",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="strings_hash",
+                hash="strings_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Backup/MyFramework.framework/Resources.bundle/es.lproj/Localizable.strings"),
@@ -186,7 +197,8 @@ class TestDuplicateFilesInsight:
                 size=1500,
                 file_type="strings",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="strings_hash_es",
+                hash="strings_hash_es",
+                is_dir=False,
             ),
         ]
 
@@ -213,7 +225,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="xcprivacy",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="privacy_hash",
+                hash="privacy_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Backup/PrivacyInfo.xcprivacy"),
@@ -221,7 +234,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="xcprivacy",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="privacy_hash",  # Same hash but should be ignored
+                hash="privacy_hash",  # Same hash but should be ignored
+                is_dir=False,
             ),
             # Duplicate regular files (should be detected)
             FileInfo(
@@ -230,7 +244,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="config_hash",
+                hash="config_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Backup/config.json"),
@@ -238,7 +253,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="config_hash",
+                hash="config_hash",
+                is_dir=False,
             ),
         ]
 
@@ -263,7 +279,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash1",
+                hash="hash1",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("file2.png"),
@@ -271,7 +288,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash2",
+                hash="hash2",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("file3.png"),
@@ -279,7 +297,8 @@ class TestDuplicateFilesInsight:
                 size=3000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash3",
+                hash="hash3",
+                is_dir=False,
             ),
         ]
 
@@ -298,7 +317,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="",  # Empty hash
+                hash="",  # Empty hash
+                is_dir=False,
             ),
             # Duplicate files with valid hashes
             FileInfo(
@@ -307,7 +327,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="valid_hash",
+                hash="valid_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("valid2.png"),
@@ -315,7 +336,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="valid_hash",
+                hash="valid_hash",
+                is_dir=False,
             ),
         ]
 
@@ -341,7 +363,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="small_hash",
+                hash="small_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("small2.png"),
@@ -349,7 +372,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="small_hash",
+                hash="small_hash",
+                is_dir=False,
             ),
             # Large duplicate group
             FileInfo(
@@ -358,7 +382,8 @@ class TestDuplicateFilesInsight:
                 size=5000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="large_hash",
+                hash="large_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("large2.png"),
@@ -366,7 +391,8 @@ class TestDuplicateFilesInsight:
                 size=5000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="large_hash",
+                hash="large_hash",
+                is_dir=False,
             ),
             # Medium duplicate group
             FileInfo(
@@ -375,7 +401,8 @@ class TestDuplicateFilesInsight:
                 size=3000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="medium_hash",
+                hash="medium_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("medium2.png"),
@@ -383,7 +410,8 @@ class TestDuplicateFilesInsight:
                 size=3000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="medium_hash",
+                hash="medium_hash",
+                is_dir=False,
             ),
         ]
 
@@ -411,7 +439,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="config_hash",
+                hash="config_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("OtherLibrary.bundle/config.json"),
@@ -419,7 +448,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="config_hash",
+                hash="config_hash",
+                is_dir=False,
             ),
             # Files outside containers
             FileInfo(
@@ -428,7 +458,8 @@ class TestDuplicateFilesInsight:
                 size=1500,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="standalone_hash",
+                hash="standalone_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Backup/standalone_config.json"),
@@ -436,7 +467,8 @@ class TestDuplicateFilesInsight:
                 size=1500,
                 file_type="json",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="standalone_hash",
+                hash="standalone_hash",
+                is_dir=False,
             ),
         ]
 
@@ -477,7 +509,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="txt",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="bundle_file1",
+                hash="bundle_file1",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Framework1.framework/Resources.bundle/file2.txt"),
@@ -485,7 +518,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="txt",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="bundle_file2",
+                hash="bundle_file2",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Framework2.framework/Resources.bundle/file1.txt"),
@@ -493,7 +527,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="txt",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="bundle_file1",  # Same content as Framework1
+                hash="bundle_file1",  # Same content as Framework1
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Framework2.framework/Resources.bundle/file2.txt"),
@@ -501,7 +536,8 @@ class TestDuplicateFilesInsight:
                 size=2000,
                 file_type="txt",
                 treemap_type=TreemapType.RESOURCES,
-                hash_md5="bundle_file2",  # Same content as Framework1
+                hash="bundle_file2",  # Same content as Framework1
+                is_dir=False,
             ),
             # Individual duplicates outside containers (should be detected separately)
             FileInfo(
@@ -510,7 +546,8 @@ class TestDuplicateFilesInsight:
                 size=5000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="icon_hash",
+                hash="icon_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Backup/icon.png"),
@@ -518,7 +555,8 @@ class TestDuplicateFilesInsight:
                 size=5000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="icon_hash",
+                hash="icon_hash",
+                is_dir=False,
             ),
             # Files with None full_path (should still be processed)
             FileInfo(
@@ -527,7 +565,8 @@ class TestDuplicateFilesInsight:
                 size=3000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="embedded_hash",
+                hash="embedded_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=None,
@@ -535,7 +574,8 @@ class TestDuplicateFilesInsight:
                 size=3000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="embedded_hash",
+                hash="embedded_hash",
+                is_dir=False,
             ),
             # Allowlisted files (should be ignored)
             FileInfo(
@@ -544,7 +584,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="xcprivacy",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="privacy_hash",
+                hash="privacy_hash",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Backup/PrivacyInfo.xcprivacy"),
@@ -552,7 +593,8 @@ class TestDuplicateFilesInsight:
                 size=1000,
                 file_type="xcprivacy",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="privacy_hash",  # Should be ignored
+                hash="privacy_hash",  # Should be ignored
+                is_dir=False,
             ),
         ]
 

--- a/tests/unit/test_duplicate_files_insight.py
+++ b/tests/unit/test_duplicate_files_insight.py
@@ -19,7 +19,9 @@ class TestDuplicateFilesInsight:
 
     def _create_insights_input(self, files: list[FileInfo]) -> InsightsInput:
         """Helper method to create InsightsInput for testing."""
-        file_analysis = FileAnalysis(files=files)
+        # Separate directories from the files list
+        directories = [f for f in files if f.is_dir]
+        file_analysis = FileAnalysis(files=files, directories=directories)
         return InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
             file_analysis=file_analysis,
@@ -123,7 +125,33 @@ class TestDuplicateFilesInsight:
             ),
         ]
 
-        all_files = bundle1_files + bundle2_files + other_duplicate_files
+        # Create directory entries for the duplicate bundle directories
+        bundle_directories = [
+            # First SwiftMath_SwiftMath.bundle directory
+            FileInfo(
+                full_path=Path("SwiftMath_SwiftMath.bundle"),
+                path="SwiftMath_SwiftMath.bundle",
+                size=12000,  # Total size of all files in bundle
+                file_type="directory",
+                treemap_type=TreemapType.OTHER,
+                hash="bundle_hash",  # Same hash for identical content
+                is_dir=True,
+            ),
+            # Second SwiftMath_SwiftMath.bundle directory (duplicate)
+            FileInfo(
+                full_path=Path(
+                    "Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle"
+                ),
+                path="Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle",
+                size=12000,  # Same total size
+                file_type="directory",
+                treemap_type=TreemapType.OTHER,
+                hash="bundle_hash",  # Same hash for identical content
+                is_dir=True,
+            ),
+        ]
+
+        all_files = bundle_directories + bundle1_files + bundle2_files + other_duplicate_files
         insights_input = self._create_insights_input(all_files)
         result = self.insight.generate(insights_input)
 
@@ -202,7 +230,32 @@ class TestDuplicateFilesInsight:
             ),
         ]
 
-        insights_input = self._create_insights_input(files)
+        # Add directory entries for the duplicate Resources.bundle directories
+        bundle_directories = [
+            # First Resources.bundle directory
+            FileInfo(
+                full_path=Path("Frameworks/MyFramework.framework/Resources.bundle"),
+                path="Frameworks/MyFramework.framework/Resources.bundle",
+                size=3500,  # Total size of all files in bundle (2000 + 1500)
+                file_type="directory",
+                treemap_type=TreemapType.OTHER,
+                hash="resources_bundle_hash",  # Same hash for identical content
+                is_dir=True,
+            ),
+            # Second Resources.bundle directory (duplicate)
+            FileInfo(
+                full_path=Path("Backup/MyFramework.framework/Resources.bundle"),
+                path="Backup/MyFramework.framework/Resources.bundle",
+                size=3500,  # Same total size
+                file_type="directory",
+                treemap_type=TreemapType.OTHER,
+                hash="resources_bundle_hash",  # Same hash for identical content
+                is_dir=True,
+            ),
+        ]
+
+        all_files = files + bundle_directories
+        insights_input = self._create_insights_input(all_files)
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, DuplicateFilesInsightResult)
@@ -598,7 +651,32 @@ class TestDuplicateFilesInsight:
             ),
         ]
 
-        insights_input = self._create_insights_input(files)
+        # Add directory entries for the duplicate Resources.bundle directories
+        bundle_directories = [
+            # First Resources.bundle directory
+            FileInfo(
+                full_path=Path("Framework1.framework/Resources.bundle"),
+                path="Framework1.framework/Resources.bundle",
+                size=3000,  # Total size of all files in bundle (1000 + 2000)
+                file_type="directory",
+                treemap_type=TreemapType.OTHER,
+                hash="resources_bundle_hash",  # Same hash for identical content
+                is_dir=True,
+            ),
+            # Second Resources.bundle directory (duplicate)
+            FileInfo(
+                full_path=Path("Framework2.framework/Resources.bundle"),
+                path="Framework2.framework/Resources.bundle",
+                size=3000,  # Same total size
+                file_type="directory",
+                treemap_type=TreemapType.OTHER,
+                hash="resources_bundle_hash",  # Same hash for identical content
+                is_dir=True,
+            ),
+        ]
+
+        all_files = files + bundle_directories
+        insights_input = self._create_insights_input(all_files)
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, DuplicateFilesInsightResult)

--- a/tests/unit/test_duplicate_files_insight.py
+++ b/tests/unit/test_duplicate_files_insight.py
@@ -1,0 +1,595 @@
+"""Tests for DuplicateFilesInsight."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from launchpad.size.insights.common.duplicate_files import DuplicateFilesInsight
+from launchpad.size.insights.insight import InsightsInput
+from launchpad.size.models.common import BaseAppInfo, FileAnalysis, FileInfo
+from launchpad.size.models.insights import DuplicateFilesInsightResult
+from launchpad.size.models.treemap import TreemapType
+
+
+class TestDuplicateFilesInsight:
+    """Test the DuplicateFilesInsight class."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.insight = DuplicateFilesInsight()
+
+    def _create_insights_input(self, files: list[FileInfo]) -> InsightsInput:
+        """Helper method to create InsightsInput for testing."""
+        file_analysis = FileAnalysis(files=files)
+        return InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+    def test_generate_with_duplicate_directories_prevents_double_counting(self):
+        """
+        Test that when duplicate directories are detected, individual files within
+        those directories are NOT flagged separately (preventing double-counting).
+
+        This tests the fix for the SwiftMath_SwiftMath.bundle edge case.
+        """
+        # Create two identical .bundle directories with identical contents
+        bundle1_files = [
+            FileInfo(
+                full_path=Path("SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont-Bold.plist"),
+                path="SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont-Bold.plist",
+                size=5000,
+                file_type="plist",
+                treemap_type=TreemapType.PLISTS,
+                hash_md5="plist_hash_1",
+            ),
+            FileInfo(
+                full_path=Path("SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont.plist"),
+                path="SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont.plist",
+                size=4000,
+                file_type="plist",
+                treemap_type=TreemapType.PLISTS,
+                hash_md5="plist_hash_2",
+            ),
+            FileInfo(
+                full_path=Path("SwiftMath_SwiftMath.bundle/Resources/config.json"),
+                path="SwiftMath_SwiftMath.bundle/Resources/config.json",
+                size=3000,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="json_hash_1",
+            ),
+        ]
+
+        bundle2_files = [
+            FileInfo(
+                full_path=Path(
+                    "Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont-Bold.plist"
+                ),
+                path="Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont-Bold.plist",
+                size=5000,
+                file_type="plist",
+                treemap_type=TreemapType.PLISTS,
+                hash_md5="plist_hash_1",  # Same hash as bundle1
+            ),
+            FileInfo(
+                full_path=Path(
+                    "Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont.plist"
+                ),
+                path="Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle/mathFonts.bundle/GenericFont.plist",
+                size=4000,
+                file_type="plist",
+                treemap_type=TreemapType.PLISTS,
+                hash_md5="plist_hash_2",  # Same hash as bundle1
+            ),
+            FileInfo(
+                full_path=Path(
+                    "Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle/Resources/config.json"
+                ),
+                path="Frameworks/SwiftMath_-5E59CDD896963160_PackageProduct.framework/SwiftMath_SwiftMath.bundle/Resources/config.json",
+                size=3000,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="json_hash_1",  # Same hash as bundle1
+            ),
+        ]
+
+        # Add some other duplicate files outside the bundles that SHOULD be detected
+        other_duplicate_files = [
+            FileInfo(
+                full_path=Path("Assets/icon.png"),
+                path="Assets/icon.png",
+                size=2000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="icon_hash",
+            ),
+            FileInfo(
+                full_path=Path("Backup/icon.png"),
+                path="Backup/icon.png",
+                size=2000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="icon_hash",  # Same hash - these should be detected
+            ),
+        ]
+
+        all_files = bundle1_files + bundle2_files + other_duplicate_files
+        insights_input = self._create_insights_input(all_files)
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, DuplicateFilesInsightResult)
+
+        # Should have exactly 2 groups:
+        # 1. The duplicate bundle directories
+        # 2. The duplicate icon.png files
+        assert len(result.groups) == 2
+
+        # Find the bundle group
+        bundle_group = next((g for g in result.groups if "SwiftMath_SwiftMath.bundle" in g.filename), None)
+        assert bundle_group is not None
+        assert len(bundle_group.files) == 2  # Two bundle instances
+        # Bundle savings = total size of one bundle (smaller one gets eliminated)
+        bundle_size = 5000 + 4000 + 3000  # 12000 per bundle
+        assert bundle_group.total_savings == bundle_size
+
+        # Find the icon group
+        icon_group = next((g for g in result.groups if g.filename == "icon.png"), None)
+        assert icon_group is not None
+        assert len(icon_group.files) == 2  # Two icon files
+        assert icon_group.total_savings == 2000  # Size of one duplicate
+
+        # Total savings should be bundle savings + icon savings
+        assert result.total_savings == bundle_size + 2000
+
+        # Verify that individual files within the bundles are NOT flagged separately
+        # None of the groups should contain the individual plist or json files
+        for group in result.groups:
+            for file in group.files:
+                assert "GenericFont-Bold.plist" not in file.path
+                assert "GenericFont.plist" not in file.path
+                assert "config.json" not in file.path
+
+    def test_directory_grouping_with_nested_bundles(self):
+        """Test that directory grouping works correctly with nested .bundle directories."""
+        files = [
+            # Files in a nested bundle structure
+            FileInfo(
+                full_path=Path("Frameworks/MyFramework.framework/Resources.bundle/en.lproj/Localizable.strings"),
+                path="Frameworks/MyFramework.framework/Resources.bundle/en.lproj/Localizable.strings",
+                size=2000,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="strings_hash",
+            ),
+            FileInfo(
+                full_path=Path("Frameworks/MyFramework.framework/Resources.bundle/es.lproj/Localizable.strings"),
+                path="Frameworks/MyFramework.framework/Resources.bundle/es.lproj/Localizable.strings",
+                size=1500,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="strings_hash_es",
+            ),
+            # Duplicate of the same bundle in a different location
+            FileInfo(
+                full_path=Path("Backup/MyFramework.framework/Resources.bundle/en.lproj/Localizable.strings"),
+                path="Backup/MyFramework.framework/Resources.bundle/en.lproj/Localizable.strings",
+                size=2000,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="strings_hash",
+            ),
+            FileInfo(
+                full_path=Path("Backup/MyFramework.framework/Resources.bundle/es.lproj/Localizable.strings"),
+                path="Backup/MyFramework.framework/Resources.bundle/es.lproj/Localizable.strings",
+                size=1500,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="strings_hash_es",
+            ),
+        ]
+
+        insights_input = self._create_insights_input(files)
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, DuplicateFilesInsightResult)
+        assert len(result.groups) == 1
+
+        # Should detect the duplicate Resources.bundle directories
+        group = result.groups[0]
+        assert group.filename == "Resources.bundle"
+        assert len(group.files) == 2
+        bundle_size = 2000 + 1500  # 3500 per bundle
+        assert group.total_savings == bundle_size
+
+    def test_extension_allowlist_excludes_xcprivacy_files(self):
+        """Test that .xcprivacy files are excluded from duplicate detection."""
+        files = [
+            # Duplicate .xcprivacy files (should be ignored)
+            FileInfo(
+                full_path=Path("PrivacyInfo.xcprivacy"),
+                path="PrivacyInfo.xcprivacy",
+                size=1000,
+                file_type="xcprivacy",
+                treemap_type=TreemapType.OTHER,
+                hash_md5="privacy_hash",
+            ),
+            FileInfo(
+                full_path=Path("Backup/PrivacyInfo.xcprivacy"),
+                path="Backup/PrivacyInfo.xcprivacy",
+                size=1000,
+                file_type="xcprivacy",
+                treemap_type=TreemapType.OTHER,
+                hash_md5="privacy_hash",  # Same hash but should be ignored
+            ),
+            # Duplicate regular files (should be detected)
+            FileInfo(
+                full_path=Path("config.json"),
+                path="config.json",
+                size=2000,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="config_hash",
+            ),
+            FileInfo(
+                full_path=Path("Backup/config.json"),
+                path="Backup/config.json",
+                size=2000,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="config_hash",
+            ),
+        ]
+
+        insights_input = self._create_insights_input(files)
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, DuplicateFilesInsightResult)
+        assert len(result.groups) == 1
+
+        # Should only detect the config.json duplicates, not .xcprivacy
+        group = result.groups[0]
+        assert group.filename == "config.json"
+        assert len(group.files) == 2
+        assert group.total_savings == 2000
+
+    def test_no_duplicates_returns_none(self):
+        """Test that no insight is generated when there are no duplicate files."""
+        files = [
+            FileInfo(
+                full_path=Path("file1.png"),
+                path="file1.png",
+                size=1000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="hash1",
+            ),
+            FileInfo(
+                full_path=Path("file2.png"),
+                path="file2.png",
+                size=2000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="hash2",
+            ),
+            FileInfo(
+                full_path=Path("file3.png"),
+                path="file3.png",
+                size=3000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="hash3",
+            ),
+        ]
+
+        insights_input = self._create_insights_input(files)
+        result = self.insight.generate(insights_input)
+
+        assert result is None
+
+    def test_files_without_hash_ignored(self):
+        """Test that files without MD5 hashes are ignored."""
+        files = [
+            # File without hash
+            FileInfo(
+                full_path=Path("no_hash.png"),
+                path="no_hash.png",
+                size=1000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="",  # Empty hash
+            ),
+            # Duplicate files with valid hashes
+            FileInfo(
+                full_path=Path("valid1.png"),
+                path="valid1.png",
+                size=2000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="valid_hash",
+            ),
+            FileInfo(
+                full_path=Path("valid2.png"),
+                path="valid2.png",
+                size=2000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="valid_hash",
+            ),
+        ]
+
+        insights_input = self._create_insights_input(files)
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, DuplicateFilesInsightResult)
+        assert len(result.groups) == 1
+
+        # Should only detect the files with valid hashes
+        group = result.groups[0]
+        assert group.filename == "valid1.png"
+        assert len(group.files) == 2
+        assert group.total_savings == 2000
+
+    def test_sorting_by_savings_and_filename(self):
+        """Test that groups are sorted by total savings (descending), then by filename."""
+        files = [
+            # Small duplicate group
+            FileInfo(
+                full_path=Path("small1.png"),
+                path="small1.png",
+                size=1000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="small_hash",
+            ),
+            FileInfo(
+                full_path=Path("small2.png"),
+                path="small2.png",
+                size=1000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="small_hash",
+            ),
+            # Large duplicate group
+            FileInfo(
+                full_path=Path("large1.png"),
+                path="large1.png",
+                size=5000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="large_hash",
+            ),
+            FileInfo(
+                full_path=Path("large2.png"),
+                path="large2.png",
+                size=5000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="large_hash",
+            ),
+            # Medium duplicate group
+            FileInfo(
+                full_path=Path("medium1.png"),
+                path="medium1.png",
+                size=3000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="medium_hash",
+            ),
+            FileInfo(
+                full_path=Path("medium2.png"),
+                path="medium2.png",
+                size=3000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="medium_hash",
+            ),
+        ]
+
+        insights_input = self._create_insights_input(files)
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, DuplicateFilesInsightResult)
+        assert len(result.groups) == 3
+
+        # Should be sorted by savings: large (5000), medium (3000), small (1000)
+        assert result.groups[0].filename == "large1.png"
+        assert result.groups[0].total_savings == 5000
+        assert result.groups[1].filename == "medium1.png"
+        assert result.groups[1].total_savings == 3000
+        assert result.groups[2].filename == "small1.png"
+        assert result.groups[2].total_savings == 1000
+
+    def test_container_name_preference_over_filename(self):
+        """Test that container names are preferred over individual filenames when available."""
+        files = [
+            # Files inside a .bundle container
+            FileInfo(
+                full_path=Path("MyLibrary.bundle/config.json"),
+                path="MyLibrary.bundle/config.json",
+                size=2000,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="config_hash",
+            ),
+            FileInfo(
+                full_path=Path("OtherLibrary.bundle/config.json"),
+                path="OtherLibrary.bundle/config.json",
+                size=2000,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="config_hash",
+            ),
+            # Files outside containers
+            FileInfo(
+                full_path=Path("standalone_config.json"),
+                path="standalone_config.json",
+                size=1500,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="standalone_hash",
+            ),
+            FileInfo(
+                full_path=Path("Backup/standalone_config.json"),
+                path="Backup/standalone_config.json",
+                size=1500,
+                file_type="json",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="standalone_hash",
+            ),
+        ]
+
+        insights_input = self._create_insights_input(files)
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, DuplicateFilesInsightResult)
+        assert len(result.groups) == 2
+
+        # Find the container-based group
+        container_group = next((g for g in result.groups if "bundle" not in g.filename.lower()), None)
+        standalone_group = next((g for g in result.groups if g.filename == "standalone_config.json"), None)
+
+        # Both groups should exist
+        assert container_group is not None
+        assert standalone_group is not None
+
+    def test_empty_file_list(self):
+        """Test that no insight is generated with empty file list."""
+        insights_input = self._create_insights_input([])
+        result = self.insight.generate(insights_input)
+        assert result is None
+
+    def test_complex_scenario_with_multiple_edge_cases(self):
+        """
+        Test a complex scenario combining multiple edge cases:
+        - Duplicate directories with nested bundles
+        - Individual file duplicates outside containers
+        - Files with None full_path
+        - Allowlisted extensions
+        - Different container types
+        """
+        files = [
+            # Duplicate .bundle directories (should be grouped as directories)
+            FileInfo(
+                full_path=Path("Framework1.framework/Resources.bundle/file1.txt"),
+                path="Framework1.framework/Resources.bundle/file1.txt",
+                size=1000,
+                file_type="txt",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="bundle_file1",
+            ),
+            FileInfo(
+                full_path=Path("Framework1.framework/Resources.bundle/file2.txt"),
+                path="Framework1.framework/Resources.bundle/file2.txt",
+                size=2000,
+                file_type="txt",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="bundle_file2",
+            ),
+            FileInfo(
+                full_path=Path("Framework2.framework/Resources.bundle/file1.txt"),
+                path="Framework2.framework/Resources.bundle/file1.txt",
+                size=1000,
+                file_type="txt",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="bundle_file1",  # Same content as Framework1
+            ),
+            FileInfo(
+                full_path=Path("Framework2.framework/Resources.bundle/file2.txt"),
+                path="Framework2.framework/Resources.bundle/file2.txt",
+                size=2000,
+                file_type="txt",
+                treemap_type=TreemapType.RESOURCES,
+                hash_md5="bundle_file2",  # Same content as Framework1
+            ),
+            # Individual duplicates outside containers (should be detected separately)
+            FileInfo(
+                full_path=Path("Assets/icon.png"),
+                path="Assets/icon.png",
+                size=5000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="icon_hash",
+            ),
+            FileInfo(
+                full_path=Path("Backup/icon.png"),
+                path="Backup/icon.png",
+                size=5000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="icon_hash",
+            ),
+            # Files with None full_path (should still be processed)
+            FileInfo(
+                full_path=None,
+                path="Assets.car/embedded_icon.png",
+                size=3000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="embedded_hash",
+            ),
+            FileInfo(
+                full_path=None,
+                path="Backup.car/embedded_icon.png",
+                size=3000,
+                file_type="png",
+                treemap_type=TreemapType.ASSETS,
+                hash_md5="embedded_hash",
+            ),
+            # Allowlisted files (should be ignored)
+            FileInfo(
+                full_path=Path("PrivacyInfo.xcprivacy"),
+                path="PrivacyInfo.xcprivacy",
+                size=1000,
+                file_type="xcprivacy",
+                treemap_type=TreemapType.OTHER,
+                hash_md5="privacy_hash",
+            ),
+            FileInfo(
+                full_path=Path("Backup/PrivacyInfo.xcprivacy"),
+                path="Backup/PrivacyInfo.xcprivacy",
+                size=1000,
+                file_type="xcprivacy",
+                treemap_type=TreemapType.OTHER,
+                hash_md5="privacy_hash",  # Should be ignored
+            ),
+        ]
+
+        insights_input = self._create_insights_input(files)
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, DuplicateFilesInsightResult)
+
+        # Should have exactly 3 groups:
+        # 1. Duplicate Resources.bundle directories (largest savings)
+        # 2. Duplicate icon.png files
+        # 3. Duplicate embedded_icon.png files
+        assert len(result.groups) == 3
+
+        # Verify the bundle group
+        bundle_group = next((g for g in result.groups if g.filename == "Resources.bundle"), None)
+        assert bundle_group is not None
+        assert len(bundle_group.files) == 2
+        bundle_size = 1000 + 2000  # 3000 per bundle
+        assert bundle_group.total_savings == bundle_size
+
+        # Verify the icon group
+        icon_group = next((g for g in result.groups if g.filename == "icon.png"), None)
+        assert icon_group is not None
+        assert len(icon_group.files) == 2
+        assert icon_group.total_savings == 5000
+
+        # Verify the embedded icon group
+        embedded_group = next((g for g in result.groups if g.filename == "embedded_icon.png"), None)
+        assert embedded_group is not None
+        assert len(embedded_group.files) == 2
+        assert embedded_group.total_savings == 3000
+
+        # Verify total savings
+        expected_total = bundle_size + 5000 + 3000  # 11000
+        assert result.total_savings == expected_total
+
+        # Verify that .xcprivacy files were ignored (no group for them)
+        privacy_group = next((g for g in result.groups if "xcprivacy" in g.filename), None)
+        assert privacy_group is None

--- a/tests/unit/test_hermes_debug_info_insight.py
+++ b/tests/unit/test_hermes_debug_info_insight.py
@@ -24,7 +24,7 @@ class TestHermesDebugInfoInsight:
             size=1024 * 1024,  # 1MB
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         # Create Hermes report with debug info
@@ -80,7 +80,7 @@ class TestHermesDebugInfoInsight:
             size=1024 * 1024,  # 1MB
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         # Create Hermes report without debug info
@@ -133,7 +133,7 @@ class TestHermesDebugInfoInsight:
             size=1024 * 1024,  # 1MB
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         file_analysis = FileAnalysis(files=[non_hermes_file])
@@ -159,7 +159,7 @@ class TestHermesDebugInfoInsight:
             size=1024 * 1024,  # 1MB
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         file_analysis = FileAnalysis(files=[hermes_file])
@@ -185,7 +185,7 @@ class TestHermesDebugInfoInsight:
             size=1024 * 1024,  # 1MB
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         hermes_file_2 = FileInfo(
             full_path=Path("assets/vendor.hbc"),
@@ -193,7 +193,7 @@ class TestHermesDebugInfoInsight:
             size=512 * 1024,  # 512KB
             file_type="hbc",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         # Create Hermes reports with different debug info sizes

--- a/tests/unit/test_hermes_debug_info_insight.py
+++ b/tests/unit/test_hermes_debug_info_insight.py
@@ -68,7 +68,7 @@ class TestHermesDebugInfoInsight:
 
         assert isinstance(result, HermesDebugInfoInsightResult)
         assert len(result.files) == 1
-        assert result.files[0].path == "assets/index.jsbundle"
+        assert result.files[0].file_path == "assets/index.jsbundle"
         assert result.total_savings == 2048  # Debug info size
 
     def test_generate_with_hermes_files_without_debug_info(self):
@@ -237,6 +237,6 @@ class TestHermesDebugInfoInsight:
         assert isinstance(result, HermesDebugInfoInsightResult)
         assert len(result.files) == 2
         # Should be sorted by debug info size (largest first)
-        assert result.files[0].path == "assets/vendor.hbc"  # Larger debug info
-        assert result.files[1].path == "assets/index.jsbundle"  # Smaller debug info
-        assert result.total_savings == 3072  # 1024 + 2048
+        assert result.files[0].file_path == "assets/vendor.hbc"  # Larger debug info
+        assert result.files[1].file_path == "assets/index.jsbundle"  # Smaller debug info
+        assert result.total_savings == 1024 + 2048  # Total debug info size

--- a/tests/unit/test_hermes_debug_info_insight.py
+++ b/tests/unit/test_hermes_debug_info_insight.py
@@ -25,6 +25,7 @@ class TestHermesDebugInfoInsight:
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
 
         # Create Hermes report with debug info
@@ -53,7 +54,7 @@ class TestHermesDebugInfoInsight:
             "file_size": 102400,
         }
 
-        file_analysis = FileAnalysis(files=[hermes_file])
+        file_analysis = FileAnalysis(files=[hermes_file], directories=[])
         hermes_reports = {"assets/index.jsbundle": hermes_report}
 
         insights_input = InsightsInput(
@@ -81,6 +82,7 @@ class TestHermesDebugInfoInsight:
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
 
         # Create Hermes report without debug info
@@ -109,7 +111,7 @@ class TestHermesDebugInfoInsight:
             "file_size": 102400,
         }
 
-        file_analysis = FileAnalysis(files=[hermes_file])
+        file_analysis = FileAnalysis(files=[hermes_file], directories=[])
         hermes_reports = {"assets/index.jsbundle": hermes_report}
 
         insights_input = InsightsInput(
@@ -134,9 +136,10 @@ class TestHermesDebugInfoInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[non_hermes_file])
+        file_analysis = FileAnalysis(files=[non_hermes_file], directories=[])
         hermes_reports: dict[str, HermesReport] = {}
 
         insights_input = InsightsInput(
@@ -160,9 +163,10 @@ class TestHermesDebugInfoInsight:
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[hermes_file])
+        file_analysis = FileAnalysis(files=[hermes_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -186,6 +190,7 @@ class TestHermesDebugInfoInsight:
             file_type="jsbundle",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         hermes_file_2 = FileInfo(
             full_path=Path("assets/vendor.hbc"),
@@ -194,6 +199,7 @@ class TestHermesDebugInfoInsight:
             file_type="hbc",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
 
         # Create Hermes reports with different debug info sizes
@@ -218,7 +224,7 @@ class TestHermesDebugInfoInsight:
             "file_size": 102400,
         }
 
-        file_analysis = FileAnalysis(files=[hermes_file_1, hermes_file_2])
+        file_analysis = FileAnalysis(files=[hermes_file_1, hermes_file_2], directories=[])
         hermes_reports = {
             "assets/index.jsbundle": hermes_report_1,
             "assets/vendor.hbc": hermes_report_2,

--- a/tests/unit/test_large_audio_file_insight.py
+++ b/tests/unit/test_large_audio_file_insight.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import Mock
 
 from launchpad.size.insights.common.large_audios import LargeAudioFileInsight
@@ -13,7 +14,7 @@ class TestLargeAudioFileInsight:
 
     def test_generate_with_large_audio_files(self):
         large_audio_1 = FileInfo(
-            full_path="assets/large_audio.mp3",
+            full_path=Path("assets/large_audio.mp3"),
             path="assets/large_audio.mp3",
             size=8 * 1024 * 1024,  # 8MB
             file_type="mp3",
@@ -21,7 +22,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash1",
         )
         large_audio_2 = FileInfo(
-            full_path="assets/large_wav.wav",
+            full_path=Path("assets/large_wav.wav"),
             path="assets/large_wav.wav",
             size=6 * 1024 * 1024,  # 6MB
             file_type="wav",
@@ -29,7 +30,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash2",
         )
         small_audio = FileInfo(
-            full_path="assets/small_audio.mp3",
+            full_path=Path("assets/small_audio.mp3"),
             path="assets/small_audio.mp3",
             size=3 * 1024 * 1024,  # 3MB
             file_type="mp3",
@@ -52,13 +53,13 @@ class TestLargeAudioFileInsight:
         assert len(result.files) == 2
 
         # Should be sorted by size (largest first)
-        assert result.files[0].path == "assets/large_audio.mp3"
-        assert result.files[0].size == 8 * 1024 * 1024
-        assert result.files[1].path == "assets/large_wav.wav"
-        assert result.files[1].size == 6 * 1024 * 1024
+        assert result.files[0].file_path == "assets/large_audio.mp3"
+        assert result.files[0].total_savings == 8 * 1024 * 1024 // 2  # 50% optimization
+        assert result.files[1].file_path == "assets/large_wav.wav"
+        assert result.files[1].total_savings == 6 * 1024 * 1024 // 2  # 50% optimization
 
         # Total savings should be 50% of the large files
-        expected_savings = (8 * 1024 * 1024 + 6 * 1024 * 1024) // 2
+        expected_savings = (8 * 1024 * 1024 // 2) + (6 * 1024 * 1024 // 2)
         assert result.total_savings == expected_savings
 
     def test_generate_with_no_large_audio_files(self):
@@ -168,8 +169,8 @@ class TestLargeAudioFileInsight:
 
         assert isinstance(result, LargeAudioFileInsightResult)
         assert len(result.files) == 1
-        assert result.files[0].path == "assets/large_audio.mp3"
-        assert result.files[0].size == 8 * 1024 * 1024
+        assert result.files[0].file_path == "assets/large_audio.mp3"
+        assert result.files[0].total_savings == 8 * 1024 * 1024 // 2  # 50% optimization
 
         # Total savings should be 50% of the large audio file only
         expected_savings = (8 * 1024 * 1024) // 2
@@ -224,13 +225,13 @@ class TestLargeAudioFileInsight:
         assert len(result.files) == 3
 
         # Should be sorted by size (largest first)
-        assert result.files[0].path == "assets/audio.flac"
-        assert result.files[0].size == 9 * 1024 * 1024
-        assert result.files[1].path == "assets/audio.aac"
-        assert result.files[1].size == 7 * 1024 * 1024
-        assert result.files[2].path == "assets/audio.mp3"
-        assert result.files[2].size == 6 * 1024 * 1024
+        assert result.files[0].file_path == "assets/audio.flac"
+        assert result.files[0].total_savings == 9 * 1024 * 1024 // 2  # 50% optimization
+        assert result.files[1].file_path == "assets/audio.aac"
+        assert result.files[1].total_savings == 7 * 1024 * 1024 // 2  # 50% optimization
+        assert result.files[2].file_path == "assets/audio.mp3"
+        assert result.files[2].total_savings == 6 * 1024 * 1024 // 2  # 50% optimization
 
         # Total savings should be 50% of the large files
-        expected_savings = (9 * 1024 * 1024 + 7 * 1024 * 1024 + 6 * 1024 * 1024) // 2
+        expected_savings = (9 * 1024 * 1024 // 2) + (7 * 1024 * 1024 // 2) + (6 * 1024 * 1024 // 2)
         assert result.total_savings == expected_savings

--- a/tests/unit/test_large_audio_file_insight.py
+++ b/tests/unit/test_large_audio_file_insight.py
@@ -19,7 +19,7 @@ class TestLargeAudioFileInsight:
             size=8 * 1024 * 1024,  # 8MB
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         large_audio_2 = FileInfo(
             full_path=Path("assets/large_wav.wav"),
@@ -27,7 +27,7 @@ class TestLargeAudioFileInsight:
             size=6 * 1024 * 1024,  # 6MB
             file_type="wav",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
         small_audio = FileInfo(
             full_path=Path("assets/small_audio.mp3"),
@@ -35,7 +35,7 @@ class TestLargeAudioFileInsight:
             size=3 * 1024 * 1024,  # 3MB
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
 
         file_analysis = FileAnalysis(files=[large_audio_1, large_audio_2, small_audio])
@@ -69,7 +69,7 @@ class TestLargeAudioFileInsight:
             size=3 * 1024 * 1024,  # 3MB
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         small_audio_2 = FileInfo(
             full_path=Path("assets/small_audio2.aac"),
@@ -77,7 +77,7 @@ class TestLargeAudioFileInsight:
             size=4 * 1024 * 1024,  # 4MB
             file_type="aac",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         file_analysis = FileAnalysis(files=[small_audio_1, small_audio_2])
@@ -114,7 +114,7 @@ class TestLargeAudioFileInsight:
             size=5 * 1024 * 1024,  # Exactly 5MB
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         file_analysis = FileAnalysis(files=[threshold_audio])
@@ -137,7 +137,7 @@ class TestLargeAudioFileInsight:
             size=8 * 1024 * 1024,  # 8MB
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         large_image = FileInfo(
             full_path=Path("assets/large_image.png"),
@@ -145,7 +145,7 @@ class TestLargeAudioFileInsight:
             size=15 * 1024 * 1024,  # 15MB
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
         small_audio = FileInfo(
             full_path=Path("assets/small_audio.wav"),
@@ -153,7 +153,7 @@ class TestLargeAudioFileInsight:
             size=3 * 1024 * 1024,  # 3MB
             file_type="wav",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
 
         file_analysis = FileAnalysis(files=[large_audio, large_image, small_audio])
@@ -183,7 +183,7 @@ class TestLargeAudioFileInsight:
             size=6 * 1024 * 1024,  # 6MB
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         aac_file = FileInfo(
             full_path=Path("assets/audio.aac"),
@@ -191,7 +191,7 @@ class TestLargeAudioFileInsight:
             size=7 * 1024 * 1024,  # 7MB
             file_type="aac",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
         flac_file = FileInfo(
             full_path=Path("assets/audio.flac"),
@@ -199,7 +199,7 @@ class TestLargeAudioFileInsight:
             size=9 * 1024 * 1024,  # 9MB
             file_type="flac",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
         ogg_file = FileInfo(
             full_path=Path("assets/audio.ogg"),
@@ -207,7 +207,7 @@ class TestLargeAudioFileInsight:
             size=4 * 1024 * 1024,  # 4MB (below threshold)
             file_type="ogg",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash4",
+            hash="hash4",
         )
 
         file_analysis = FileAnalysis(files=[mp3_file, aac_file, flac_file, ogg_file])

--- a/tests/unit/test_large_audio_file_insight.py
+++ b/tests/unit/test_large_audio_file_insight.py
@@ -20,6 +20,7 @@ class TestLargeAudioFileInsight:
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         large_audio_2 = FileInfo(
             full_path=Path("assets/large_wav.wav"),
@@ -28,6 +29,7 @@ class TestLargeAudioFileInsight:
             file_type="wav",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
         small_audio = FileInfo(
             full_path=Path("assets/small_audio.mp3"),
@@ -36,9 +38,10 @@ class TestLargeAudioFileInsight:
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[large_audio_1, large_audio_2, small_audio])
+        file_analysis = FileAnalysis(files=[large_audio_1, large_audio_2, small_audio], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -70,6 +73,7 @@ class TestLargeAudioFileInsight:
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         small_audio_2 = FileInfo(
             full_path=Path("assets/small_audio2.aac"),
@@ -78,9 +82,10 @@ class TestLargeAudioFileInsight:
             file_type="aac",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[small_audio_1, small_audio_2])
+        file_analysis = FileAnalysis(files=[small_audio_1, small_audio_2], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -94,7 +99,7 @@ class TestLargeAudioFileInsight:
         assert result is None
 
     def test_generate_with_empty_file_list(self):
-        file_analysis = FileAnalysis(files=[])
+        file_analysis = FileAnalysis(files=[], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -115,9 +120,10 @@ class TestLargeAudioFileInsight:
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[threshold_audio])
+        file_analysis = FileAnalysis(files=[threshold_audio], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -138,6 +144,7 @@ class TestLargeAudioFileInsight:
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         large_image = FileInfo(
             full_path=Path("assets/large_image.png"),
@@ -146,6 +153,7 @@ class TestLargeAudioFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
         small_audio = FileInfo(
             full_path=Path("assets/small_audio.wav"),
@@ -154,9 +162,10 @@ class TestLargeAudioFileInsight:
             file_type="wav",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[large_audio, large_image, small_audio])
+        file_analysis = FileAnalysis(files=[large_audio, large_image, small_audio], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -184,6 +193,7 @@ class TestLargeAudioFileInsight:
             file_type="mp3",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         aac_file = FileInfo(
             full_path=Path("assets/audio.aac"),
@@ -192,6 +202,7 @@ class TestLargeAudioFileInsight:
             file_type="aac",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
         flac_file = FileInfo(
             full_path=Path("assets/audio.flac"),
@@ -200,6 +211,7 @@ class TestLargeAudioFileInsight:
             file_type="flac",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
         ogg_file = FileInfo(
             full_path=Path("assets/audio.ogg"),
@@ -208,9 +220,10 @@ class TestLargeAudioFileInsight:
             file_type="ogg",
             treemap_type=TreemapType.ASSETS,
             hash="hash4",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[mp3_file, aac_file, flac_file, ogg_file])
+        file_analysis = FileAnalysis(files=[mp3_file, aac_file, flac_file, ogg_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),

--- a/tests/unit/test_large_audio_file_insight.py
+++ b/tests/unit/test_large_audio_file_insight.py
@@ -64,7 +64,7 @@ class TestLargeAudioFileInsight:
 
     def test_generate_with_no_large_audio_files(self):
         small_audio_1 = FileInfo(
-            full_path="assets/small_audio1.mp3",
+            full_path=Path("assets/small_audio1.mp3"),
             path="assets/small_audio1.mp3",
             size=3 * 1024 * 1024,  # 3MB
             file_type="mp3",
@@ -72,7 +72,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash1",
         )
         small_audio_2 = FileInfo(
-            full_path="assets/small_audio2.aac",
+            full_path=Path("assets/small_audio2.aac"),
             path="assets/small_audio2.aac",
             size=4 * 1024 * 1024,  # 4MB
             file_type="aac",
@@ -109,7 +109,7 @@ class TestLargeAudioFileInsight:
 
     def test_generate_with_exactly_threshold_size(self):
         threshold_audio = FileInfo(
-            full_path="assets/threshold_audio.mp3",
+            full_path=Path("assets/threshold_audio.mp3"),
             path="assets/threshold_audio.mp3",
             size=5 * 1024 * 1024,  # Exactly 5MB
             file_type="mp3",
@@ -132,7 +132,7 @@ class TestLargeAudioFileInsight:
 
     def test_generate_with_mixed_file_types(self):
         large_audio = FileInfo(
-            full_path="assets/large_audio.mp3",
+            full_path=Path("assets/large_audio.mp3"),
             path="assets/large_audio.mp3",
             size=8 * 1024 * 1024,  # 8MB
             file_type="mp3",
@@ -140,7 +140,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash1",
         )
         large_image = FileInfo(
-            full_path="assets/large_image.png",
+            full_path=Path("assets/large_image.png"),
             path="assets/large_image.png",
             size=15 * 1024 * 1024,  # 15MB
             file_type="png",
@@ -148,7 +148,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash2",
         )
         small_audio = FileInfo(
-            full_path="assets/small_audio.wav",
+            full_path=Path("assets/small_audio.wav"),
             path="assets/small_audio.wav",
             size=3 * 1024 * 1024,  # 3MB
             file_type="wav",
@@ -178,7 +178,7 @@ class TestLargeAudioFileInsight:
 
     def test_generate_with_various_audio_formats(self):
         mp3_file = FileInfo(
-            full_path="assets/audio.mp3",
+            full_path=Path("assets/audio.mp3"),
             path="assets/audio.mp3",
             size=6 * 1024 * 1024,  # 6MB
             file_type="mp3",
@@ -186,7 +186,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash1",
         )
         aac_file = FileInfo(
-            full_path="assets/audio.aac",
+            full_path=Path("assets/audio.aac"),
             path="assets/audio.aac",
             size=7 * 1024 * 1024,  # 7MB
             file_type="aac",
@@ -194,7 +194,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash2",
         )
         flac_file = FileInfo(
-            full_path="assets/audio.flac",
+            full_path=Path("assets/audio.flac"),
             path="assets/audio.flac",
             size=9 * 1024 * 1024,  # 9MB
             file_type="flac",
@@ -202,7 +202,7 @@ class TestLargeAudioFileInsight:
             hash_md5="hash3",
         )
         ogg_file = FileInfo(
-            full_path="assets/audio.ogg",
+            full_path=Path("assets/audio.ogg"),
             path="assets/audio.ogg",
             size=4 * 1024 * 1024,  # 4MB (below threshold)
             file_type="ogg",

--- a/tests/unit/test_large_file_insight.py
+++ b/tests/unit/test_large_file_insight.py
@@ -20,6 +20,7 @@ class TestLargeImageFileInsight:
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         large_file_2 = FileInfo(
             full_path=Path("assets/large_image.png"),
@@ -28,6 +29,7 @@ class TestLargeImageFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
         small_file = FileInfo(
             full_path=Path("assets/small_image.png"),
@@ -36,9 +38,10 @@ class TestLargeImageFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[large_file_1, large_file_2, small_file])
+        file_analysis = FileAnalysis(files=[large_file_1, large_file_2, small_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -64,6 +67,7 @@ class TestLargeImageFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         small_file_2 = FileInfo(
             full_path=Path("assets/small_image2.png"),
@@ -72,9 +76,10 @@ class TestLargeImageFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[small_file_1, small_file_2])
+        file_analysis = FileAnalysis(files=[small_file_1, small_file_2], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -88,7 +93,7 @@ class TestLargeImageFileInsight:
         assert result is None
 
     def test_generate_with_empty_file_list(self):
-        file_analysis = FileAnalysis(files=[])
+        file_analysis = FileAnalysis(files=[], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -109,9 +114,10 @@ class TestLargeImageFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[threshold_file])
+        file_analysis = FileAnalysis(files=[threshold_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),

--- a/tests/unit/test_large_file_insight.py
+++ b/tests/unit/test_large_file_insight.py
@@ -19,7 +19,7 @@ class TestLargeImageFileInsight:
             size=15 * 1024 * 1024,  # 15MB
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         large_file_2 = FileInfo(
             full_path=Path("assets/large_image.png"),
@@ -27,7 +27,7 @@ class TestLargeImageFileInsight:
             size=12 * 1024 * 1024,  # 12MB
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
         small_file = FileInfo(
             full_path=Path("assets/small_image.png"),
@@ -35,7 +35,7 @@ class TestLargeImageFileInsight:
             size=5 * 1024 * 1024,  # 5MB
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
 
         file_analysis = FileAnalysis(files=[large_file_1, large_file_2, small_file])
@@ -63,7 +63,7 @@ class TestLargeImageFileInsight:
             size=5 * 1024 * 1024,  # 5MB
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         small_file_2 = FileInfo(
             full_path=Path("assets/small_image2.png"),
@@ -71,7 +71,7 @@ class TestLargeImageFileInsight:
             size=8 * 1024 * 1024,  # 8MB
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         file_analysis = FileAnalysis(files=[small_file_1, small_file_2])
@@ -108,7 +108,7 @@ class TestLargeImageFileInsight:
             size=10 * 1024 * 1024,  # Exactly 10MB
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         file_analysis = FileAnalysis(files=[threshold_file])

--- a/tests/unit/test_large_file_insight.py
+++ b/tests/unit/test_large_file_insight.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import Mock
 
 from launchpad.size.insights.common.large_images import LargeImageFileInsight
@@ -13,7 +14,7 @@ class TestLargeImageFileInsight:
 
     def test_generate_with_large_files(self):
         large_file_1 = FileInfo(
-            full_path="assets/large_video.mp4",
+            full_path=Path("assets/large_video.mp4"),
             path="assets/large_video.mp4",
             size=15 * 1024 * 1024,  # 15MB
             file_type="mp4",
@@ -21,7 +22,7 @@ class TestLargeImageFileInsight:
             hash_md5="hash1",
         )
         large_file_2 = FileInfo(
-            full_path="assets/large_image.png",
+            full_path=Path("assets/large_image.png"),
             path="assets/large_image.png",
             size=12 * 1024 * 1024,  # 12MB
             file_type="png",
@@ -29,7 +30,7 @@ class TestLargeImageFileInsight:
             hash_md5="hash2",
         )
         small_file = FileInfo(
-            full_path="assets/small_image.png",
+            full_path=Path("assets/small_image.png"),
             path="assets/small_image.png",
             size=5 * 1024 * 1024,  # 5MB
             file_type="png",
@@ -51,11 +52,13 @@ class TestLargeImageFileInsight:
         assert isinstance(result, LargeImageFileInsightResult)
         assert len(result.files) == 1
 
-        assert result.files[0].path == "assets/large_image.png"
+        assert result.files[0].file_path == "assets/large_image.png"
+        # Verify savings calculation (50% of file size)
+        assert result.files[0].total_savings == 12 * 1024 * 1024 // 2  # 6MB savings
 
     def test_generate_with_no_large_files(self):
         small_file_1 = FileInfo(
-            full_path="assets/small_image1.png",
+            full_path=Path("assets/small_image1.png"),
             path="assets/small_image1.png",
             size=5 * 1024 * 1024,  # 5MB
             file_type="png",
@@ -63,7 +66,7 @@ class TestLargeImageFileInsight:
             hash_md5="hash1",
         )
         small_file_2 = FileInfo(
-            full_path="assets/small_image2.png",
+            full_path=Path("assets/small_image2.png"),
             path="assets/small_image2.png",
             size=8 * 1024 * 1024,  # 8MB
             file_type="png",
@@ -100,7 +103,7 @@ class TestLargeImageFileInsight:
 
     def test_generate_with_exactly_threshold_size(self):
         threshold_file = FileInfo(
-            full_path="assets/threshold_image.png",
+            full_path=Path("assets/threshold_image.png"),
             path="assets/threshold_image.png",
             size=10 * 1024 * 1024,  # Exactly 10MB
             file_type="png",

--- a/tests/unit/test_large_video_file_insight.py
+++ b/tests/unit/test_large_video_file_insight.py
@@ -20,6 +20,7 @@ class TestLargeVideoFileInsight:
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         large_video_2 = FileInfo(
             full_path=Path("assets/large_video.mov"),
@@ -28,6 +29,7 @@ class TestLargeVideoFileInsight:
             file_type="mov",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
         small_video = FileInfo(
             full_path=Path("assets/small_video.mp4"),
@@ -36,6 +38,7 @@ class TestLargeVideoFileInsight:
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
         image_file = FileInfo(
             full_path=Path("assets/large_image.png"),
@@ -44,9 +47,10 @@ class TestLargeVideoFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash4",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[large_video_1, large_video_2, small_video, image_file])
+        file_analysis = FileAnalysis(files=[large_video_1, large_video_2, small_video, image_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -78,6 +82,7 @@ class TestLargeVideoFileInsight:
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         small_video_2 = FileInfo(
             full_path=Path("assets/small_video2.mov"),
@@ -86,9 +91,10 @@ class TestLargeVideoFileInsight:
             file_type="mov",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[small_video_1, small_video_2])
+        file_analysis = FileAnalysis(files=[small_video_1, small_video_2], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -102,7 +108,7 @@ class TestLargeVideoFileInsight:
         assert result is None
 
     def test_generate_with_empty_file_list(self):
-        file_analysis = FileAnalysis(files=[])
+        file_analysis = FileAnalysis(files=[], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -123,9 +129,10 @@ class TestLargeVideoFileInsight:
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[threshold_file])
+        file_analysis = FileAnalysis(files=[threshold_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -146,6 +153,7 @@ class TestLargeVideoFileInsight:
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         mov_file = FileInfo(
             full_path=Path("assets/video.mov"),
@@ -154,6 +162,7 @@ class TestLargeVideoFileInsight:
             file_type="mov",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
         webm_file = FileInfo(
             full_path=Path("assets/video.webm"),
@@ -162,6 +171,7 @@ class TestLargeVideoFileInsight:
             file_type="webm",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
         mkv_file = FileInfo(
             full_path=Path("assets/video.mkv"),
@@ -170,9 +180,10 @@ class TestLargeVideoFileInsight:
             file_type="mkv",
             treemap_type=TreemapType.ASSETS,
             hash="hash4",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[mp4_file, mov_file, webm_file, mkv_file])
+        file_analysis = FileAnalysis(files=[mp4_file, mov_file, webm_file, mkv_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -203,6 +214,7 @@ class TestLargeVideoFileInsight:
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         image_file = FileInfo(
             full_path=Path("assets/image.png"),
@@ -211,6 +223,7 @@ class TestLargeVideoFileInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash2",
+            is_dir=False,
         )
         text_file = FileInfo(
             full_path=Path("assets/data.txt"),
@@ -219,9 +232,10 @@ class TestLargeVideoFileInsight:
             file_type="txt",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[video_file, image_file, text_file])
+        file_analysis = FileAnalysis(files=[video_file, image_file, text_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),

--- a/tests/unit/test_large_video_file_insight.py
+++ b/tests/unit/test_large_video_file_insight.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import Mock
 
 from launchpad.size.insights.common.large_videos import LargeVideoFileInsight
@@ -13,7 +14,7 @@ class TestLargeVideoFileInsight:
 
     def test_generate_with_large_files(self):
         large_video_1 = FileInfo(
-            full_path="assets/large_video.mp4",
+            full_path=Path("assets/large_video.mp4"),
             path="assets/large_video.mp4",
             size=25 * 1024 * 1024,  # 25MB
             file_type="mp4",
@@ -21,7 +22,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash1",
         )
         large_video_2 = FileInfo(
-            full_path="assets/large_video.mov",
+            full_path=Path("assets/large_video.mov"),
             path="assets/large_video.mov",
             size=18 * 1024 * 1024,  # 18MB
             file_type="mov",
@@ -29,7 +30,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash2",
         )
         small_video = FileInfo(
-            full_path="assets/small_video.mp4",
+            full_path=Path("assets/small_video.mp4"),
             path="assets/small_video.mp4",
             size=5 * 1024 * 1024,  # 5MB
             file_type="mp4",
@@ -37,7 +38,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash3",
         )
         image_file = FileInfo(
-            full_path="assets/large_image.png",
+            full_path=Path("assets/large_image.png"),
             path="assets/large_image.png",
             size=15 * 1024 * 1024,  # 15MB (should be ignored)
             file_type="png",
@@ -60,18 +61,18 @@ class TestLargeVideoFileInsight:
         assert len(result.files) == 2
 
         # Should be sorted by largest first
-        assert result.files[0].path == "assets/large_video.mp4"
-        assert result.files[0].size == 25 * 1024 * 1024
-        assert result.files[1].path == "assets/large_video.mov"
-        assert result.files[1].size == 18 * 1024 * 1024
+        assert result.files[0].file_path == "assets/large_video.mp4"
+        assert result.files[0].total_savings == 25 * 1024 * 1024 // 2  # 50% optimization
+        assert result.files[1].file_path == "assets/large_video.mov"
+        assert result.files[1].total_savings == 18 * 1024 * 1024 // 2  # 50% optimization
 
-        # Check total savings calculation (50% of each file)
+        # Check total savings calculation (50% of file sizes)
         expected_savings = (25 * 1024 * 1024 // 2) + (18 * 1024 * 1024 // 2)
         assert result.total_savings == expected_savings
 
     def test_generate_with_no_large_files(self):
         small_video_1 = FileInfo(
-            full_path="assets/small_video1.mp4",
+            full_path=Path("assets/small_video1.mp4"),
             path="assets/small_video1.mp4",
             size=5 * 1024 * 1024,  # 5MB
             file_type="mp4",
@@ -79,7 +80,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash1",
         )
         small_video_2 = FileInfo(
-            full_path="assets/small_video2.mov",
+            full_path=Path("assets/small_video2.mov"),
             path="assets/small_video2.mov",
             size=8 * 1024 * 1024,  # 8MB
             file_type="mov",
@@ -116,7 +117,7 @@ class TestLargeVideoFileInsight:
 
     def test_generate_with_exactly_threshold_size(self):
         threshold_file = FileInfo(
-            full_path="assets/threshold_video.mp4",
+            full_path=Path("assets/threshold_video.mp4"),
             path="assets/threshold_video.mp4",
             size=10 * 1024 * 1024,  # Exactly 10MB
             file_type="mp4",
@@ -139,7 +140,7 @@ class TestLargeVideoFileInsight:
 
     def test_generate_with_different_video_formats(self):
         mp4_file = FileInfo(
-            full_path="assets/video.mp4",
+            full_path=Path("assets/video.mp4"),
             path="assets/video.mp4",
             size=15 * 1024 * 1024,  # 15MB
             file_type="mp4",
@@ -147,7 +148,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash1",
         )
         mov_file = FileInfo(
-            full_path="assets/video.mov",
+            full_path=Path("assets/video.mov"),
             path="assets/video.mov",
             size=12 * 1024 * 1024,  # 12MB
             file_type="mov",
@@ -155,7 +156,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash2",
         )
         webm_file = FileInfo(
-            full_path="assets/video.webm",
+            full_path=Path("assets/video.webm"),
             path="assets/video.webm",
             size=20 * 1024 * 1024,  # 20MB
             file_type="webm",
@@ -163,7 +164,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash3",
         )
         mkv_file = FileInfo(
-            full_path="assets/video.mkv",
+            full_path=Path("assets/video.mkv"),
             path="assets/video.mkv",
             size=8 * 1024 * 1024,  # 8MB (below threshold)
             file_type="mkv",
@@ -186,17 +187,17 @@ class TestLargeVideoFileInsight:
         assert len(result.files) == 3
 
         # Should be sorted by largest first
-        assert result.files[0].path == "assets/video.webm"
-        assert result.files[1].path == "assets/video.mp4"
-        assert result.files[2].path == "assets/video.mov"
+        assert result.files[0].file_path == "assets/video.webm"
+        assert result.files[1].file_path == "assets/video.mp4"
+        assert result.files[2].file_path == "assets/video.mov"
 
-        # Check total savings calculation
+        # Check total savings calculation (50% of file sizes)
         expected_savings = (20 * 1024 * 1024 // 2) + (15 * 1024 * 1024 // 2) + (12 * 1024 * 1024 // 2)
         assert result.total_savings == expected_savings
 
     def test_generate_ignores_non_video_files(self):
         video_file = FileInfo(
-            full_path="assets/video.mp4",
+            full_path=Path("assets/video.mp4"),
             path="assets/video.mp4",
             size=15 * 1024 * 1024,  # 15MB
             file_type="mp4",
@@ -204,7 +205,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash1",
         )
         image_file = FileInfo(
-            full_path="assets/image.png",
+            full_path=Path("assets/image.png"),
             path="assets/image.png",
             size=20 * 1024 * 1024,  # 20MB (should be ignored)
             file_type="png",
@@ -212,7 +213,7 @@ class TestLargeVideoFileInsight:
             hash_md5="hash2",
         )
         text_file = FileInfo(
-            full_path="assets/data.txt",
+            full_path=Path("assets/data.txt"),
             path="assets/data.txt",
             size=25 * 1024 * 1024,  # 25MB (should be ignored)
             file_type="txt",
@@ -233,5 +234,5 @@ class TestLargeVideoFileInsight:
 
         assert isinstance(result, LargeVideoFileInsightResult)
         assert len(result.files) == 1
-        assert result.files[0].path == "assets/video.mp4"
-        assert result.total_savings == 15 * 1024 * 1024 // 2
+        assert result.files[0].file_path == "assets/video.mp4"
+        assert result.total_savings == 15 * 1024 * 1024 // 2  # 50% optimization

--- a/tests/unit/test_large_video_file_insight.py
+++ b/tests/unit/test_large_video_file_insight.py
@@ -19,7 +19,7 @@ class TestLargeVideoFileInsight:
             size=25 * 1024 * 1024,  # 25MB
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         large_video_2 = FileInfo(
             full_path=Path("assets/large_video.mov"),
@@ -27,7 +27,7 @@ class TestLargeVideoFileInsight:
             size=18 * 1024 * 1024,  # 18MB
             file_type="mov",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
         small_video = FileInfo(
             full_path=Path("assets/small_video.mp4"),
@@ -35,7 +35,7 @@ class TestLargeVideoFileInsight:
             size=5 * 1024 * 1024,  # 5MB
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
         image_file = FileInfo(
             full_path=Path("assets/large_image.png"),
@@ -43,7 +43,7 @@ class TestLargeVideoFileInsight:
             size=15 * 1024 * 1024,  # 15MB (should be ignored)
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash4",
+            hash="hash4",
         )
 
         file_analysis = FileAnalysis(files=[large_video_1, large_video_2, small_video, image_file])
@@ -77,7 +77,7 @@ class TestLargeVideoFileInsight:
             size=5 * 1024 * 1024,  # 5MB
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         small_video_2 = FileInfo(
             full_path=Path("assets/small_video2.mov"),
@@ -85,7 +85,7 @@ class TestLargeVideoFileInsight:
             size=8 * 1024 * 1024,  # 8MB
             file_type="mov",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         file_analysis = FileAnalysis(files=[small_video_1, small_video_2])
@@ -122,7 +122,7 @@ class TestLargeVideoFileInsight:
             size=10 * 1024 * 1024,  # Exactly 10MB
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         file_analysis = FileAnalysis(files=[threshold_file])
@@ -145,7 +145,7 @@ class TestLargeVideoFileInsight:
             size=15 * 1024 * 1024,  # 15MB
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         mov_file = FileInfo(
             full_path=Path("assets/video.mov"),
@@ -153,7 +153,7 @@ class TestLargeVideoFileInsight:
             size=12 * 1024 * 1024,  # 12MB
             file_type="mov",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
         webm_file = FileInfo(
             full_path=Path("assets/video.webm"),
@@ -161,7 +161,7 @@ class TestLargeVideoFileInsight:
             size=20 * 1024 * 1024,  # 20MB
             file_type="webm",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
         mkv_file = FileInfo(
             full_path=Path("assets/video.mkv"),
@@ -169,7 +169,7 @@ class TestLargeVideoFileInsight:
             size=8 * 1024 * 1024,  # 8MB (below threshold)
             file_type="mkv",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash4",
+            hash="hash4",
         )
 
         file_analysis = FileAnalysis(files=[mp4_file, mov_file, webm_file, mkv_file])
@@ -202,7 +202,7 @@ class TestLargeVideoFileInsight:
             size=15 * 1024 * 1024,  # 15MB
             file_type="mp4",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         image_file = FileInfo(
             full_path=Path("assets/image.png"),
@@ -210,7 +210,7 @@ class TestLargeVideoFileInsight:
             size=20 * 1024 * 1024,  # 20MB (should be ignored)
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash2",
+            hash="hash2",
         )
         text_file = FileInfo(
             full_path=Path("assets/data.txt"),
@@ -218,7 +218,7 @@ class TestLargeVideoFileInsight:
             size=25 * 1024 * 1024,  # 25MB (should be ignored)
             file_type="txt",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
 
         file_analysis = FileAnalysis(files=[video_file, image_file, text_file])

--- a/tests/unit/test_localized_strings_insight.py
+++ b/tests/unit/test_localized_strings_insight.py
@@ -22,6 +22,7 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
+            is_dir=False,
         )
         localized_file_2 = FileInfo(
             full_path=Path("es.lproj/Localizable.strings"),
@@ -30,6 +31,7 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
+            is_dir=False,
         )
         # Non-localized file that should be ignored
         other_file = FileInfo(
@@ -39,9 +41,10 @@ class TestLocalizedStringsInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash3",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2, other_file])
+        file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2, other_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -71,6 +74,7 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
+            is_dir=False,
         )
         localized_file_2 = FileInfo(
             full_path=Path("es.lproj/Localizable.strings"),
@@ -79,9 +83,10 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2])
+        file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -103,9 +108,10 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[localized_file])
+        file_analysis = FileAnalysis(files=[localized_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -127,6 +133,7 @@ class TestLocalizedStringsInsight:
             file_type="png",
             treemap_type=TreemapType.ASSETS,
             hash="hash1",
+            is_dir=False,
         )
         other_file_2 = FileInfo(
             full_path=Path("Info.plist"),
@@ -135,9 +142,10 @@ class TestLocalizedStringsInsight:
             file_type="plist",
             treemap_type=TreemapType.PLISTS,
             hash="hash2",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[other_file_1, other_file_2])
+        file_analysis = FileAnalysis(files=[other_file_1, other_file_2], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -152,7 +160,7 @@ class TestLocalizedStringsInsight:
 
     def test_generate_with_empty_file_list(self):
         """Test that no insight is generated with empty file list."""
-        file_analysis = FileAnalysis(files=[])
+        file_analysis = FileAnalysis(files=[], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -174,6 +182,7 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
+            is_dir=False,
         )
         other_strings_file = FileInfo(
             full_path=Path("en.lproj/Other.strings"),
@@ -182,9 +191,10 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[localized_file, other_strings_file])
+        file_analysis = FileAnalysis(files=[localized_file, other_strings_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -210,6 +220,7 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
+            is_dir=False,
         )
         invalid_localized_file = FileInfo(
             full_path=Path("Localizable.strings"),  # Not in .lproj directory
@@ -218,9 +229,10 @@ class TestLocalizedStringsInsight:
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
+            is_dir=False,
         )
 
-        file_analysis = FileAnalysis(files=[valid_localized_file, invalid_localized_file])
+        file_analysis = FileAnalysis(files=[valid_localized_file, invalid_localized_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),

--- a/tests/unit/test_localized_strings_insight.py
+++ b/tests/unit/test_localized_strings_insight.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import Mock
 
 from launchpad.size.insights.apple.localized_strings import LocalizedStringsInsight
@@ -15,7 +16,7 @@ class TestLocalizedStringsInsight:
         """Test that insight is generated when total size exceeds 100KB threshold."""
         # Create localized strings files that exceed 100KB total
         localized_file_1 = FileInfo(
-            full_path="en.lproj/Localizable.strings",
+            full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
             size=60 * 1024,  # 60KB
             file_type="strings",
@@ -23,7 +24,7 @@ class TestLocalizedStringsInsight:
             hash_md5="hash1",
         )
         localized_file_2 = FileInfo(
-            full_path="es.lproj/Localizable.strings",
+            full_path=Path("es.lproj/Localizable.strings"),
             path="es.lproj/Localizable.strings",
             size=50 * 1024,  # 50KB
             file_type="strings",
@@ -32,7 +33,7 @@ class TestLocalizedStringsInsight:
         )
         # Non-localized file that should be ignored
         other_file = FileInfo(
-            full_path="assets/image.png",
+            full_path=Path("assets/image.png"),
             path="assets/image.png",
             size=1024,
             file_type="png",
@@ -54,14 +55,17 @@ class TestLocalizedStringsInsight:
         assert isinstance(result, LocalizedStringInsightResult)
         assert len(result.files) == 2
         assert result.total_savings == 110 * 1024  # 110KB total
-        assert result.files[0].path == "en.lproj/Localizable.strings"
-        assert result.files[1].path == "es.lproj/Localizable.strings"
+        assert result.files[0].file_path == "en.lproj/Localizable.strings"
+        assert result.files[1].file_path == "es.lproj/Localizable.strings"
+        # Verify savings match file sizes
+        assert result.files[0].total_savings == 60 * 1024
+        assert result.files[1].total_savings == 50 * 1024
 
     def test_generate_with_small_localized_strings(self):
         """Test that no insight is generated when total size is below 100KB threshold."""
         # Create localized strings files that don't exceed 100KB total
         localized_file_1 = FileInfo(
-            full_path="en.lproj/Localizable.strings",
+            full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
             size=40 * 1024,  # 40KB
             file_type="strings",
@@ -69,7 +73,7 @@ class TestLocalizedStringsInsight:
             hash_md5="hash1",
         )
         localized_file_2 = FileInfo(
-            full_path="es.lproj/Localizable.strings",
+            full_path=Path("es.lproj/Localizable.strings"),
             path="es.lproj/Localizable.strings",
             size=30 * 1024,  # 30KB
             file_type="strings",
@@ -93,7 +97,7 @@ class TestLocalizedStringsInsight:
     def test_generate_with_exactly_threshold_size(self):
         """Test that insight is generated when total size exactly equals 100KB threshold."""
         localized_file = FileInfo(
-            full_path="en.lproj/Localizable.strings",
+            full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
             size=100 * 1024,  # Exactly 100KB
             file_type="strings",
@@ -117,7 +121,7 @@ class TestLocalizedStringsInsight:
     def test_generate_with_no_localized_strings(self):
         """Test that no insight is generated when no localized strings files exist."""
         other_file_1 = FileInfo(
-            full_path="assets/image.png",
+            full_path=Path("assets/image.png"),
             path="assets/image.png",
             size=1024,
             file_type="png",
@@ -125,7 +129,7 @@ class TestLocalizedStringsInsight:
             hash_md5="hash1",
         )
         other_file_2 = FileInfo(
-            full_path="Info.plist",
+            full_path=Path("Info.plist"),
             path="Info.plist",
             size=2048,
             file_type="plist",
@@ -164,7 +168,7 @@ class TestLocalizedStringsInsight:
     def test_generate_ignores_non_localizable_strings(self):
         """Test that only Localizable.strings files are considered, not other .strings files."""
         localized_file = FileInfo(
-            full_path="en.lproj/Localizable.strings",
+            full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
             size=150 * 1024,  # 150KB - should trigger insight
             file_type="strings",
@@ -172,7 +176,7 @@ class TestLocalizedStringsInsight:
             hash_md5="hash1",
         )
         other_strings_file = FileInfo(
-            full_path="en.lproj/Other.strings",
+            full_path=Path("en.lproj/Other.strings"),
             path="en.lproj/Other.strings",
             size=50 * 1024,  # 50KB - should be ignored
             file_type="strings",
@@ -193,13 +197,14 @@ class TestLocalizedStringsInsight:
 
         assert isinstance(result, LocalizedStringInsightResult)
         assert len(result.files) == 1
-        assert result.files[0].path == "en.lproj/Localizable.strings"
+        assert result.files[0].file_path == "en.lproj/Localizable.strings"
         assert result.total_savings == 150 * 1024  # Only the Localizable.strings file
+        assert result.files[0].total_savings == 150 * 1024
 
     def test_generate_ignores_non_lproj_localizable_strings(self):
         """Test that Localizable.strings files outside .lproj directories are ignored."""
         valid_localized_file = FileInfo(
-            full_path="en.lproj/Localizable.strings",
+            full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
             size=150 * 1024,  # 150KB - should be included
             file_type="strings",
@@ -207,7 +212,7 @@ class TestLocalizedStringsInsight:
             hash_md5="hash1",
         )
         invalid_localized_file = FileInfo(
-            full_path="Localizable.strings",  # Not in .lproj directory
+            full_path=Path("Localizable.strings"),  # Not in .lproj directory
             path="Localizable.strings",
             size=50 * 1024,  # 50KB - should be ignored
             file_type="strings",
@@ -228,5 +233,6 @@ class TestLocalizedStringsInsight:
 
         assert isinstance(result, LocalizedStringInsightResult)
         assert len(result.files) == 1
-        assert result.files[0].path == "en.lproj/Localizable.strings"
+        assert result.files[0].file_path == "en.lproj/Localizable.strings"
         assert result.total_savings == 150 * 1024  # Only the valid file
+        assert result.files[0].total_savings == 150 * 1024

--- a/tests/unit/test_localized_strings_insight.py
+++ b/tests/unit/test_localized_strings_insight.py
@@ -21,7 +21,7 @@ class TestLocalizedStringsInsight:
             size=60 * 1024,  # 60KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash1",
+            hash="hash1",
         )
         localized_file_2 = FileInfo(
             full_path=Path("es.lproj/Localizable.strings"),
@@ -29,7 +29,7 @@ class TestLocalizedStringsInsight:
             size=50 * 1024,  # 50KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash2",
+            hash="hash2",
         )
         # Non-localized file that should be ignored
         other_file = FileInfo(
@@ -38,7 +38,7 @@ class TestLocalizedStringsInsight:
             size=1024,
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash3",
+            hash="hash3",
         )
 
         file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2, other_file])
@@ -70,7 +70,7 @@ class TestLocalizedStringsInsight:
             size=40 * 1024,  # 40KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash1",
+            hash="hash1",
         )
         localized_file_2 = FileInfo(
             full_path=Path("es.lproj/Localizable.strings"),
@@ -78,7 +78,7 @@ class TestLocalizedStringsInsight:
             size=30 * 1024,  # 30KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         file_analysis = FileAnalysis(files=[localized_file_1, localized_file_2])
@@ -102,7 +102,7 @@ class TestLocalizedStringsInsight:
             size=100 * 1024,  # Exactly 100KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash1",
+            hash="hash1",
         )
 
         file_analysis = FileAnalysis(files=[localized_file])
@@ -126,7 +126,7 @@ class TestLocalizedStringsInsight:
             size=1024,
             file_type="png",
             treemap_type=TreemapType.ASSETS,
-            hash_md5="hash1",
+            hash="hash1",
         )
         other_file_2 = FileInfo(
             full_path=Path("Info.plist"),
@@ -134,7 +134,7 @@ class TestLocalizedStringsInsight:
             size=2048,
             file_type="plist",
             treemap_type=TreemapType.PLISTS,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         file_analysis = FileAnalysis(files=[other_file_1, other_file_2])
@@ -173,7 +173,7 @@ class TestLocalizedStringsInsight:
             size=150 * 1024,  # 150KB - should trigger insight
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash1",
+            hash="hash1",
         )
         other_strings_file = FileInfo(
             full_path=Path("en.lproj/Other.strings"),
@@ -181,7 +181,7 @@ class TestLocalizedStringsInsight:
             size=50 * 1024,  # 50KB - should be ignored
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         file_analysis = FileAnalysis(files=[localized_file, other_strings_file])
@@ -209,7 +209,7 @@ class TestLocalizedStringsInsight:
             size=150 * 1024,  # 150KB - should be included
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash1",
+            hash="hash1",
         )
         invalid_localized_file = FileInfo(
             full_path=Path("Localizable.strings"),  # Not in .lproj directory
@@ -217,7 +217,7 @@ class TestLocalizedStringsInsight:
             size=50 * 1024,  # 50KB - should be ignored
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
-            hash_md5="hash2",
+            hash="hash2",
         )
 
         file_analysis = FileAnalysis(files=[valid_localized_file, invalid_localized_file])

--- a/tests/unit/test_loose_images_insight.py
+++ b/tests/unit/test_loose_images_insight.py
@@ -21,7 +21,7 @@ class TestLooseImagesInsight:
                 size=1024000,
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_car",
+                hash="hash_car",
             ),
             # Raw images that should be flagged
             FileInfo(
@@ -30,7 +30,7 @@ class TestLooseImagesInsight:
                 size=10240,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_home",
+                hash="hash_home",
             ),
             FileInfo(
                 full_path=Path("icons/home@2x.png"),
@@ -38,7 +38,7 @@ class TestLooseImagesInsight:
                 size=20480,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_home_2x",
+                hash="hash_home_2x",
             ),
             FileInfo(
                 full_path=Path("buttons/submit.jpg"),
@@ -46,7 +46,7 @@ class TestLooseImagesInsight:
                 size=15360,
                 file_type="jpg",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_submit",
+                hash="hash_submit",
             ),
             # Non-image file (should be ignored)
             FileInfo(
@@ -55,7 +55,7 @@ class TestLooseImagesInsight:
                 size=2048,
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
-                hash_md5="hash_plist",
+                hash="hash_plist",
             ),
         ]
 
@@ -96,7 +96,7 @@ class TestLooseImagesInsight:
                 size=5120,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_app_icon",
+                hash="hash_app_icon",
             ),
             FileInfo(
                 full_path=Path("iMessage App Icon-60@2x.png"),
@@ -104,7 +104,7 @@ class TestLooseImagesInsight:
                 size=7168,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_imessage_icon",
+                hash="hash_imessage_icon",
             ),
             FileInfo(
                 full_path=Path("regular_icon.png"),
@@ -112,7 +112,7 @@ class TestLooseImagesInsight:
                 size=3072,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_regular",
+                hash="hash_regular",
             ),
             FileInfo(
                 full_path=Path("regular_icon@2x.png"),
@@ -120,7 +120,7 @@ class TestLooseImagesInsight:
                 size=6144,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_regular_2x",
+                hash="hash_regular_2x",
             ),
         ]
 
@@ -150,7 +150,7 @@ class TestLooseImagesInsight:
                 size=5120,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_sticker",
+                hash="hash_sticker",
             ),
             FileInfo(
                 full_path=Path("regular/image.png"),
@@ -158,7 +158,7 @@ class TestLooseImagesInsight:
                 size=3072,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_regular",
+                hash="hash_regular",
             ),
             FileInfo(
                 full_path=Path("regular/image@2x.png"),
@@ -166,7 +166,7 @@ class TestLooseImagesInsight:
                 size=6144,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_regular_2x",
+                hash="hash_regular_2x",
             ),
         ]
 
@@ -197,7 +197,7 @@ class TestLooseImagesInsight:
                 size=1024000,
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_car",
+                hash="hash_car",
             ),
             FileInfo(
                 full_path=Path("Info.plist"),
@@ -205,7 +205,7 @@ class TestLooseImagesInsight:
                 size=2048,
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
-                hash_md5="hash_plist",
+                hash="hash_plist",
             ),
         ]
 
@@ -230,7 +230,7 @@ class TestLooseImagesInsight:
                 size=5000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_1x",
+                hash="hash_1x",
             ),
             FileInfo(
                 full_path=Path("icon@2x.png"),
@@ -238,7 +238,7 @@ class TestLooseImagesInsight:
                 size=10000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_2x",
+                hash="hash_2x",
             ),
             FileInfo(
                 full_path=Path("icon@3x.png"),
@@ -246,7 +246,7 @@ class TestLooseImagesInsight:
                 size=15000,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_3x",
+                hash="hash_3x",
             ),
             FileInfo(
                 full_path=Path("different.jpg"),
@@ -254,7 +254,7 @@ class TestLooseImagesInsight:
                 size=8000,
                 file_type="jpg",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash_diff",
+                hash="hash_diff",
             ),
         ]
 

--- a/tests/unit/test_loose_images_insight.py
+++ b/tests/unit/test_loose_images_insight.py
@@ -22,6 +22,7 @@ class TestLooseImagesInsight:
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_car",
+                is_dir=False,
             ),
             # Raw images that should be flagged
             FileInfo(
@@ -31,6 +32,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_home",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("icons/home@2x.png"),
@@ -39,6 +41,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_home_2x",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("buttons/submit.jpg"),
@@ -47,6 +50,7 @@ class TestLooseImagesInsight:
                 file_type="jpg",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_submit",
+                is_dir=False,
             ),
             # Non-image file (should be ignored)
             FileInfo(
@@ -56,10 +60,11 @@ class TestLooseImagesInsight:
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
                 hash="hash_plist",
+                is_dir=False,
             ),
         ]
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
             file_analysis=file_analysis,
@@ -97,6 +102,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_app_icon",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("iMessage App Icon-60@2x.png"),
@@ -105,6 +111,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_imessage_icon",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("regular_icon.png"),
@@ -113,6 +120,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_regular",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("regular_icon@2x.png"),
@@ -121,10 +129,11 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_regular_2x",
+                is_dir=False,
             ),
         ]
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
             file_analysis=file_analysis,
@@ -151,6 +160,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_sticker",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("regular/image.png"),
@@ -159,6 +169,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_regular",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("regular/image@2x.png"),
@@ -167,10 +178,11 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_regular_2x",
+                is_dir=False,
             ),
         ]
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
             file_analysis=file_analysis,
@@ -198,6 +210,7 @@ class TestLooseImagesInsight:
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_car",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Info.plist"),
@@ -206,10 +219,11 @@ class TestLooseImagesInsight:
                 file_type="plist",
                 treemap_type=TreemapType.PLISTS,
                 hash="hash_plist",
+                is_dir=False,
             ),
         ]
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
             file_analysis=file_analysis,
@@ -231,6 +245,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_1x",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("icon@2x.png"),
@@ -239,6 +254,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_2x",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("icon@3x.png"),
@@ -247,6 +263,7 @@ class TestLooseImagesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_3x",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("different.jpg"),
@@ -255,10 +272,11 @@ class TestLooseImagesInsight:
                 file_type="jpg",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash_diff",
+                is_dir=False,
             ),
         ]
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
             file_analysis=file_analysis,

--- a/tests/unit/test_main_binary_export_metadata_insight.py
+++ b/tests/unit/test_main_binary_export_metadata_insight.py
@@ -40,7 +40,7 @@ class TestMainBinaryExportMetadataInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[main_binary_analysis],
         )
@@ -77,7 +77,7 @@ class TestMainBinaryExportMetadataInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[main_binary_analysis],
         )
@@ -103,7 +103,7 @@ class TestMainBinaryExportMetadataInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[framework_binary_analysis],
         )
@@ -129,7 +129,7 @@ class TestMainBinaryExportMetadataInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[main_binary_analysis],
         )
@@ -142,7 +142,7 @@ class TestMainBinaryExportMetadataInsight:
         """Test that no insight is generated when binary_analysis list is empty."""
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[],  # Empty list
         )
@@ -191,7 +191,7 @@ class TestMainBinaryExportMetadataInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[framework_binary_analysis, main_binary_analysis],  # Framework first, main second
         )
@@ -214,7 +214,7 @@ class TestMainBinaryExportMetadataInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[non_macho_binary],
         )
@@ -249,7 +249,7 @@ class TestMainBinaryExportMetadataInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[main_binary_analysis],
         )

--- a/tests/unit/test_small_files_insight.py
+++ b/tests/unit/test_small_files_insight.py
@@ -28,6 +28,7 @@ class TestSmallFilesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash=f"hash_small_{i}",
+                is_dir=False,
             )
             small_files.append(small_file)
 
@@ -40,10 +41,11 @@ class TestSmallFilesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash=f"hash_large_{i}",
+                is_dir=False,
             )
             large_files.append(large_file)
 
-        file_analysis = FileAnalysis(files=small_files + large_files)
+        file_analysis = FileAnalysis(files=small_files + large_files, directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -75,10 +77,11 @@ class TestSmallFilesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash=f"hash_{i}",
+                is_dir=False,
             )
             files.append(file)
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -104,10 +107,11 @@ class TestSmallFilesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash=f"hash_{i}",
+                is_dir=False,
             )
             files.append(file)
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -139,10 +143,11 @@ class TestSmallFilesInsight:
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
                 hash=f"hash_{i}",
+                is_dir=False,
             )
             files.append(file)
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -157,7 +162,7 @@ class TestSmallFilesInsight:
 
     def test_generate_with_empty_file_list(self):
         """Test that no insight is generated when there are no files."""
-        file_analysis = FileAnalysis(files=[])
+        file_analysis = FileAnalysis(files=[], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -193,10 +198,11 @@ class TestSmallFilesInsight:
                 file_type="bin",
                 treemap_type=TreemapType.OTHER,
                 hash=f"hash_{i}",
+                is_dir=False,
             )
             files.append(file)
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -232,6 +238,7 @@ class TestSmallFilesInsight:
                 file_type="bin",
                 treemap_type=TreemapType.OTHER,
                 hash=f"hash_{i}",
+                is_dir=False,
             )
             files.append(file)
             expected_savings += APPLE_FILESYSTEM_BLOCK_SIZE - size
@@ -245,10 +252,11 @@ class TestSmallFilesInsight:
                 file_type="bin",
                 treemap_type=TreemapType.OTHER,
                 hash=f"hash_large_{i}",
+                is_dir=False,
             )
             files.append(file)
 
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),

--- a/tests/unit/test_small_files_insight.py
+++ b/tests/unit/test_small_files_insight.py
@@ -59,9 +59,9 @@ class TestSmallFilesInsight:
         assert result.file_count == 50
         # Each small file wastes 3072 bytes (4096 - 1024)
         assert result.total_savings == 50 * (APPLE_FILESYSTEM_BLOCK_SIZE - 1024)
-        # Verify all returned files are small
-        for file in result.files:
-            assert file.size < APPLE_FILESYSTEM_BLOCK_SIZE
+        # Verify all returned files have correct savings calculation
+        for file_savings in result.files:
+            assert file_savings.total_savings == APPLE_FILESYSTEM_BLOCK_SIZE - 1024
 
     def test_generate_with_few_total_files(self):
         """Test that no insight is generated when app has < 100 total files."""
@@ -123,6 +123,9 @@ class TestSmallFilesInsight:
         assert result.file_count == 30
         # Each small file wastes 2048 bytes (4096 - 2048)
         assert result.total_savings == 30 * (APPLE_FILESYSTEM_BLOCK_SIZE - 2048)
+        # Verify savings calculation for each file
+        for file_savings in result.files:
+            assert file_savings.total_savings == APPLE_FILESYSTEM_BLOCK_SIZE - 2048
 
     def test_generate_with_many_files_but_no_small_files(self):
         """Test that insight is generated but with empty results when no small files exist."""
@@ -209,6 +212,9 @@ class TestSmallFilesInsight:
         assert result.file_count == 20
         # Each small file wastes 1 byte (4096 - 4095)
         assert result.total_savings == 20 * 1
+        # Verify savings calculation for each file
+        for file_savings in result.files:
+            assert file_savings.total_savings == 1
 
     def test_calculate_savings_correctly(self):
         """Test that savings calculation is correct for various file sizes."""

--- a/tests/unit/test_small_files_insight.py
+++ b/tests/unit/test_small_files_insight.py
@@ -27,7 +27,7 @@ class TestSmallFilesInsight:
                 size=1024,  # 1KB - small file
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5=f"hash_small_{i}",
+                hash=f"hash_small_{i}",
             )
             small_files.append(small_file)
 
@@ -39,7 +39,7 @@ class TestSmallFilesInsight:
                 size=8192,  # 8KB - large file
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5=f"hash_large_{i}",
+                hash=f"hash_large_{i}",
             )
             large_files.append(large_file)
 
@@ -74,7 +74,7 @@ class TestSmallFilesInsight:
                 size=512,  # Small file
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5=f"hash_{i}",
+                hash=f"hash_{i}",
             )
             files.append(file)
 
@@ -103,7 +103,7 @@ class TestSmallFilesInsight:
                 size=size,
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5=f"hash_{i}",
+                hash=f"hash_{i}",
             )
             files.append(file)
 
@@ -138,7 +138,7 @@ class TestSmallFilesInsight:
                 size=8192,  # All large files
                 file_type="png",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5=f"hash_{i}",
+                hash=f"hash_{i}",
             )
             files.append(file)
 
@@ -192,7 +192,7 @@ class TestSmallFilesInsight:
                 size=size,
                 file_type="bin",
                 treemap_type=TreemapType.OTHER,
-                hash_md5=f"hash_{i}",
+                hash=f"hash_{i}",
             )
             files.append(file)
 
@@ -231,7 +231,7 @@ class TestSmallFilesInsight:
                 size=size,
                 file_type="bin",
                 treemap_type=TreemapType.OTHER,
-                hash_md5=f"hash_{i}",
+                hash=f"hash_{i}",
             )
             files.append(file)
             expected_savings += APPLE_FILESYSTEM_BLOCK_SIZE - size
@@ -244,7 +244,7 @@ class TestSmallFilesInsight:
                 size=8192,
                 file_type="bin",
                 treemap_type=TreemapType.OTHER,
-                hash_md5=f"hash_large_{i}",
+                hash=f"hash_large_{i}",
             )
             files.append(file)
 

--- a/tests/unit/test_strip_symbols_insight.py
+++ b/tests/unit/test_strip_symbols_insight.py
@@ -45,7 +45,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
         )
@@ -88,7 +88,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
         )
@@ -138,7 +138,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
         )
@@ -234,7 +234,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[binary_analysis_1, binary_analysis_2, binary_analysis_3],
         )
@@ -292,7 +292,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
         )
@@ -331,7 +331,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
         )
@@ -353,7 +353,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[non_macho_binary],
         )
@@ -395,7 +395,7 @@ class TestStripSymbolsInsight:
 
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[binary_analysis],
         )
@@ -420,7 +420,7 @@ class TestStripSymbolsInsight:
         """Test that no insight is generated when binary_analysis is empty."""
         insights_input = InsightsInput(
             app_info=BaseAppInfo(name="TestApp", version="1.0", build="1", app_id="com.testapp"),
-            file_analysis=FileAnalysis(files=[]),
+            file_analysis=FileAnalysis(files=[], directories=[]),
             treemap=None,
             binary_analysis=[],  # Empty list
         )

--- a/tests/unit/test_unnecessary_files_insight.py
+++ b/tests/unit/test_unnecessary_files_insight.py
@@ -37,7 +37,7 @@ class TestUnnecessaryFilesInsight:
                 size=5000,
                 file_type="md",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash1",
+                hash="hash1",
             ),
             # Shell script
             FileInfo(
@@ -46,7 +46,7 @@ class TestUnnecessaryFilesInsight:
                 size=3000,
                 file_type="sh",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash2",
+                hash="hash2",
             ),
             # Xcode config
             FileInfo(
@@ -55,7 +55,7 @@ class TestUnnecessaryFilesInsight:
                 size=2000,
                 file_type="xcconfig",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash3",
+                hash="hash3",
             ),
         ]
 
@@ -67,7 +67,7 @@ class TestUnnecessaryFilesInsight:
                 size=100000,
                 file_type="",
                 treemap_type=TreemapType.EXECUTABLES,
-                hash_md5="hash4",
+                hash="hash4",
             ),
             # Asset file
             FileInfo(
@@ -76,7 +76,7 @@ class TestUnnecessaryFilesInsight:
                 size=50000,
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash5",
+                hash="hash5",
             ),
         ]
 
@@ -101,7 +101,7 @@ class TestUnnecessaryFilesInsight:
                 size=100000,
                 file_type="",
                 treemap_type=TreemapType.EXECUTABLES,
-                hash_md5="hash1",
+                hash="hash1",
             ),
             FileInfo(
                 full_path=Path("Assets.car"),
@@ -109,7 +109,7 @@ class TestUnnecessaryFilesInsight:
                 size=50000,
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
-                hash_md5="hash2",
+                hash="hash2",
             ),
         ]
 
@@ -139,7 +139,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type="txt",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -163,7 +163,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type="txt",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -187,7 +187,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type="sh",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -216,7 +216,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type=filename.split(".")[-1] if "." in filename else "",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -239,7 +239,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type="",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -260,7 +260,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type="",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -282,7 +282,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type="txt",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -313,7 +313,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type=filename.split(".")[-1] if "." in filename else "",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash",
+                hash="hash",
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -334,7 +334,7 @@ class TestUnnecessaryFilesInsight:
                 size=1000,
                 file_type="sh",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash1",
+                hash="hash1",
             ),
             FileInfo(
                 full_path=Path("README.md"),
@@ -342,7 +342,7 @@ class TestUnnecessaryFilesInsight:
                 size=5000,
                 file_type="md",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash2",
+                hash="hash2",
             ),
             FileInfo(
                 full_path=Path("medium.xcconfig"),
@@ -350,7 +350,7 @@ class TestUnnecessaryFilesInsight:
                 size=3000,
                 file_type="xcconfig",
                 treemap_type=TreemapType.OTHER,
-                hash_md5="hash3",
+                hash="hash3",
             ),
         ]
 

--- a/tests/unit/test_unnecessary_files_insight.py
+++ b/tests/unit/test_unnecessary_files_insight.py
@@ -88,9 +88,9 @@ class TestUnnecessaryFilesInsight:
         assert result.total_savings == 10000  # 5000 + 3000 + 2000
 
         # Files should be sorted by size descending
-        assert result.files[0].size == 5000  # README.md
-        assert result.files[1].size == 3000  # build.sh
-        assert result.files[2].size == 2000  # Debug.xcconfig
+        assert result.files[0].total_savings == 5000  # README.md
+        assert result.files[1].total_savings == 3000  # build.sh
+        assert result.files[2].total_savings == 2000  # Debug.xcconfig
 
     def test_generate_with_no_unnecessary_files(self):
         """Test that no insight is generated when no unnecessary files are found."""
@@ -145,7 +145,7 @@ class TestUnnecessaryFilesInsight:
             result = self.insight.generate(insights_input)
             assert result is not None, f"Should match {filename}"
             assert len(result.files) == 1
-            assert result.files[0].path == filename
+            assert result.files[0].file_path == filename
 
     def test_pattern_matching_changelog_files(self):
         """Test that various CHANGELOG file patterns are matched."""
@@ -169,7 +169,7 @@ class TestUnnecessaryFilesInsight:
             result = self.insight.generate(insights_input)
             assert result is not None, f"Should match {filename}"
             assert len(result.files) == 1
-            assert result.files[0].path == filename
+            assert result.files[0].file_path == filename
 
     def test_pattern_matching_shell_scripts(self):
         """Test that shell script patterns are matched."""
@@ -193,7 +193,7 @@ class TestUnnecessaryFilesInsight:
             result = self.insight.generate(insights_input)
             assert result is not None, f"Should match {filename}"
             assert len(result.files) == 1
-            assert result.files[0].path == filename
+            assert result.files[0].file_path == filename
 
     def test_pattern_matching_development_files(self):
         """Test that various development files are matched."""
@@ -222,7 +222,7 @@ class TestUnnecessaryFilesInsight:
             result = self.insight.generate(insights_input)
             assert result is not None, f"Should match {filename}"
             assert len(result.files) == 1
-            assert result.files[0].path == filename
+            assert result.files[0].file_path == filename
 
     def test_pattern_matching_exact_filenames(self):
         """Test that exact filename matches work correctly."""
@@ -245,7 +245,7 @@ class TestUnnecessaryFilesInsight:
             result = self.insight.generate(insights_input)
             assert result is not None, f"Should match exact filename {filename}"
             assert len(result.files) == 1
-            assert result.files[0].path == filename
+            assert result.files[0].file_path == filename
 
         # These should NOT match (similar but not exact)
         non_matches = [
@@ -321,7 +321,7 @@ class TestUnnecessaryFilesInsight:
             if should_match:
                 assert result is not None, f"Should match {filename}"
                 assert len(result.files) == 1
-                assert result.files[0].path == filename
+                assert result.files[0].file_path == filename
             else:
                 assert result is None, f"Should not match {filename}"
 
@@ -361,6 +361,6 @@ class TestUnnecessaryFilesInsight:
         assert len(result.files) == 3
 
         # Should be sorted by size descending
-        assert result.files[0].size == 5000  # README.md
-        assert result.files[1].size == 3000  # medium.xcconfig
-        assert result.files[2].size == 1000  # small.sh
+        assert result.files[0].total_savings == 5000  # README.md
+        assert result.files[1].total_savings == 3000  # medium.xcconfig
+        assert result.files[2].total_savings == 1000  # small.sh

--- a/tests/unit/test_unnecessary_files_insight.py
+++ b/tests/unit/test_unnecessary_files_insight.py
@@ -19,7 +19,7 @@ class TestUnnecessaryFilesInsight:
 
     def _create_insights_input(self, files: list[FileInfo]) -> InsightsInput:
         """Helper method to create InsightsInput for testing."""
-        file_analysis = FileAnalysis(files=files)
+        file_analysis = FileAnalysis(files=files, directories=[])
         return InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
             file_analysis=file_analysis,
@@ -38,6 +38,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="md",
                 treemap_type=TreemapType.OTHER,
                 hash="hash1",
+                is_dir=False,
             ),
             # Shell script
             FileInfo(
@@ -47,6 +48,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="sh",
                 treemap_type=TreemapType.OTHER,
                 hash="hash2",
+                is_dir=False,
             ),
             # Xcode config
             FileInfo(
@@ -56,6 +58,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="xcconfig",
                 treemap_type=TreemapType.OTHER,
                 hash="hash3",
+                is_dir=False,
             ),
         ]
 
@@ -68,6 +71,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="",
                 treemap_type=TreemapType.EXECUTABLES,
                 hash="hash4",
+                is_dir=False,
             ),
             # Asset file
             FileInfo(
@@ -77,6 +81,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash5",
+                is_dir=False,
             ),
         ]
 
@@ -102,6 +107,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="",
                 treemap_type=TreemapType.EXECUTABLES,
                 hash="hash1",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("Assets.car"),
@@ -110,6 +116,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="car",
                 treemap_type=TreemapType.ASSETS,
                 hash="hash2",
+                is_dir=False,
             ),
         ]
 
@@ -140,6 +147,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="txt",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -164,6 +172,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="txt",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -188,6 +197,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="sh",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -217,6 +227,7 @@ class TestUnnecessaryFilesInsight:
                 file_type=filename.split(".")[-1] if "." in filename else "",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -240,6 +251,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -261,6 +273,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -283,6 +296,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="txt",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -314,6 +328,7 @@ class TestUnnecessaryFilesInsight:
                 file_type=filename.split(".")[-1] if "." in filename else "",
                 treemap_type=TreemapType.OTHER,
                 hash="hash",
+                is_dir=False,
             )
             insights_input = self._create_insights_input([file_info])
             result = self.insight.generate(insights_input)
@@ -335,6 +350,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="sh",
                 treemap_type=TreemapType.OTHER,
                 hash="hash1",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("README.md"),
@@ -343,6 +359,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="md",
                 treemap_type=TreemapType.OTHER,
                 hash="hash2",
+                is_dir=False,
             ),
             FileInfo(
                 full_path=Path("medium.xcconfig"),
@@ -351,6 +368,7 @@ class TestUnnecessaryFilesInsight:
                 file_type="xcconfig",
                 treemap_type=TreemapType.OTHER,
                 hash="hash3",
+                is_dir=False,
             ),
         ]
 

--- a/web/public/sample-data.json
+++ b/web/public/sample-data.json
@@ -8,67 +8,67 @@
           "path": "HackerNews",
           "size": 2628128,
           "file_type": "unknown",
-          "hash_md5": "9be613d41e87fc737691d6eae65ef868"
+          "hash": "9be613d41e87fc737691d6eae65ef868"
         },
         {
           "path": "PkgInfo",
           "size": 8,
           "file_type": "unknown",
-          "hash_md5": "23b7d7d024abb0f558420e098800bf27"
+          "hash": "23b7d7d024abb0f558420e098800bf27"
         },
         {
           "path": "_CodeSignature/CodeResources",
           "size": 8523,
           "file_type": "unknown",
-          "hash_md5": "c055dde49c13eb268ee256bfaab270af"
+          "hash": "c055dde49c13eb268ee256bfaab270af"
         },
         {
           "path": "Frameworks/Sentry.framework/Sentry",
           "size": 51456,
           "file_type": "unknown",
-          "hash_md5": "885ec86bb33e7489367f169bf7ad10eb"
+          "hash": "885ec86bb33e7489367f169bf7ad10eb"
         },
         {
           "path": "Frameworks/Common.framework/Common",
           "size": 188992,
           "file_type": "unknown",
-          "hash_md5": "03b50a5c46df571c54cd680b90d471df"
+          "hash": "03b50a5c46df571c54cd680b90d471df"
         },
         {
           "path": "Frameworks/Reaper.framework/Reaper",
           "size": 51440,
           "file_type": "unknown",
-          "hash_md5": "dc56b59c17e9fdfb19c1dbf6631cfbee"
+          "hash": "dc56b59c17e9fdfb19c1dbf6631cfbee"
         },
         {
           "path": "Frameworks/Reaper.framework/_CodeSignature/CodeResources",
           "size": 1798,
           "file_type": "unknown",
-          "hash_md5": "4928eb799bb841e9d412ed5bb2abb4d7"
+          "hash": "4928eb799bb841e9d412ed5bb2abb4d7"
         },
         {
           "path": "Frameworks/Common.framework/_CodeSignature/CodeResources",
           "size": 1798,
           "file_type": "unknown",
-          "hash_md5": "4dd70944d296b9be7e67a3539f888996"
+          "hash": "4dd70944d296b9be7e67a3539f888996"
         },
         {
           "path": "Frameworks/Sentry.framework/_CodeSignature/CodeResources",
           "size": 2034,
           "file_type": "unknown",
-          "hash_md5": "c4db10dccf2de9f141799d6b1ef97138"
+          "hash": "c4db10dccf2de9f141799d6b1ef97138"
         },
         {
           "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/HackerNewsHomeWidgetExtension",
           "size": 152400,
           "file_type": "unknown",
-          "hash_md5": "f3dbc38d127461b656272ad6f9796953"
+          "hash": "f3dbc38d127461b656272ad6f9796953"
         },
         {
           "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/_CodeSignature/CodeResources",
           "size": 3304,
           "file_type": "unknown",
-          "hash_md5": "893b80e17e4098504590992a97f1d1d4"
+          "hash": "893b80e17e4098504590992a97f1d1d4"
         }
       ],
       "png": [
@@ -76,13 +76,13 @@
           "path": "AppIcon60x60@2x.png",
           "size": 10040,
           "file_type": "png",
-          "hash_md5": "bcba3ca728dc0f3d06391aa9f92e0b5a"
+          "hash": "bcba3ca728dc0f3d06391aa9f92e0b5a"
         },
         {
           "path": "AppIcon76x76@2x~ipad.png",
           "size": 15008,
           "file_type": "png",
-          "hash_md5": "a15ef67ba856ec744c20a3aef9da1237"
+          "hash": "a15ef67ba856ec744c20a3aef9da1237"
         }
       ],
       "car": [
@@ -90,13 +90,13 @@
           "path": "Assets.car",
           "size": 4785504,
           "file_type": "car",
-          "hash_md5": "1b9f45846c27187e515a7453de0b44e2"
+          "hash": "1b9f45846c27187e515a7453de0b44e2"
         },
         {
           "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/Assets.car",
           "size": 23504,
           "file_type": "car",
-          "hash_md5": "10708a136443bc6369686c040c2515ef"
+          "hash": "10708a136443bc6369686c040c2515ef"
         }
       ],
       "plist": [
@@ -104,43 +104,43 @@
           "path": "Hacker-News-Info.plist",
           "size": 402,
           "file_type": "plist",
-          "hash_md5": "d619378dad2b5c879026f42ee40151a4"
+          "hash": "d619378dad2b5c879026f42ee40151a4"
         },
         {
           "path": "Info.plist",
           "size": 1863,
           "file_type": "plist",
-          "hash_md5": "7d63330f5ff96011402d66984317b717"
+          "hash": "7d63330f5ff96011402d66984317b717"
         },
         {
           "path": "Fonts_Fonts.bundle/Info.plist",
           "size": 668,
           "file_type": "plist",
-          "hash_md5": "6275a17bffb670de4f09848c3e2e16d3"
+          "hash": "6275a17bffb670de4f09848c3e2e16d3"
         },
         {
           "path": "Frameworks/Sentry.framework/Info.plist",
           "size": 746,
           "file_type": "plist",
-          "hash_md5": "30d677d01465852100014817224bec17"
+          "hash": "30d677d01465852100014817224bec17"
         },
         {
           "path": "Frameworks/Common.framework/Info.plist",
           "size": 743,
           "file_type": "plist",
-          "hash_md5": "49c7946b12351d1b0632391ef66aca48"
+          "hash": "49c7946b12351d1b0632391ef66aca48"
         },
         {
           "path": "Frameworks/Reaper.framework/Info.plist",
           "size": 749,
           "file_type": "plist",
-          "hash_md5": "bdaa1c3b3fb41f39204b7b5b7d12e98f"
+          "hash": "bdaa1c3b3fb41f39204b7b5b7d12e98f"
         },
         {
           "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/Info.plist",
           "size": 1098,
           "file_type": "plist",
-          "hash_md5": "10e17dc4ef12e95c112faf6e765a9b52"
+          "hash": "10e17dc4ef12e95c112faf6e765a9b52"
         }
       ],
       "mobileprovision": [
@@ -148,13 +148,13 @@
           "path": "embedded.mobileprovision",
           "size": 37798,
           "file_type": "mobileprovision",
-          "hash_md5": "512485ed4385e31a645f40a0239fcbb6"
+          "hash": "512485ed4385e31a645f40a0239fcbb6"
         },
         {
           "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/embedded.mobileprovision",
           "size": 37798,
           "file_type": "mobileprovision",
-          "hash_md5": "512485ed4385e31a645f40a0239fcbb6"
+          "hash": "512485ed4385e31a645f40a0239fcbb6"
         }
       ],
       "ttf": [
@@ -162,19 +162,19 @@
           "path": "Fonts_Fonts.bundle/ibm_plex_sans_medium.ttf",
           "size": 177104,
           "file_type": "ttf",
-          "hash_md5": "361336a2ed1908c5cd8dec2e10aa71a2"
+          "hash": "361336a2ed1908c5cd8dec2e10aa71a2"
         },
         {
           "path": "Fonts_Fonts.bundle/ibm_plex_sans_regular.ttf",
           "size": 133720,
           "file_type": "ttf",
-          "hash_md5": "ea96a0afddbe8ff439be465b16cbd381"
+          "hash": "ea96a0afddbe8ff439be465b16cbd381"
         },
         {
           "path": "Fonts_Fonts.bundle/ibm_plex_sans_bold.ttf",
           "size": 135932,
           "file_type": "ttf",
-          "hash_md5": "be4cc57a744421b843e08a2001436f40"
+          "hash": "be4cc57a744421b843e08a2001436f40"
         }
       ],
       "xcprivacy": [
@@ -182,7 +182,7 @@
           "path": "Frameworks/Sentry.framework/PrivacyInfo.xcprivacy",
           "size": 2108,
           "file_type": "xcprivacy",
-          "hash_md5": "72147fd439c166b667c137f8f5b604eb"
+          "hash": "72147fd439c166b667c137f8f5b604eb"
         }
       ],
       "bundle": [
@@ -190,7 +190,7 @@
           "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/Fonts_Fonts.bundle",
           "size": 24,
           "file_type": "bundle",
-          "hash_md5": "4a7acfa65b4e20c34a2f7bbb521d996b"
+          "hash": "4a7acfa65b4e20c34a2f7bbb521d996b"
         }
       ]
     },
@@ -201,13 +201,13 @@
             "path": "embedded.mobileprovision",
             "size": 37798,
             "file_type": "mobileprovision",
-            "hash_md5": "512485ed4385e31a645f40a0239fcbb6"
+            "hash": "512485ed4385e31a645f40a0239fcbb6"
           },
           {
             "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/embedded.mobileprovision",
             "size": 37798,
             "file_type": "mobileprovision",
-            "hash_md5": "512485ed4385e31a645f40a0239fcbb6"
+            "hash": "512485ed4385e31a645f40a0239fcbb6"
           }
         ],
         "potential_savings": 37798
@@ -218,121 +218,121 @@
         "path": "Assets.car",
         "size": 4785504,
         "file_type": "car",
-        "hash_md5": "1b9f45846c27187e515a7453de0b44e2"
+        "hash": "1b9f45846c27187e515a7453de0b44e2"
       },
       {
         "path": "HackerNews",
         "size": 2628128,
         "file_type": "unknown",
-        "hash_md5": "9be613d41e87fc737691d6eae65ef868"
+        "hash": "9be613d41e87fc737691d6eae65ef868"
       },
       {
         "path": "Frameworks/Common.framework/Common",
         "size": 188992,
         "file_type": "unknown",
-        "hash_md5": "03b50a5c46df571c54cd680b90d471df"
+        "hash": "03b50a5c46df571c54cd680b90d471df"
       },
       {
         "path": "Fonts_Fonts.bundle/ibm_plex_sans_medium.ttf",
         "size": 177104,
         "file_type": "ttf",
-        "hash_md5": "361336a2ed1908c5cd8dec2e10aa71a2"
+        "hash": "361336a2ed1908c5cd8dec2e10aa71a2"
       },
       {
         "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/HackerNewsHomeWidgetExtension",
         "size": 152400,
         "file_type": "unknown",
-        "hash_md5": "f3dbc38d127461b656272ad6f9796953"
+        "hash": "f3dbc38d127461b656272ad6f9796953"
       },
       {
         "path": "Fonts_Fonts.bundle/ibm_plex_sans_bold.ttf",
         "size": 135932,
         "file_type": "ttf",
-        "hash_md5": "be4cc57a744421b843e08a2001436f40"
+        "hash": "be4cc57a744421b843e08a2001436f40"
       },
       {
         "path": "Fonts_Fonts.bundle/ibm_plex_sans_regular.ttf",
         "size": 133720,
         "file_type": "ttf",
-        "hash_md5": "ea96a0afddbe8ff439be465b16cbd381"
+        "hash": "ea96a0afddbe8ff439be465b16cbd381"
       },
       {
         "path": "Frameworks/Sentry.framework/Sentry",
         "size": 51456,
         "file_type": "unknown",
-        "hash_md5": "885ec86bb33e7489367f169bf7ad10eb"
+        "hash": "885ec86bb33e7489367f169bf7ad10eb"
       },
       {
         "path": "Frameworks/Reaper.framework/Reaper",
         "size": 51440,
         "file_type": "unknown",
-        "hash_md5": "dc56b59c17e9fdfb19c1dbf6631cfbee"
+        "hash": "dc56b59c17e9fdfb19c1dbf6631cfbee"
       },
       {
         "path": "embedded.mobileprovision",
         "size": 37798,
         "file_type": "mobileprovision",
-        "hash_md5": "512485ed4385e31a645f40a0239fcbb6"
+        "hash": "512485ed4385e31a645f40a0239fcbb6"
       },
       {
         "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/embedded.mobileprovision",
         "size": 37798,
         "file_type": "mobileprovision",
-        "hash_md5": "512485ed4385e31a645f40a0239fcbb6"
+        "hash": "512485ed4385e31a645f40a0239fcbb6"
       },
       {
         "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/Assets.car",
         "size": 23504,
         "file_type": "car",
-        "hash_md5": "10708a136443bc6369686c040c2515ef"
+        "hash": "10708a136443bc6369686c040c2515ef"
       },
       {
         "path": "AppIcon76x76@2x~ipad.png",
         "size": 15008,
         "file_type": "png",
-        "hash_md5": "a15ef67ba856ec744c20a3aef9da1237"
+        "hash": "a15ef67ba856ec744c20a3aef9da1237"
       },
       {
         "path": "AppIcon60x60@2x.png",
         "size": 10040,
         "file_type": "png",
-        "hash_md5": "bcba3ca728dc0f3d06391aa9f92e0b5a"
+        "hash": "bcba3ca728dc0f3d06391aa9f92e0b5a"
       },
       {
         "path": "_CodeSignature/CodeResources",
         "size": 8523,
         "file_type": "unknown",
-        "hash_md5": "c055dde49c13eb268ee256bfaab270af"
+        "hash": "c055dde49c13eb268ee256bfaab270af"
       },
       {
         "path": "PlugIns/HackerNewsHomeWidgetExtension.appex/_CodeSignature/CodeResources",
         "size": 3304,
         "file_type": "unknown",
-        "hash_md5": "893b80e17e4098504590992a97f1d1d4"
+        "hash": "893b80e17e4098504590992a97f1d1d4"
       },
       {
         "path": "Frameworks/Sentry.framework/PrivacyInfo.xcprivacy",
         "size": 2108,
         "file_type": "xcprivacy",
-        "hash_md5": "72147fd439c166b667c137f8f5b604eb"
+        "hash": "72147fd439c166b667c137f8f5b604eb"
       },
       {
         "path": "Frameworks/Sentry.framework/_CodeSignature/CodeResources",
         "size": 2034,
         "file_type": "unknown",
-        "hash_md5": "c4db10dccf2de9f141799d6b1ef97138"
+        "hash": "c4db10dccf2de9f141799d6b1ef97138"
       },
       {
         "path": "Info.plist",
         "size": 1863,
         "file_type": "plist",
-        "hash_md5": "7d63330f5ff96011402d66984317b717"
+        "hash": "7d63330f5ff96011402d66984317b717"
       },
       {
         "path": "Frameworks/Reaper.framework/_CodeSignature/CodeResources",
         "size": 1798,
         "file_type": "unknown",
-        "hash_md5": "4928eb799bb841e9d412ed5bb2abb4d7"
+        "hash": "4928eb799bb841e9d412ed5bb2abb4d7"
       }
     ]
   },

--- a/web/public/treemap-sample.json
+++ b/web/public/treemap-sample.json
@@ -25,7 +25,7 @@
             "children": [],
             "details": {
               "file_type": "unknown",
-              "hash_md5": "9be613d41e87fc737691d6eae65ef868"
+              "hash": "9be613d41e87fc737691d6eae65ef868"
             }
           },
           {
@@ -38,7 +38,7 @@
             "children": [],
             "details": {
               "file_type": "unknown",
-              "hash_md5": "03b50a5c46df571c54cd680b90d471df"
+              "hash": "03b50a5c46df571c54cd680b90d471df"
             }
           }
         ],
@@ -65,7 +65,7 @@
             "children": [],
             "details": {
               "file_type": "car",
-              "hash_md5": "1b9f45846c27187e515a7453de0b44e2"
+              "hash": "1b9f45846c27187e515a7453de0b44e2"
             }
           }
         ],
@@ -92,7 +92,7 @@
             "children": [],
             "details": {
               "file_type": "ttf",
-              "hash_md5": "361336a2ed1908c5cd8dec2e10aa71a2"
+              "hash": "361336a2ed1908c5cd8dec2e10aa71a2"
             }
           }
         ],

--- a/web/src/components/InsightsDisplay.tsx
+++ b/web/src/components/InsightsDisplay.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
 import type { DuplicateFilesInsightResult, FileAnalysisReport, InsightResult, LooseImagesInsightResult, StripBinaryInsightResult } from '../utils/dataConverter';
 
+// Add type for main binary export metadata
+interface FileSavingsResult {
+  file_path: string;
+  total_savings: number;
+}
+
+interface MainBinaryExportMetadataResult {
+  total_savings: number;
+  files: FileSavingsResult[];
+}
+
 interface InsightsDisplayProps {
   data: FileAnalysisReport;
 }
@@ -34,6 +45,7 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       webp_optimization: 'WebP Optimization',
       strip_binary: 'Binary Stripping',
       localized_strings: 'Localized Strings',
+      main_binary_exported_symbols: 'Main Binary Export Metadata',
     };
     return titles[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
   };
@@ -48,6 +60,7 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       webp_optimization: 'Images that could be converted to WebP format for better compression',
       strip_binary: 'Debug symbols and metadata that can be removed from binaries',
       localized_strings: 'Unused localization strings that can be removed',
+      main_binary_exported_symbols: 'Export metadata in main binaries that could be optimized',
     };
     return descriptions[key] || 'Potential optimization opportunity';
   };
@@ -62,6 +75,7 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       webp_optimization: '🗜️',
       strip_binary: '⚡',
       localized_strings: '🌐',
+      main_binary_exported_symbols: '📦',
     };
     return icons[key] || '💡';
   };
@@ -96,12 +110,19 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       return hasValidSavings || hasImageGroups;
     }
 
+    // Handle main binary export metadata differently (has FileSavingsResult files)
+    if (key === 'main_binary_exported_symbols') {
+      const exportInsight = value as MainBinaryExportMetadataResult;
+      const hasFiles = exportInsight.files && Array.isArray(exportInsight.files) && exportInsight.files.length > 0;
+      return hasValidSavings || hasFiles;
+    }
+
     const regularInsight = value as InsightResult;
     const hasFiles = regularInsight.files && Array.isArray(regularInsight.files) && regularInsight.files.length > 0;
 
     // Include insights that either have savings or have files to show
     return hasValidSavings || hasFiles;
-  }) as [string, InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | LooseImagesInsightResult][];
+  }) as [string, InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | LooseImagesInsightResult | MainBinaryExportMetadataResult][];
 
   if (insightEntries.length === 0) {
     return null;
@@ -412,6 +433,67 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
                             <div>
                               Symbol table: {formatSize(file.symbol_table_savings)}
                             </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()
+            ) : key === 'main_binary_exported_symbols' ? (
+              // Handle main binary export metadata with FileSavingsResult files
+              (() => {
+                const exportInsight = insight as MainBinaryExportMetadataResult;
+                return exportInsight.files && exportInsight.files.length > 0 && (
+                  <div>
+                    <h4 style={{
+                      margin: '0 0 0.75rem 0',
+                      color: '#495057',
+                      fontSize: '1rem',
+                      fontWeight: '600'
+                    }}>
+                      Main Binary Files ({exportInsight.files.length})
+                    </h4>
+                    <div style={{
+                      backgroundColor: '#f8f9fa',
+                      borderRadius: '6px',
+                      padding: '0.75rem',
+                      maxHeight: '200px',
+                      overflowY: 'auto'
+                    }}>
+                      {exportInsight.files.map((file, index) => (
+                        <div
+                          key={index}
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            padding: '0.75rem',
+                            marginBottom: index < exportInsight.files.length - 1 ? '0.5rem' : '0',
+                            backgroundColor: '#ffffff',
+                            borderRadius: '4px',
+                            border: '1px solid #e9ecef'
+                          }}
+                        >
+                          <div style={{
+                            flex: 1,
+                            color: '#495057',
+                            fontFamily: 'monospace',
+                            fontSize: '0.8rem',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            marginRight: '1rem'
+                          }}>
+                            {file.file_path}
+                          </div>
+                          <div style={{
+                            color: '#28a745',
+                            fontSize: '0.8rem',
+                            fontWeight: '600',
+                            flexShrink: 0
+                          }}>
+                            {formatSize(file.total_savings)} export metadata
                           </div>
                         </div>
                       ))}

--- a/web/src/components/InsightsDisplay.tsx
+++ b/web/src/components/InsightsDisplay.tsx
@@ -12,6 +12,11 @@ interface MainBinaryExportMetadataResult {
   files: FileSavingsResult[];
 }
 
+interface FileSavingsInsightResult {
+  total_savings: number;
+  files: FileSavingsResult[];
+}
+
 interface InsightsDisplayProps {
   data: FileAnalysisReport;
 }
@@ -45,6 +50,8 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       webp_optimization: 'WebP Optimization',
       strip_binary: 'Binary Stripping',
       localized_strings: 'Localized Strings',
+      small_files: 'Small Files',
+      unnecessary_files: 'Unnecessary Files',
       main_binary_exported_symbols: 'Main Binary Export Metadata',
     };
     return titles[key] || key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
@@ -53,14 +60,16 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
   const getInsightDescription = (key: string): string => {
     const descriptions: Record<string, string> = {
       duplicate_files: 'Files that appear multiple times in your app, wasting space',
-      large_images: 'Image files that could be compressed or optimized',
-      large_videos: 'Video files that may benefit from compression',
-      large_audio: 'Audio files that could be optimized for size',
+      large_images: 'Image files with potential optimization savings',
+      large_videos: 'Video files with potential compression savings',
+      large_audio: 'Audio files with potential optimization savings',
       hermes_debug_info: 'Debug information that can be removed from production builds',
       webp_optimization: 'Images that could be converted to WebP format for better compression',
       strip_binary: 'Debug symbols and metadata that can be removed from binaries',
-      localized_strings: 'Unused localization strings that can be removed',
+      localized_strings: 'Localization strings with potential optimization savings',
+      small_files: 'Small files wasting space due to filesystem block size constraints',
       main_binary_exported_symbols: 'Export metadata in main binaries that could be optimized',
+      unnecessary_files: 'Unnecessary files that can be removed to save space',
     };
     return descriptions[key] || 'Potential optimization opportunity';
   };
@@ -75,7 +84,9 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       webp_optimization: '🗜️',
       strip_binary: '⚡',
       localized_strings: '🌐',
+      small_files: '📄',
       main_binary_exported_symbols: '📦',
+      unnecessary_files: '🗑️',
     };
     return icons[key] || '💡';
   };
@@ -117,12 +128,19 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
       return hasValidSavings || hasFiles;
     }
 
+    // Handle insights that now use FileSavingsResult format
+    if (['large_images', 'large_videos', 'large_audio', 'hermes_debug_info', 'unnecessary_files', 'localized_strings', 'small_files'].includes(key)) {
+      const fileSavingsInsight = value as FileSavingsInsightResult;
+      const hasFiles = fileSavingsInsight.files && Array.isArray(fileSavingsInsight.files) && fileSavingsInsight.files.length > 0;
+      return hasValidSavings || hasFiles;
+    }
+
     const regularInsight = value as InsightResult;
     const hasFiles = regularInsight.files && Array.isArray(regularInsight.files) && regularInsight.files.length > 0;
 
     // Include insights that either have savings or have files to show
     return hasValidSavings || hasFiles;
-  }) as [string, InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | LooseImagesInsightResult | MainBinaryExportMetadataResult][];
+  }) as [string, InsightResult | DuplicateFilesInsightResult | StripBinaryInsightResult | LooseImagesInsightResult | MainBinaryExportMetadataResult | FileSavingsInsightResult][];
 
   if (insightEntries.length === 0) {
     return null;
@@ -596,8 +614,67 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
                   </div>
                 );
               })()
+            ) : ['large_images', 'large_videos', 'large_audio', 'hermes_debug_info', 'unnecessary_files', 'localized_strings', 'small_files'].includes(key) ? (
+              // Handle insights that now use FileSavingsResult format
+              (() => {
+                const fileSavingsInsight = insight as FileSavingsInsightResult;
+                return fileSavingsInsight.files && fileSavingsInsight.files.length > 0 && (
+                  <div>
+                    <h4 style={{
+                      margin: '0 0 0.75rem 0',
+                      color: '#495057',
+                      fontSize: '1rem',
+                      fontWeight: '600'
+                    }}>
+                      Affected Files ({fileSavingsInsight.files.length})
+                    </h4>
+                    <div style={{
+                      backgroundColor: '#f8f9fa',
+                      borderRadius: '6px',
+                      padding: '0.75rem',
+                      maxHeight: '200px',
+                      overflowY: 'auto'
+                    }}>
+                      {fileSavingsInsight.files.map((file, index) => (
+                        <div
+                          key={index}
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            padding: '0.4rem 0',
+                            borderBottom: index < fileSavingsInsight.files.length - 1 ? '1px solid #e9ecef' : 'none',
+                            fontSize: '0.85rem'
+                          }}
+                        >
+                          <div style={{
+                            flex: 1,
+                            color: '#495057',
+                            fontFamily: 'monospace',
+                            fontSize: '0.8rem',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            marginRight: '1rem'
+                          }}>
+                            {file.file_path}
+                          </div>
+                          <div style={{
+                            color: '#28a745',
+                            fontSize: '0.8rem',
+                            fontWeight: '600',
+                            flexShrink: 0
+                          }}>
+                            {formatSize(file.total_savings)} savings
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()
             ) : (
-              // Handle regular insights with files array
+              // Handle regular insights with files array (legacy format)
               (() => {
                 const regularInsight = insight as InsightResult;
                 return regularInsight.files && regularInsight.files.length > 0 && (

--- a/web/src/components/InsightsDisplay.tsx
+++ b/web/src/components/InsightsDisplay.tsx
@@ -257,7 +257,7 @@ const InsightsDisplay: React.FC<InsightsDisplayProps> = ({ data }) => {
                               fontWeight: '600',
                               fontSize: '0.9rem'
                             }}>
-                              📄 {group.filename}
+                              📄 {group.filename} ({group.files.length} files)
                             </div>
                             <div style={{
                               color: '#28a745',

--- a/web/src/utils/dataConverter.ts
+++ b/web/src/utils/dataConverter.ts
@@ -5,7 +5,7 @@ interface FileAnalysisFile {
   path: string;
   size: number;
   file_type: string;
-  hash_md5: string;
+  hash: string;
 }
 
 interface FileAnalysisData {
@@ -76,7 +76,7 @@ export interface LooseImageGroup {
     path: string;
     size: number;
     file_type: string;
-    hash_md5: string;
+    hash: string;
   }[];
   total_savings: number;
 }


### PR DESCRIPTION
- Fixes bug where Watch/AppExtension binaries weren't considered for the export metadata insight
- Fixes the duplicate files insight to group the results by file, previously everything was flat. Also fixes some edge cases where it would report duplicates within nested folders.
  - Added special grouping for `.bundle` folders and allowlisted `.xcprivacy` files
- Introduces a new `FileSavingsResult` to share amongst insights which is more slimmed down and should make the response JSON smaller.