### PR TITLE
Treemap data cleanup + minify

### DIFF
--- a/src/launchpad/size/models/treemap.py
+++ b/src/launchpad/size/models/treemap.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -87,16 +87,11 @@ class TreemapElement(BaseModel):
 
     name: str = Field(..., description="Display name of the element")
     size: int = Field(..., ge=0, description="Install size in bytes")
-    element_type: TreemapType | None = Field(None, description="Type of element for visualization")
+    type: TreemapType | None = Field(None, description="Type of element for visualization")
     path: str | None = Field(None, description="Relative file or directory path")
-    is_directory: bool = Field(False, description="Whether this element represents a directory")
+    is_dir: bool = Field(False, description="Whether this element represents a directory")
+    """ Some files (like zip files) are not directories but have children. """
     children: List[TreemapElement] = Field(default_factory=list, description="Child elements")
-    details: Dict[str, Any] = Field(default_factory=dict, description="Platform and context-specific metadata")
-
-    @property
-    def is_leaf(self) -> bool:
-        """Check if this is a leaf node (no children)."""
-        return len(self.children) == 0
 
 
 class TreemapResults(BaseModel):

--- a/src/launchpad/size/runner.py
+++ b/src/launchpad/size/runner.py
@@ -70,4 +70,4 @@ def do_size(
 
 
 def write_results_as_json(results: BaseAnalysisResults, out: TextIO) -> None:
-    json.dump(results.to_dict(), out, indent=2, ensure_ascii=False)
+    json.dump(results.to_dict(), out, ensure_ascii=False, separators=(",", ":"))

--- a/src/launchpad/size/treemap/default_file_element_builder.py
+++ b/src/launchpad/size/treemap/default_file_element_builder.py
@@ -9,21 +9,11 @@ from launchpad.utils.file_utils import to_nearest_block_size
 class DefaultFileElementBuilder(TreemapElementBuilder):
     def build_element(self, file_info: FileInfo, display_name: str) -> TreemapElement:
         size = to_nearest_block_size(file_info.size, self.filesystem_block_size)
-
-        details: dict[str, object] = {
-            "hash": file_info.hash,  # File hash for deduplication
-        }
-
-        # Add file extension only for actual files (not binary subsections)
-        if file_info.file_type and file_info.file_type != "unknown":
-            details["fileExtension"] = file_info.file_type
-
         return TreemapElement(
             name=display_name,
             size=size,
-            element_type=file_info.treemap_type,
+            type=file_info.treemap_type,
             path=file_info.path,
-            is_directory=False,
-            details=details,
+            is_dir=False,
             children=[self.build_element(child, os.path.basename(child.path)) for child in file_info.children],
         )

--- a/src/launchpad/size/treemap/dex_element_builder.py
+++ b/src/launchpad/size/treemap/dex_element_builder.py
@@ -29,19 +29,13 @@ class DexElementBuilder(TreemapElementBuilder):
 
         root_packages = self._build_package_tree()
 
-        details = {
-            "fileExtension": file_info.file_type,
-            "class_count": len(self.class_definitions),
-        }
-
         return TreemapElement(
             name=display_name,
             size=size,
-            element_type=TreemapType.DEX,
+            type=TreemapType.DEX,
             path=file_info.path,
-            is_directory=True,
+            is_dir=True,
             children=root_packages,
-            details=details,
         )
 
     def _build_package_tree(self) -> list[TreemapElement]:
@@ -89,19 +83,14 @@ class DexElementBuilder(TreemapElementBuilder):
 
                 total_size = sum(child.size for child in children)
 
-                details = {
-                    "class_count": len([child for child in children if not child.is_directory]),
-                }
-
                 elements.append(
                     TreemapElement(
                         name=name,
                         size=total_size,
-                        element_type=TreemapType.DEX,
+                        type=TreemapType.DEX,
                         path=package_path,
-                        is_directory=True,
+                        is_dir=True,
                         children=children,
-                        details=details,
                     )
                 )
 
@@ -110,17 +99,11 @@ class DexElementBuilder(TreemapElementBuilder):
     def _create_class_element(self, class_def: ClassDefinition) -> TreemapElement:
         class_size = class_def.size
 
-        details = {
-            "fqn": class_def.fqn(),
-            "source_file": class_def.source_file_name,
-        }
-
         return TreemapElement(
             name=class_def.get_name(),
             size=class_size,
-            element_type=TreemapType.DEX,
+            type=TreemapType.DEX,
             path=class_def.fqn(),
-            is_directory=False,
+            is_dir=False,
             children=[],
-            details=details,
         )

--- a/src/launchpad/size/treemap/hermes_element_builder.py
+++ b/src/launchpad/size/treemap/hermes_element_builder.py
@@ -66,14 +66,10 @@ class HermesElementBuilder(TreemapElementBuilder):
             element = TreemapElement(
                 name=section_name,
                 size=section_info["bytes"],
-                element_type=treemap_type,
+                type=treemap_type,
                 path=None,
-                is_directory=False,
+                is_dir=False,
                 children=[],
-                details={
-                    "percentage": section_info["percentage"],
-                    "section_type": section_name,
-                },
             )
 
             if "string" in section_name.lower() or "identifier" in section_name.lower():
@@ -90,11 +86,10 @@ class HermesElementBuilder(TreemapElementBuilder):
                 TreemapElement(
                     name="Strings & Identifiers",
                     size=string_total,
-                    element_type=TreemapType.STRINGS,
+                    type=TreemapType.STRINGS,
                     path=None,
-                    is_directory=True,
+                    is_dir=True,
                     children=string_sections,
-                    details={"category": "strings"},
                 )
             )
         else:
@@ -106,11 +101,10 @@ class HermesElementBuilder(TreemapElementBuilder):
                 TreemapElement(
                     name="Functions",
                     size=function_total,
-                    element_type=TreemapType.METHODS,
+                    type=TreemapType.METHODS,
                     path=None,
-                    is_directory=True,
+                    is_dir=True,
                     children=function_sections,
-                    details={"category": "functions"},
                 )
             )
         else:
@@ -125,14 +119,10 @@ class HermesElementBuilder(TreemapElementBuilder):
                 TreemapElement(
                     name="Unattributed",
                     size=report["unattributed"]["bytes"],
-                    element_type=TreemapType.BINARY,
+                    type=TreemapType.BINARY,
                     path=None,
-                    is_directory=False,
+                    is_dir=False,
                     children=[],
-                    details={
-                        "percentage": report["unattributed"]["percentage"],
-                        "section_type": "unattributed",
-                    },
                 )
             )
 
@@ -141,14 +131,10 @@ class HermesElementBuilder(TreemapElementBuilder):
         return TreemapElement(
             name=name,
             size=total_size,
-            element_type=TreemapType.BINARY,
+            type=TreemapType.BINARY,
             path=file_path,
-            is_directory=True,
+            is_dir=True,
             children=section_children,
-            details={
-                "file_size": report["file_size"],
-                "bytecode_type": "hermes",
-            },
         )
 
     def _get_treemap_type_for_section(self, section_name: str) -> TreemapType:

--- a/src/launchpad/size/treemap/macho_element_builder.py
+++ b/src/launchpad/size/treemap/macho_element_builder.py
@@ -49,9 +49,9 @@ class MachOElementBuilder(TreemapElementBuilder):
         return TreemapElement(
             name=display_name,
             size=file_info.size,
-            element_type=TreemapType.EXECUTABLES,
+            type=TreemapType.EXECUTABLES,
             path=file_info.path,
-            is_directory=False,
+            is_dir=False,
             children=children,
         )
 
@@ -161,9 +161,9 @@ class MachOElementBuilder(TreemapElementBuilder):
                             self_elem = TreemapElement(
                                 name=node["type_name"],
                                 size=node["self_size"],
-                                element_type=TreemapType.MODULES,
+                                type=TreemapType.MODULES,
                                 path=None,
-                                is_directory=False,
+                                is_dir=False,
                                 children=[],
                             )
                             child_elems.append(self_elem)
@@ -178,9 +178,9 @@ class MachOElementBuilder(TreemapElementBuilder):
                             TreemapElement(
                                 name=node["type_name"],
                                 size=total_size,
-                                element_type=TreemapType.MODULES,
+                                type=TreemapType.MODULES,
                                 path=None,
-                                is_directory=False,
+                                is_dir=False,
                                 children=child_elems,
                             )
                         )
@@ -194,9 +194,9 @@ class MachOElementBuilder(TreemapElementBuilder):
                     TreemapElement(
                         name=module_name,
                         size=module_total_size,
-                        element_type=TreemapType.MODULES,
+                        type=TreemapType.MODULES,
                         path=None,
-                        is_directory=False,
+                        is_dir=False,
                         children=module_children,
                     )
                 )
@@ -218,9 +218,9 @@ class MachOElementBuilder(TreemapElementBuilder):
                     TreemapElement(
                         name=meth_name,
                         size=size,
-                        element_type=TreemapType.MODULES,
+                        type=TreemapType.MODULES,
                         path=None,
-                        is_directory=False,
+                        is_dir=False,
                         children=[],
                     )
                     for meth_name, size in meths
@@ -229,9 +229,9 @@ class MachOElementBuilder(TreemapElementBuilder):
                     TreemapElement(
                         name=cls_name,
                         size=sum(m.size for m in meth_elems),
-                        element_type=TreemapType.MODULES,
+                        type=TreemapType.MODULES,
                         path=None,
-                        is_directory=True,
+                        is_dir=True,
                         children=meth_elems,
                     )
                 )
@@ -261,15 +261,10 @@ class MachOElementBuilder(TreemapElementBuilder):
             elem = TreemapElement(
                 name=section_name,
                 size=adjusted,
-                element_type=element_type,
+                type=element_type,
                 path=None,
-                is_directory=False,
+                is_dir=False,
                 children=[],
-                details={
-                    "tag": first_tag,
-                    "component_name": section_name,
-                    "adjusted_size": adjusted,
-                },
             )
 
             is_dyld = (
@@ -284,11 +279,10 @@ class MachOElementBuilder(TreemapElementBuilder):
                 TreemapElement(
                     name="DYLD",
                     size=dyld_total,
-                    element_type=TreemapType.DYLD,
+                    type=TreemapType.DYLD,
                     path=None,
-                    is_directory=True,
+                    is_dir=True,
                     children=dyld_children,
-                    details={"tag": "dyld"},
                 )
             )
 
@@ -298,9 +292,9 @@ class MachOElementBuilder(TreemapElementBuilder):
                 TreemapElement(
                     name="Unanalyzed",
                     size=int(binary_component_analysis.unanalyzed_size),
-                    element_type=TreemapType.UNMAPPED,
+                    type=TreemapType.UNMAPPED,
                     path=None,
-                    is_directory=False,
+                    is_dir=False,
                     children=[],
                 )
             )

--- a/src/launchpad/size/treemap/treemap_builder.py
+++ b/src/launchpad/size/treemap/treemap_builder.py
@@ -60,9 +60,9 @@ class TreemapBuilder:
         root = TreemapElement(
             name=self.app_name,
             size=total_size,
-            element_type=None,
+            type=None,
             path=None,
-            is_directory=True,  # Root app element is treated as a directory
+            is_dir=True,  # Root app element is treated as a directory
             children=children,
         )
 
@@ -204,9 +204,9 @@ class TreemapBuilder:
             return TreemapElement(
                 name=dir_name,
                 size=total_size,
-                element_type=self._get_directory_type(dir_name),
+                type=self._get_directory_type(dir_name),
                 path=dir_path,
-                is_directory=True,
+                is_dir=True,
                 children=children,
             )
 

--- a/tests/integration/size/test_treemap_generation.py
+++ b/tests/integration/size/test_treemap_generation.py
@@ -91,7 +91,7 @@ class TestTreemapGeneration:
         assert manifest is not None
         manifest_size = manifest.size
         assert manifest_size == 20480
-        manifest_element_type = manifest.element_type
+        manifest_element_type = manifest.type
         assert manifest_element_type == "manifests"
 
         # Verify classes.dex exists
@@ -99,7 +99,7 @@ class TestTreemapGeneration:
         assert dex is not None
         dex_size = dex.size
         assert dex_size == 4363232
-        dex_element_type = dex.element_type
+        dex_element_type = dex.type
         assert dex_element_type == "dex"
 
         # Verify resources.arsc exists
@@ -107,7 +107,7 @@ class TestTreemapGeneration:
         assert resources is not None
         resources_size = resources.size
         assert resources_size == 94208
-        resources_element_type = resources.element_type
+        resources_element_type = resources.type
         assert resources_element_type == "resources"
 
         # Verify expected totals
@@ -178,7 +178,7 @@ class TestTreemapGeneration:
         assert manifest is not None
         manifest_size = manifest.size
         assert manifest_size == 24576
-        manifest_element_type = manifest.element_type
+        manifest_element_type = manifest.type
         assert manifest_element_type == "manifests"
 
         # Verify classes.dex exists
@@ -186,7 +186,7 @@ class TestTreemapGeneration:
         assert dex is not None
         dex_size = dex.size
         assert dex_size == 4363232
-        dex_element_type = dex.element_type
+        dex_element_type = dex.type
         assert dex_element_type == "dex"
 
         # Verify resources.arsc exists
@@ -194,7 +194,7 @@ class TestTreemapGeneration:
         assert resources is not None
         resources_size = resources.size
         assert resources_size == 24576
-        resources_element_type = resources.element_type
+        resources_element_type = resources.type
         assert resources_element_type == "resources"
 
         # Verify category breakdown exists
@@ -228,7 +228,7 @@ class TestTreemapGeneration:
         root_data = treemap_dict["root"]
         assert "name" in root_data
         assert "size" in root_data
-        assert "is_directory" in root_data
+        assert "is_dir" in root_data
         assert "children" in root_data
 
         # Verify children have expected structure
@@ -239,7 +239,7 @@ class TestTreemapGeneration:
         for child in children:
             assert "name" in child
             assert "size" in child
-            assert "is_directory" in child
+            assert "is_dir" in child
 
         # Test that it's actually serializable to JSON
         json_str = json.dumps(treemap_dict)
@@ -277,7 +277,7 @@ class TestTreemapGeneration:
         root_data = treemap_dict["root"]
         assert "name" in root_data
         assert "size" in root_data
-        assert "is_directory" in root_data
+        assert "is_dir" in root_data
         assert "children" in root_data
 
         # Verify children have expected structure
@@ -288,7 +288,7 @@ class TestTreemapGeneration:
         for child in children:
             assert "name" in child
             assert "size" in child
-            assert "is_directory" in child
+            assert "is_dir" in child
 
         # Test that it's actually serializable to JSON
         json_str = json.dumps(treemap_dict)
@@ -349,9 +349,9 @@ class TestTreemapGeneration:
         # Verify root node
         root_name = treemap.root.name
         assert root_name == "HackerNews"
-        root_is_directory = treemap.root.is_directory
-        assert root_is_directory is True
-        root_element_type = treemap.root.element_type
+        root_is_dir = treemap.root.is_dir
+        assert root_is_dir is True
+        root_element_type = treemap.root.type
         assert root_element_type is None
 
         # Verify main executable
@@ -359,10 +359,10 @@ class TestTreemapGeneration:
         assert main_exe is not None
         # main_exe_size = main_exe.size
         # assert main_exe_size == 3190648
-        main_exe_element_type = main_exe.element_type
+        main_exe_element_type = main_exe.type
         assert main_exe_element_type == "executables"
-        main_exe_is_directory = main_exe.is_directory
-        assert main_exe_is_directory is False
+        main_exe_is_dir = main_exe.is_dir
+        assert main_exe_is_dir is False
 
         # Verify main executable sections
         main_exe_sections = {child.name: child for child in main_exe.children}
@@ -382,74 +382,74 @@ class TestTreemapGeneration:
         # Verify Frameworks directory
         frameworks = find_node_by_path(treemap.root, "Frameworks")
         assert frameworks is not None
-        frameworks_element_type = frameworks.element_type
+        frameworks_element_type = frameworks.type
         assert frameworks_element_type == "frameworks"
-        frameworks_is_directory = frameworks.is_directory
-        assert frameworks_is_directory is True
+        frameworks_is_dir = frameworks.is_dir
+        assert frameworks_is_dir is True
 
         # Verify Sentry framework
         sentry = find_node_by_path(treemap.root, "Frameworks/Sentry.framework")
         assert sentry is not None
-        sentry_element_type = sentry.element_type
+        sentry_element_type = sentry.type
         assert sentry_element_type == "frameworks"
-        sentry_is_directory = sentry.is_directory
-        assert sentry_is_directory is True
+        sentry_is_dir = sentry.is_dir
+        assert sentry_is_dir is True
 
         # Verify Sentry binary
         sentry_binary = find_node_by_path(treemap.root, "Frameworks/Sentry.framework/Sentry")
         assert sentry_binary is not None
         sentry_binary_size = sentry_binary.size
         assert sentry_binary_size == 53248
-        sentry_binary_element_type = sentry_binary.element_type
+        sentry_binary_element_type = sentry_binary.type
         assert sentry_binary_element_type == "executables"
 
         # Verify Common framework
         common = find_node_by_path(treemap.root, "Frameworks/Common.framework")
         assert common is not None
-        common_element_type = common.element_type
+        common_element_type = common.type
         assert common_element_type == "frameworks"
-        common_is_directory = common.is_directory
-        assert common_is_directory is True
+        common_is_dir = common.is_dir
+        assert common_is_dir is True
 
         # Verify Common binary
         common_binary = find_node_by_path(treemap.root, "Frameworks/Common.framework/Common")
         assert common_binary is not None
         # common_binary_size = common_binary.size
         # assert common_binary_size == 199376
-        common_binary_element_type = common_binary.element_type
+        common_binary_element_type = common_binary.type
         assert common_binary_element_type == "executables"
 
         # Verify Reaper framework
         reaper = find_node_by_path(treemap.root, "Frameworks/Reaper.framework")
         assert reaper is not None
-        reaper_element_type = reaper.element_type
+        reaper_element_type = reaper.type
         assert reaper_element_type == "frameworks"
-        reaper_is_directory = reaper.is_directory
-        assert reaper_is_directory is True
+        reaper_is_dir = reaper.is_dir
+        assert reaper_is_dir is True
 
         # Verify Reaper binary
         reaper_binary = find_node_by_path(treemap.root, "Frameworks/Reaper.framework/Reaper")
         assert reaper_binary is not None
         # reaper_binary_size = reaper_binary.size
         # assert reaper_binary_size == 51440
-        reaper_binary_element_type = reaper_binary.element_type
+        reaper_binary_element_type = reaper_binary.type
         assert reaper_binary_element_type == "executables"
 
         # Verify PlugIns directory
         plugins = find_node_by_path(treemap.root, "PlugIns")
         assert plugins is not None
-        plugins_element_type = plugins.element_type
+        plugins_element_type = plugins.type
         assert plugins_element_type == "extensions"
-        plugins_is_directory = plugins.is_directory
-        assert plugins_is_directory is True
+        plugins_is_dir = plugins.is_dir
+        assert plugins_is_dir is True
 
         # Verify HomeWidget extension
         widget = find_node_by_path(treemap.root, "PlugIns/HackerNewsHomeWidgetExtension.appex")
         assert widget is not None
-        widget_element_type = widget.element_type
+        widget_element_type = widget.type
         assert widget_element_type == "extensions"
-        widget_is_directory = widget.is_directory
-        assert widget_is_directory is True
+        widget_is_dir = widget.is_dir
+        assert widget_is_dir is True
 
         # Verify widget binary
         widget_binary = find_node_by_path(
@@ -459,7 +459,7 @@ class TestTreemapGeneration:
         assert widget_binary is not None
         # widget_binary_size = widget_binary.size
         # assert widget_binary_size == 153016
-        widget_binary_element_type = widget_binary.element_type
+        widget_binary_element_type = widget_binary.type
         assert widget_binary_element_type == "executables"
 
         # Verify Assets.car
@@ -467,7 +467,7 @@ class TestTreemapGeneration:
         assert assets is not None
         # assets_size = assets.size
         # assert assets_size == 4788000
-        assets_element_type = assets.element_type
+        assets_element_type = assets.type
         assert assets_element_type == "assets"
         assets_children_len = len(assets.children)
         assert assets_children_len == 14
@@ -531,12 +531,12 @@ class TestTreemapGeneration:
         assert app_view_model is not None
         app_view_model_size = app_view_model.size
         assert app_view_model_size == 25648
-        app_view_model_element_type = app_view_model.element_type
+        app_view_model_element_type = app_view_model.type
         assert app_view_model_element_type == "modules"
 
         app_view_model = find_node_by_name(treemap.root, "SentryUserFeedbackFormViewModel")
         assert app_view_model is not None
         app_view_model_size = app_view_model.size
         assert app_view_model_size == 27620
-        app_view_model_element_type = app_view_model.element_type
+        app_view_model_element_type = app_view_model.type
         assert app_view_model_element_type == "modules"

--- a/web/src/components/TreemapVisualization.tsx
+++ b/web/src/components/TreemapVisualization.tsx
@@ -84,7 +84,7 @@ function convertToEChartsData(
   sizeMode: 'install' | 'download'
 ): EChartsTreemapData {
   const size = sizeMode === 'install' ? element.install_size : element.download_size;
-  const color = element.element_type ? TYPE_COLORS[element.element_type] : TYPE_COLORS[TreemapType.OTHER];
+  const color = element.type ? TYPE_COLORS[element.type] : TYPE_COLORS[TreemapType.OTHER];
 
   const data: EChartsTreemapData = {
     name: element.name,

--- a/web/src/types/treemap.ts
+++ b/web/src/types/treemap.ts
@@ -45,19 +45,15 @@ export interface TreemapElement {
   /** Display name of the element */
   name: string;
   /** Install size in bytes */
-  install_size: number;
-  /** Download size in bytes (compressed) */
-  download_size: number;
+  size: number;
   /** Type of element for visualization */
-  element_type?: TreemapType;
+  type?: TreemapType;
   /** File or directory path */
   path?: string;
   /** Whether this element represents a directory */
-  is_directory: boolean;
+  is_dir: boolean;
   /** Child elements */
   children: TreemapElement[];
-  /** Platform and context-specific metadata */
-  details: Record<string, unknown>;
 }
 
 export interface TreemapResults {


### PR DESCRIPTION
Removes stuff that isn't being used and stops pretty-printing the JSON. This reduces some JSON for a test app from 45MB -> 13MB in testing.