### PR TITLE
Add gocd stage to deploy canary before rest

### DIFF
--- a/gocd/templates/launchpad.jsonnet
+++ b/gocd/templates/launchpad.jsonnet
@@ -24,7 +24,7 @@ local pipedream_config = {
   },
   rollback: {
     material_name: 'launchpad_repo',
-    stage: 'deploy_primary',
+    stage: 'deploy-primary',
     elastic_profile_id: 'launchpad',
   },
 };

--- a/gocd/templates/pipelines/launchpad.libsonnet
+++ b/gocd/templates/pipelines/launchpad.libsonnet
@@ -17,7 +17,27 @@ function(region) {
   lock_behavior: 'unlockWhenFinished',
   stages: [
     {
-      deploy_primary: {
+      'deploy-canary': {
+        approval: {
+          type: 'success',
+        },
+        fetch_materials: true,
+        jobs: {
+          deploy: {
+            timeout: 1200,
+            elastic_profile_id: 'launchpad',
+            environment_variables: {
+              LABEL_SELECTOR: 'service=launchpad,env=canary',
+            },
+            tasks: [
+              gocdtasks.script(importstr '../bash/deploy.sh'),
+            ],
+          },
+        },
+      },
+    },
+    {
+      'deploy-primary': {
         approval: {
           type: 'success',
         },


### PR DESCRIPTION
This adds an additional stage prior to `deploy-primary` which deploys to the canary
deployment (`launchpad-production-canary`) named `deploy-canary`.

We don't do anything additional to check the deployment is working beyond the existing
ready checks done by k8s. In particular we don't run the `checks-canary-canarychecks`
script which is a pure 'wait N minutes' script and not currently that useful for us.

We use the label selector:
```
LABEL_SELECTOR: 'service=launchpad,env=canary'
```
for the `deploy-canary` and the selector:
```
LABEL_SELECTOR: 'service=launchpad'
```
for the primary deploy. This matches what the other Sentry pipelines do.
I don't know if that means we end up deploying to `launchpad-production-canary`
twice (once in each stage) or if something is clever enough not redeploy the same
code. In any case this seems important since I believe the 'rollback' workflow
*only* runs `deploy-primary` but should cover everything.

Additionally rename deploy_primary to deploy-primary to better match other Sentry services.