### PR TITLE
hide kafka healthcheck logs for now

### DIFF
--- a/src/launchpad/server.py
+++ b/src/launchpad/server.py
@@ -263,10 +263,9 @@ class LaunchpadServer:
 
     async def ready_check(self, request: Request) -> Response:
         """Readiness check endpoint."""
-        logger.info("Ready check endpoint called - performing health check for logging")
 
         # Call health check for detailed logging but ignore the result
-        await self._log_health_check_details()
+        # await self._log_health_check_details()
 
         # TODO: Add actual readiness checks (database connectivity, etc.)
         return web.json_response(


### PR DESCRIPTION
now that the kafka healthcheck is "resolved" for now, lets hide these logs so we can debug other logic during s4s launch