### PR TITLE
SmallStrings insight fixes

### DIFF
--- a/src/launchpad/size/insights/apple/localized_strings.py
+++ b/src/launchpad/size/insights/apple/localized_strings.py
@@ -1,13 +1,24 @@
+import re
+
+from pathlib import Path
+
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.common import FileInfo
-from launchpad.size.models.insights import FileSavingsResult, LocalizedStringInsightResult
+from launchpad.size.models.insights import LocalizedStringInsightResult
 
 
 class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
-    """Insight for analyzing localized strings files in iOS apps."""
+    """Insight for analyzing localized strings files in iOS apps. If the total size of the localized strings files is greater than the threshold, we recommend using our SmallStrings library."""
 
-    # 100KB threshold for reporting localized strings
     THRESHOLD_BYTES = 100 * 1024  # 100KB
+
+    ESTIMATED_SAVINGS_RATIO = 0.8  # Based on our user testing
+
+    STRINGS_FILE_DENYLIST = ["LaunchScreen.strings"]
+
+    # Pattern to match .strings files directly inside .lproj directories
+    # Matches: en.lproj/Localizable.strings, Base.lproj/InfoPlist.strings
+    _LPROJ_STRINGS_PATTERN = re.compile(r"[^/]+\.lproj/[^/]+\.strings$")
 
     def generate(self, input: InsightsInput) -> LocalizedStringInsightResult | None:
         """Generate insight for localized strings files.
@@ -18,19 +29,18 @@ class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
         localized_files: list[FileInfo] = []
         total_size = 0
 
-        # Find all Localizable.strings files in *.lproj directories
+        # Find all .strings files in *.lproj directories
         for file_info in input.file_analysis.files:
-            # Check if file path ends with *.lproj/Localizable.strings
-            if file_info.path.endswith(".lproj/Localizable.strings"):
-                localized_files.append(file_info)
-                total_size += file_info.size
+            if self._LPROJ_STRINGS_PATTERN.search(file_info.path):
+                filename = Path(file_info.path).name
+                if filename not in self.STRINGS_FILE_DENYLIST:
+                    localized_files.append(file_info)
+                    total_size += file_info.size
 
-        if total_size > self.THRESHOLD_BYTES:
-            file_savings = [FileSavingsResult(file_path=file.path, total_savings=file.size) for file in localized_files]
-
+        estimated_savings = int(total_size * self.ESTIMATED_SAVINGS_RATIO)
+        if estimated_savings > self.THRESHOLD_BYTES:
             return LocalizedStringInsightResult(
-                files=file_savings,
-                total_savings=total_size,
+                total_savings=estimated_savings,
             )
 
         return None

--- a/src/launchpad/size/insights/apple/localized_strings.py
+++ b/src/launchpad/size/insights/apple/localized_strings.py
@@ -3,16 +3,13 @@ import re
 from pathlib import Path
 
 from launchpad.size.insights.insight import Insight, InsightsInput
-from launchpad.size.models.common import FileInfo
 from launchpad.size.models.insights import LocalizedStringInsightResult
 
 
 class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
     """Insight for analyzing localized strings files in iOS apps. If the total size of the localized strings files is greater than the threshold, we recommend using our SmallStrings library."""
 
-    THRESHOLD_BYTES = 100 * 1024  # 100KB
-
-    ESTIMATED_SAVINGS_RATIO = 0.8  # Based on our user testing
+    SAVINGS_THRESHOLD_BYTES = 100 * 1024  # 100KB
 
     STRINGS_FILE_DENYLIST = ["LaunchScreen.strings"]
 
@@ -26,7 +23,6 @@ class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
         Finds all Localizable.strings files in *.lproj directories,
         calculates total size, and returns insight if above threshold.
         """
-        localized_files: list[FileInfo] = []
         total_size = 0
 
         # Find all .strings files in *.lproj directories
@@ -34,13 +30,12 @@ class LocalizedStringsInsight(Insight[LocalizedStringInsightResult]):
             if self._LPROJ_STRINGS_PATTERN.search(file_info.path):
                 filename = Path(file_info.path).name
                 if filename not in self.STRINGS_FILE_DENYLIST:
-                    localized_files.append(file_info)
                     total_size += file_info.size
 
-        estimated_savings = int(total_size * self.ESTIMATED_SAVINGS_RATIO)
-        if estimated_savings > self.THRESHOLD_BYTES:
+        small_strings_savings = int(total_size * 0.5)
+        if small_strings_savings > self.SAVINGS_THRESHOLD_BYTES:
             return LocalizedStringInsightResult(
-                total_savings=estimated_savings,
+                total_savings=small_strings_savings,
             )
 
         return None

--- a/src/launchpad/size/models/insights.py
+++ b/src/launchpad/size/models/insights.py
@@ -108,7 +108,8 @@ class WebPOptimizationInsightResult(FilesInsightResult):
 class LocalizedStringInsightResult(BaseInsightResult):
     """Results from localized string analysis.
 
-    Files contain localized strings files exceeding 100KB threshold with their sizes.
+    Reports the total estimated savings that could be achieved by optimizing localized strings.
+
     """
 
     pass

--- a/src/launchpad/size/models/insights.py
+++ b/src/launchpad/size/models/insights.py
@@ -105,7 +105,7 @@ class WebPOptimizationInsightResult(FilesInsightResult):
     pass
 
 
-class LocalizedStringInsightResult(FilesInsightResult):
+class LocalizedStringInsightResult(BaseInsightResult):
     """Results from localized string analysis.
 
     Files contain localized strings files exceeding 100KB threshold with their sizes.

--- a/tests/unit/test_localized_strings_insight.py
+++ b/tests/unit/test_localized_strings_insight.py
@@ -18,7 +18,7 @@ class TestLocalizedStringsInsight:
         localized_file_1 = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=60 * 1024,  # 60KB
+            size=150 * 1024,  # 150KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
@@ -27,7 +27,7 @@ class TestLocalizedStringsInsight:
         localized_file_2 = FileInfo(
             full_path=Path("es.lproj/Localizable.strings"),
             path="es.lproj/Localizable.strings",
-            size=50 * 1024,  # 50KB
+            size=60 * 1024,  # 60KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
@@ -56,8 +56,8 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        # Total savings should be 50% of the total file size (110KB * 0.5 = 55KB)
-        expected_total_savings = int((60 + 50) * 1024 * 0.5)
+        # Total savings should be 50% of the total file size (210KB * 0.5 = 105KB)
+        expected_total_savings = int((150 + 60) * 1024 * 0.5)
         assert result.total_savings == expected_total_savings
 
     def test_generate_with_small_localized_strings(self):
@@ -175,7 +175,7 @@ class TestLocalizedStringsInsight:
         localizable_file = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=80 * 1024,  # 80KB
+            size=150 * 1024,  # 150KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
@@ -184,7 +184,7 @@ class TestLocalizedStringsInsight:
         infoplist_file = FileInfo(
             full_path=Path("en.lproj/InfoPlist.strings"),
             path="en.lproj/InfoPlist.strings",
-            size=50 * 1024,  # 50KB - should be included
+            size=100 * 1024,  # 100KB - should be included
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
@@ -213,8 +213,8 @@ class TestLocalizedStringsInsight:
 
         assert isinstance(result, LocalizedStringInsightResult)
         # Should include localizable and infoplist, but not launchscreen
-        # Total size: (80KB + 50KB) * 0.5 = 65KB savings
-        expected_savings = int((80 + 50) * 1024 * 0.5)
+        # Total size: (150KB + 100KB) * 0.5 = 125KB savings
+        expected_savings = int((150 + 100) * 1024 * 0.5)
         assert result.total_savings == expected_savings
 
     def test_generate_ignores_non_lproj_localizable_strings(self):
@@ -222,7 +222,7 @@ class TestLocalizedStringsInsight:
         valid_localized_file = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=150 * 1024,  # 150KB - should be included
+            size=250 * 1024,  # 250KB - should be included
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
@@ -250,8 +250,8 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        # Only the valid file should be included: 150KB * 0.5 = 75KB savings
-        expected_savings = int(150 * 1024 * 0.5)
+        # Only the valid file should be included: 250KB * 0.5 = 125KB savings
+        expected_savings = int(250 * 1024 * 0.5)
         assert result.total_savings == expected_savings
 
     def test_regex_pattern_matching(self):
@@ -285,6 +285,15 @@ class TestLocalizedStringsInsight:
                 hash="hash3",
                 is_dir=False,
             ),
+            FileInfo(
+                full_path=Path("some/path/en.lproj/file.strings"),  # Valid: frameworks can have .lproj dirs
+                path="some/path/en.lproj/file.strings",
+                size=50 * 1024,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash="hash5",
+                is_dir=False,
+            ),
         ]
 
         # Invalid patterns that should NOT match
@@ -296,15 +305,6 @@ class TestLocalizedStringsInsight:
                 file_type="strings",
                 treemap_type=TreemapType.RESOURCES,
                 hash="hash4",
-                is_dir=False,
-            ),
-            FileInfo(
-                full_path=Path("some/path/en.lproj/file.strings"),  # Has path before .lproj
-                path="some/path/en.lproj/file.strings",
-                size=50 * 1024,
-                file_type="strings",
-                treemap_type=TreemapType.RESOURCES,
-                hash="hash5",
                 is_dir=False,
             ),
             FileInfo(
@@ -331,6 +331,7 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        # Should only include valid files: (250 + 30 + 20) * 1024 * 0.5 = 150KB
-        expected_savings = int((250 + 30 + 20) * 1024 * 0.5)
+        # Should include valid files: (250 + 30 + 20 + 50) * 1024 * 0.5 = 175KB
+        # Note: some/path/en.lproj/file.strings is valid (frameworks can have .lproj dirs)
+        expected_savings = int((250 + 30 + 20 + 50) * 1024 * 0.5)
         assert result.total_savings == expected_savings

--- a/tests/unit/test_localized_strings_insight.py
+++ b/tests/unit/test_localized_strings_insight.py
@@ -56,17 +56,17 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        # Total savings should be 80% of the total file size (110KB * 0.8 = 88KB)
-        expected_total_savings = int((60 + 50) * 1024 * 0.8)
+        # Total savings should be 50% of the total file size (110KB * 0.5 = 55KB)
+        expected_total_savings = int((60 + 50) * 1024 * 0.5)
         assert result.total_savings == expected_total_savings
 
     def test_generate_with_small_localized_strings(self):
         """Test that no insight is generated when estimated savings is below 100KB threshold."""
-        # Create localized strings files where estimated savings (80%) don't exceed 100KB
+        # Create localized strings files where estimated savings (50%) don't exceed 100KB
         localized_file_1 = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=60 * 1024,  # 60KB * 0.8 = 48KB savings
+            size=60 * 1024,  # 60KB * 0.5 = 30KB savings
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
@@ -75,7 +75,7 @@ class TestLocalizedStringsInsight:
         localized_file_2 = FileInfo(
             full_path=Path("es.lproj/Localizable.strings"),
             path="es.lproj/Localizable.strings",
-            size=50 * 1024,  # 50KB * 0.8 = 40KB savings (total 88KB < 100KB threshold)
+            size=50 * 1024,  # 50KB * 0.5 = 25KB savings (total 55KB < 100KB threshold)
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
@@ -97,11 +97,11 @@ class TestLocalizedStringsInsight:
 
     def test_generate_with_exactly_threshold_size(self):
         """Test that insight is generated when estimated savings exceeds 100KB threshold."""
-        # Need 125KB to get exactly 100KB savings (125KB * 0.8 = 100KB)
+        # Need 200KB to get exactly 100KB savings (200KB * 0.5 = 100KB)
         localized_file = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=125 * 1024,  # 125KB * 0.8 = 100KB savings
+            size=200 * 1024,  # 200KB * 0.5 = 100KB savings
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
@@ -213,8 +213,8 @@ class TestLocalizedStringsInsight:
 
         assert isinstance(result, LocalizedStringInsightResult)
         # Should include localizable and infoplist, but not launchscreen
-        # Total size: (80KB + 50KB) * 0.8 = 104KB savings
-        expected_savings = int((80 + 50) * 1024 * 0.8)
+        # Total size: (80KB + 50KB) * 0.5 = 65KB savings
+        expected_savings = int((80 + 50) * 1024 * 0.5)
         assert result.total_savings == expected_savings
 
     def test_generate_ignores_non_lproj_localizable_strings(self):
@@ -250,8 +250,8 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        # Only the valid file should be included: 150KB * 0.8 = 120KB savings
-        expected_savings = int(150 * 1024 * 0.8)
+        # Only the valid file should be included: 150KB * 0.5 = 75KB savings
+        expected_savings = int(150 * 1024 * 0.5)
         assert result.total_savings == expected_savings
 
     def test_regex_pattern_matching(self):
@@ -261,7 +261,7 @@ class TestLocalizedStringsInsight:
             FileInfo(
                 full_path=Path("en.lproj/Localizable.strings"),
                 path="en.lproj/Localizable.strings",
-                size=130 * 1024,  # Large enough to trigger insight after 0.8 ratio
+                size=250 * 1024,  # Large enough to trigger insight after 0.5 ratio
                 file_type="strings",
                 treemap_type=TreemapType.RESOURCES,
                 hash="hash1",
@@ -331,6 +331,6 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        # Should only include valid files: (130 + 30 + 20) * 1024 * 0.8 = 144KB
-        expected_savings = int((130 + 30 + 20) * 1024 * 0.8)
+        # Should only include valid files: (250 + 30 + 20) * 1024 * 0.5 = 150KB
+        expected_savings = int((250 + 30 + 20) * 1024 * 0.5)
         assert result.total_savings == expected_savings

--- a/tests/unit/test_localized_strings_insight.py
+++ b/tests/unit/test_localized_strings_insight.py
@@ -56,21 +56,17 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        assert len(result.files) == 2
-        assert result.total_savings == 110 * 1024  # 110KB total
-        assert result.files[0].file_path == "en.lproj/Localizable.strings"
-        assert result.files[1].file_path == "es.lproj/Localizable.strings"
-        # Verify savings match file sizes
-        assert result.files[0].total_savings == 60 * 1024
-        assert result.files[1].total_savings == 50 * 1024
+        # Total savings should be 80% of the total file size (110KB * 0.8 = 88KB)
+        expected_total_savings = int((60 + 50) * 1024 * 0.8)
+        assert result.total_savings == expected_total_savings
 
     def test_generate_with_small_localized_strings(self):
-        """Test that no insight is generated when total size is below 100KB threshold."""
-        # Create localized strings files that don't exceed 100KB total
+        """Test that no insight is generated when estimated savings is below 100KB threshold."""
+        # Create localized strings files where estimated savings (80%) don't exceed 100KB
         localized_file_1 = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=40 * 1024,  # 40KB
+            size=60 * 1024,  # 60KB * 0.8 = 48KB savings
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
@@ -79,7 +75,7 @@ class TestLocalizedStringsInsight:
         localized_file_2 = FileInfo(
             full_path=Path("es.lproj/Localizable.strings"),
             path="es.lproj/Localizable.strings",
-            size=30 * 1024,  # 30KB
+            size=50 * 1024,  # 50KB * 0.8 = 40KB savings (total 88KB < 100KB threshold)
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
@@ -97,14 +93,15 @@ class TestLocalizedStringsInsight:
 
         result = self.insight.generate(insights_input)
 
-        assert result is None  # Should return None when below threshold
+        assert result is None  # Should return None when estimated savings below threshold
 
     def test_generate_with_exactly_threshold_size(self):
-        """Test that insight is generated when total size exactly equals 100KB threshold."""
+        """Test that insight is generated when estimated savings exceeds 100KB threshold."""
+        # Need 125KB to get exactly 100KB savings (125KB * 0.8 = 100KB)
         localized_file = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=100 * 1024,  # Exactly 100KB
+            size=125 * 1024,  # 125KB * 0.8 = 100KB savings
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
@@ -122,7 +119,7 @@ class TestLocalizedStringsInsight:
 
         result = self.insight.generate(insights_input)
 
-        assert result is None  # Should return None when exactly at threshold
+        assert result is None  # Should return None when exactly at threshold (100KB, not >100KB)
 
     def test_generate_with_no_localized_strings(self):
         """Test that no insight is generated when no localized strings files exist."""
@@ -173,28 +170,37 @@ class TestLocalizedStringsInsight:
 
         assert result is None
 
-    def test_generate_ignores_non_localizable_strings(self):
-        """Test that only Localizable.strings files are considered, not other .strings files."""
-        localized_file = FileInfo(
+    def test_generate_includes_all_strings_files_except_denylisted(self):
+        """Test that all .strings files in .lproj directories are considered, except denylisted ones."""
+        localizable_file = FileInfo(
             full_path=Path("en.lproj/Localizable.strings"),
             path="en.lproj/Localizable.strings",
-            size=150 * 1024,  # 150KB - should trigger insight
+            size=80 * 1024,  # 80KB
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash1",
             is_dir=False,
         )
-        other_strings_file = FileInfo(
-            full_path=Path("en.lproj/Other.strings"),
-            path="en.lproj/Other.strings",
-            size=50 * 1024,  # 50KB - should be ignored
+        infoplist_file = FileInfo(
+            full_path=Path("en.lproj/InfoPlist.strings"),
+            path="en.lproj/InfoPlist.strings",
+            size=50 * 1024,  # 50KB - should be included
             file_type="strings",
             treemap_type=TreemapType.RESOURCES,
             hash="hash2",
             is_dir=False,
         )
+        launchscreen_file = FileInfo(
+            full_path=Path("en.lproj/LaunchScreen.strings"),
+            path="en.lproj/LaunchScreen.strings",
+            size=30 * 1024,  # 30KB - should be ignored (in denylist)
+            file_type="strings",
+            treemap_type=TreemapType.RESOURCES,
+            hash="hash3",
+            is_dir=False,
+        )
 
-        file_analysis = FileAnalysis(files=[localized_file, other_strings_file], directories=[])
+        file_analysis = FileAnalysis(files=[localizable_file, infoplist_file, launchscreen_file], directories=[])
 
         insights_input = InsightsInput(
             app_info=Mock(spec=BaseAppInfo),
@@ -206,10 +212,10 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        assert len(result.files) == 1
-        assert result.files[0].file_path == "en.lproj/Localizable.strings"
-        assert result.total_savings == 150 * 1024  # Only the Localizable.strings file
-        assert result.files[0].total_savings == 150 * 1024
+        # Should include localizable and infoplist, but not launchscreen
+        # Total size: (80KB + 50KB) * 0.8 = 104KB savings
+        expected_savings = int((80 + 50) * 1024 * 0.8)
+        assert result.total_savings == expected_savings
 
     def test_generate_ignores_non_lproj_localizable_strings(self):
         """Test that Localizable.strings files outside .lproj directories are ignored."""
@@ -244,7 +250,87 @@ class TestLocalizedStringsInsight:
         result = self.insight.generate(insights_input)
 
         assert isinstance(result, LocalizedStringInsightResult)
-        assert len(result.files) == 1
-        assert result.files[0].file_path == "en.lproj/Localizable.strings"
-        assert result.total_savings == 150 * 1024  # Only the valid file
-        assert result.files[0].total_savings == 150 * 1024
+        # Only the valid file should be included: 150KB * 0.8 = 120KB savings
+        expected_savings = int(150 * 1024 * 0.8)
+        assert result.total_savings == expected_savings
+
+    def test_regex_pattern_matching(self):
+        """Test that the regex pattern correctly matches .lproj/.strings files."""
+        # Valid patterns that should match
+        valid_files = [
+            FileInfo(
+                full_path=Path("en.lproj/Localizable.strings"),
+                path="en.lproj/Localizable.strings",
+                size=130 * 1024,  # Large enough to trigger insight after 0.8 ratio
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash="hash1",
+                is_dir=False,
+            ),
+            FileInfo(
+                full_path=Path("Base.lproj/InfoPlist.strings"),
+                path="Base.lproj/InfoPlist.strings",
+                size=30 * 1024,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash="hash2",
+                is_dir=False,
+            ),
+            FileInfo(
+                full_path=Path("pt-BR.lproj/Custom.strings"),
+                path="pt-BR.lproj/Custom.strings",
+                size=20 * 1024,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash="hash3",
+                is_dir=False,
+            ),
+        ]
+
+        # Invalid patterns that should NOT match
+        invalid_files = [
+            FileInfo(
+                full_path=Path("Localizable.strings"),  # Not in .lproj
+                path="Localizable.strings",
+                size=50 * 1024,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash="hash4",
+                is_dir=False,
+            ),
+            FileInfo(
+                full_path=Path("some/path/en.lproj/file.strings"),  # Has path before .lproj
+                path="some/path/en.lproj/file.strings",
+                size=50 * 1024,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash="hash5",
+                is_dir=False,
+            ),
+            FileInfo(
+                full_path=Path("en.lproj/subdir/file.strings"),  # Has subdirectory in .lproj
+                path="en.lproj/subdir/file.strings",
+                size=50 * 1024,
+                file_type="strings",
+                treemap_type=TreemapType.RESOURCES,
+                hash="hash6",
+                is_dir=False,
+            ),
+        ]
+
+        all_files = valid_files + invalid_files
+        file_analysis = FileAnalysis(files=all_files, directories=[])
+
+        insights_input = InsightsInput(
+            app_info=Mock(spec=BaseAppInfo),
+            file_analysis=file_analysis,
+            treemap=Mock(),
+            binary_analysis=[],
+        )
+
+        result = self.insight.generate(insights_input)
+
+        assert isinstance(result, LocalizedStringInsightResult)
+        # Should only include valid files: (130 + 30 + 20) * 1024 * 0.8 = 144KB
+        expected_savings = int((130 + 30 + 20) * 1024 * 0.8)
+        assert result.total_savings == expected_savings


### PR DESCRIPTION
- exclude `LaunchScreen.strings` since I don't believe that's usable in code
- remove the files list from the response, we don't want to duplicate this with our other minify script
- only show the insight if the estimated savings is greater than 100KB