### PR TITLE
Stop building docker images on every PR

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,7 +1,4 @@
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
Hasn't caught anything. Our unit and integration tests should be sufficient for PR protection. Our canary and soak test stages should be enough to protect a bad prod deploy