### PR TITLE
Configure SASL for Kafka when present

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -51,13 +51,13 @@ def create_kafka_consumer(
         "arroyo.strict.offset.reset": config["arroyo_strict_offset_reset"],
         "enable.auto.commit": False,
         "enable.auto.offset.store": False,
+        "security.protocol": config["security.protocol"],
     }
 
-    # Only include security fields in non-development environments
-    if environment != "development":
+    # SASL is used in some prod environments.
+    if config["sasl.mechanism"]:
         consumer_config.update(
             {
-                "security.protocol": config["security.protocol"],
                 "sasl.mechanism": config["sasl.mechanism"],
                 "sasl.username": config["sasl.username"],
                 "sasl.password": config["sasl.password"],


### PR DESCRIPTION
Although SASL is not present in dev environments:
- it is also not present is *all* prod environments
- we do not yet correctly set LAUNCHPAD_ENV in prod

Change Kafka setup to use SASL when available.
