### PR TITLE
Use new kafka SASL fields

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -47,6 +47,10 @@ def create_kafka_consumer(
         "arroyo.strict.offset.reset": config["arroyo_strict_offset_reset"],
         "enable.auto.commit": False,
         "enable.auto.offset.store": False,
+        "security.protocol": config["security.protocol"],
+        "sasl.mechanism": config["sasl.mechanism"],
+        "sasl.username": config["sasl.username"],
+        "sasl.password": config["sasl.password"],
     }
 
     arroyo_consumer = ArroyoKafkaConsumer(consumer_config)


### PR DESCRIPTION
In https://github.com/getsentry/launchpad/pull/238 I introduced these new fields but forgot to actually pass them thru to the usage in `create_kafka_consumer`