### PR TITLE
Prepare for reinstating the health check

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import time
 
 from typing import Any, Callable, Dict, Mapping
 
@@ -20,7 +22,7 @@ from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
     PreprodArtifactEvents,
 )
 
-from launchpad.constants import PREPROD_ARTIFACT_EVENTS_TOPIC
+from launchpad.constants import HEALTHCHECK_MAX_AGE_SECONDS, PREPROD_ARTIFACT_EVENTS_TOPIC
 from launchpad.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -31,9 +33,15 @@ PREPROD_ARTIFACT_SCHEMA = get_codec(PREPROD_ARTIFACT_EVENTS_TOPIC)
 
 def create_kafka_consumer(
     message_handler: Callable[[PreprodArtifactEvents], Any],
-) -> StreamProcessor[KafkaPayload]:
+) -> LaunchpadKafkaConsumer:
     """Create and configure a Kafka consumer using environment variables."""
-    # Get configuration from environment
+
+    healthcheck_path = os.getenv("KAFKA_HEALTHCHECK_FILE")
+    if not healthcheck_path:
+        healthcheck_path = f"/tmp/launchpad-kafka-health-{os.getpid()}"
+        os.environ["KAFKA_HEALTHCHECK_FILE"] = healthcheck_path
+        logger.info(f"Using healthcheck file: {healthcheck_path}")
+
     config = get_kafka_config()
 
     environment = os.getenv("LAUNCHPAD_ENV")
@@ -65,23 +73,78 @@ def create_kafka_consumer(
         )
 
     arroyo_consumer = ArroyoKafkaConsumer(consumer_config)
+    healthcheck_path = config.get("healthcheck_file")
 
-    # Create strategy factory
     strategy_factory = LaunchpadStrategyFactory(
         message_handler=message_handler,
         concurrency=config["concurrency"],
         max_pending_futures=config["max_pending_futures"],
-        healthcheck_file=config.get("healthcheck_file"),
+        healthcheck_file=healthcheck_path,
     )
 
-    # Create and return stream processor
     topics = [Topic(topic) for topic in config["topics"]]
     topic = topics[0] if topics else Topic("default")
-    return StreamProcessor(
+    processor = StreamProcessor(
         consumer=arroyo_consumer,
         topic=topic,
         processor_factory=strategy_factory,
     )
+    return LaunchpadKafkaConsumer(processor, healthcheck_path)
+
+
+class LaunchpadKafkaConsumer:
+    processor: StreamProcessor[KafkaPayload]
+    healthcheck_path: str
+    _future: asyncio.Future
+    _running: bool
+
+    def __init__(self, processor, healthcheck_path):
+        self.processor = processor
+        self.healthcheck_path = healthcheck_path
+        loop = asyncio.get_event_loop()
+        self._future = loop.create_future()
+        self._future.set_result(None)
+        self._running = False
+
+    async def start(self):
+        logger.info(f"{self} start commanded")
+        loop = asyncio.get_event_loop()
+        # run() is blocking so we need to run in another thread:
+        self._future = loop.run_in_executor(None, self.run)
+
+    def run(self):
+        assert not self._running, "Already running"
+        logger.info(f"{self} running")
+        try:
+            self._running = True
+            self.processor.run()
+            try:
+                os.remove(self.healthcheck_path)
+                logger.info(f"Removed healthcheck file: {self.healthcheck_path}")
+            except FileNotFoundError:
+                pass
+        finally:
+            self._running = False
+
+    async def stop(self, timeout_s=10):
+        logger.info(f"{self} stop commanded")
+        self.processor.signal_shutdown()
+        try:
+            logger.info(f"Waiting for Kafka processor shutdown ({timeout_s}s)...")
+            await asyncio.wait_for(self._future, timeout=timeout_s)
+            logger.info("...Kafka processor shutdown complete")
+        except asyncio.TimeoutError:
+            logger.warning(f"{self} did not stop within timeout {timeout_s}s")
+            self._future.cancel()
+
+    def is_healthy(self) -> bool:
+        try:
+            mtime = os.path.getmtime(self.healthcheck_path)
+            age = time.time() - mtime
+        except OSError:
+            return False
+        else:
+            return age <= HEALTHCHECK_MAX_AGE_SECONDS
 
 
 class LaunchpadStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
@@ -113,16 +176,12 @@ class LaunchpadStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         next_step: ProcessingStrategy[Any] = CommitOffsets(commit)
         logger.info("KAFKASETUP: Base strategy: CommitOffsets")
 
-        # Add healthcheck if configured
         logger.info("KAFKASETUP: Checking healthcheck configuration...")
-        if self.healthcheck_file:
-            logger.info(f"KAFKASETUP: Healthcheck file configured: {self.healthcheck_file}")
-            logger.info("KAFKASETUP: Adding Healthcheck strategy to processing chain")
-            next_step = Healthcheck(self.healthcheck_file, next_step)
-            logger.info("KAFKASETUP: Healthcheck strategy added successfully")
-        else:
-            logger.warning("KAFKASETUP: No healthcheck file configured - skipping healthcheck strategy")
-            logger.info("KAFKASETUP: Processing will continue without healthcheck monitoring")
+        logger.info(f"KAFKASETUP: Healthcheck file configured: {self.healthcheck_file}")
+        logger.info("KAFKASETUP: Adding Healthcheck strategy to processing chain")
+        assert self.healthcheck_file
+        next_step = Healthcheck(self.healthcheck_file, next_step)
+        logger.info("KAFKASETUP: Healthcheck strategy added successfully")
 
         # Use RunTaskInThreads for concurrent processing
         logger.info("KAFKASETUP: Setting up concurrent message processing")

--- a/src/launchpad/server.py
+++ b/src/launchpad/server.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 
-from typing import Any, Awaitable, Callable, Dict, TypedDict
+from typing import Any, Callable, Dict
 
 from aiohttp import web
 from aiohttp.typedefs import Handler
@@ -30,18 +30,6 @@ APP_KEY_DEBUG = AppKey("debug", bool)
 APP_KEY_ENVIRONMENT = AppKey("environment", str)
 
 
-class HealthCheckResponse(TypedDict, total=False):
-    """Health check response with minimal required fields."""
-
-    status: str  # Required: "ok", "degraded", "error"
-    service: str
-    components: Dict[str, Dict[str, Any]]
-    environment: str
-    version: str
-    error: str
-    warning: str
-
-
 @middleware
 async def security_headers_middleware(request: Request, handler: Handler) -> StreamResponse:
     """Add security headers for production mode."""
@@ -60,15 +48,19 @@ async def security_headers_middleware(request: Request, handler: Handler) -> Str
 class LaunchpadServer:
     """Main server class for Launchpad."""
 
+    _running: bool
+    health_check_callback: Callable[[], bool]
+
     def __init__(
         self,
+        health_check_callback: Callable[[], bool],
         host: str | None = None,
         port: int | None = None,
         config: Dict[str, Any] | None = None,
         setup_logging: bool = True,
-        health_check_callback: (Callable[[], Awaitable[HealthCheckResponse]] | None) = None,
     ) -> None:
         self.app: Application | None = None
+        self._running = False
         self._shutdown_event = asyncio.Event()
         self.config = config or get_server_config()
         self.health_check_callback = health_check_callback
@@ -104,7 +96,7 @@ class LaunchpadServer:
         if not self.config["access_log"]:
             logging.getLogger("aiohttp.access").setLevel(logging.WARNING)
 
-    async def create_app(self) -> Application:
+    def create_app(self) -> Application:
         """Create the aiohttp application with routes."""
         middlewares = [security_headers_middleware] if not self.config["debug"] else []
 
@@ -116,177 +108,39 @@ class LaunchpadServer:
         app[APP_KEY_DEBUG] = self.config["debug"]
         app[APP_KEY_ENVIRONMENT] = self.config["environment"]
 
-        # Health check routes
-        app.router.add_get("/health", self.ready_check)  # temporarily just use ready check
-
-        # Ready check route
-        app.router.add_get("/ready", self.ready_check)
-
+        app.router.add_get("/health", self.health_check)
+        app.router.add_get("/ready", self.health_check)
         return app
 
-    async def _log_health_check_details(self) -> None:
-        """Perform health check logic purely for detailed logging purposes."""
-        logger.info("HEALTHCHECKDEBUG: === HEALTH CHECK LOGGING START ===")
-        logger.info(f"HEALTHCHECKDEBUG: Environment: {self.config['environment']}")
-        logger.info(f"HEALTHCHECKDEBUG: Debug mode: {self.config['debug']}")
-        logger.info(f"HEALTHCHECKDEBUG: Host: {self.host}:{self.port}")
-
-        try:
-            # Check if health check callback is configured
-            if self.health_check_callback:
-                logger.info("HEALTHCHECKDEBUG: Health check callback is configured - calling service health check")
-                logger.debug(f"HEALTHCHECKDEBUG: Health check callback type: {type(self.health_check_callback)}")
-
-                logger.info("HEALTHCHECKDEBUG: Executing health check callback...")
-                health_data = await self.health_check_callback()
-                logger.info("HEALTHCHECKDEBUG: Health check callback completed successfully")
-                logger.debug(f"HEALTHCHECKDEBUG: Raw health data: {health_data}")
-
-                # Validate response structure
-                logger.info("HEALTHCHECKDEBUG: Validating health check response structure...")
-                if not isinstance(health_data, dict):
-                    logger.error(f"HEALTHCHECKDEBUG: Health check response is not a dict, got: {type(health_data)}")
-                    raise ValueError("Invalid health check response: not a dictionary")
-
-                if "status" not in health_data:
-                    logger.error("HEALTHCHECKDEBUG: Health check response missing required 'status' field")
-                    logger.debug(f"HEALTHCHECKDEBUG: Available fields: {list(health_data.keys())}")
-                    raise ValueError("Invalid health check response: missing status field")
-
-                status = health_data["status"]
-                logger.info(f"HEALTHCHECKDEBUG: Health check status: {status}")
-
-                # Log all components if present
-                if "components" in health_data:
-                    logger.info("HEALTHCHECKDEBUG: Health check components found:")
-                    for component_name, component_data in health_data["components"].items():
-                        component_status = component_data.get("status", "unknown")
-                        logger.info(f"HEALTHCHECKDEBUG:   - {component_name}: {component_status}")
-                        if component_data.get("error"):
-                            logger.warning(f"HEALTHCHECKDEBUG:     Error: {component_data['error']}")
-                        if component_data.get("latency_ms"):
-                            logger.info(f"HEALTHCHECKDEBUG:     Latency: {component_data['latency_ms']}ms")
-                else:
-                    logger.info("HEALTHCHECKDEBUG: No components data in health check response")
-
-                # Map status to HTTP code and log decision
-                status_mapping = {"ok": 200, "degraded": 503}
-                status_code = status_mapping.get(status, 500)
-                logger.info(f"HEALTHCHECKDEBUG: Mapping status '{status}' to HTTP code {status_code}")
-
-                if status_code == 500:
-                    logger.warning(f"HEALTHCHECKDEBUG: Unknown status '{status}' - using 500 as fallback")
-
-                # Report to monitoring
-                is_healthy = status_code == 200
-                logger.info(
-                    f"HEALTHCHECKDEBUG: Reporting health status to Datadog: {'healthy' if is_healthy else 'unhealthy'}"
-                )
-                self._report_health_status(is_healthy)
-
-                logger.info("HEALTHCHECKDEBUG: === HEALTH CHECK LOGGING COMPLETE (SUCCESS) ===")
-            else:
-                # No callback configured - use fallback
-                logger.warning("HEALTHCHECKDEBUG: No health check callback configured - using fallback health check")
-                logger.info("HEALTHCHECKDEBUG: This means the service cannot check internal component health")
-                logger.info("HEALTHCHECKDEBUG: Consider implementing a health check callback for production use")
-
-                # Report success for basic fallback
-                logger.info("HEALTHCHECKDEBUG: Reporting basic health status (OK) to Datadog")
-                self._report_health_status(True)
-
-                logger.info("HEALTHCHECKDEBUG: Using fallback health check response")
-                logger.info("HEALTHCHECKDEBUG: === HEALTH CHECK LOGGING COMPLETE (FALLBACK) ===")
-
-        except Exception as error:
-            # Determine error context based on whether we have a callback and what failed
-            if self.health_check_callback:
-                error_context = "Health check callback execution"
-                completion_msg = "CALLBACK ERROR"
-            else:
-                error_context = "Health check system"
-                completion_msg = "SYSTEM ERROR"
-
-            logger.error(f"HEALTHCHECKDEBUG: {error_context} failed: {error}")
-            logger.error(f"HEALTHCHECKDEBUG: Error type: {type(error)}")
-            logger.error(f"HEALTHCHECKDEBUG: {error_context} stack trace:", exc_info=True)
-            logger.info("HEALTHCHECKDEBUG: Reporting failed health status to Datadog")
-            self._report_health_status(False)
-            logger.info(f"HEALTHCHECKDEBUG: === HEALTH CHECK LOGGING COMPLETE ({completion_msg}) ===")
-
-    async def health_check(self, request: Request) -> Response:
-        """Health check endpoint that checks all service components."""
-        try:
-            # Get health status from the service if callback is provided
-            if self.health_check_callback:
-                try:
-                    health_data = await self.health_check_callback()
-
-                    # Basic validation - just ensure we have a status
-                    if not isinstance(health_data, dict) or "status" not in health_data:
-                        raise ValueError("Invalid health check response")
-
-                    # Map status to HTTP code
-                    status_code = {"ok": 200, "degraded": 503}.get(health_data["status"], 500)
-
-                    # Send service check to Datadog
-                    self._report_health_status(status_code == 200)
-                    return web.json_response(health_data, status=status_code)
-
-                except Exception as e:
-                    logger.error(f"Health check callback failed: {e}", exc_info=True)
-                    self._report_health_status(False)
-                    return web.json_response(
-                        {
-                            "status": "error",
-                            "service": "launchpad",
-                            "error": str(e),
-                        },
-                        status=500,
-                    )
-            else:
-                # Fallback to basic health check if no callback
-                self._report_health_status(True)
-                return web.json_response(
-                    {
-                        "status": "ok",
-                        "service": "launchpad",
-                        "version": "0.0.1",
-                        "environment": self.config["environment"],
-                        "warning": "No service health check callback configured",
-                    }
-                )
-        except Exception as e:
-            logger.error(f"Health check failed: {e}", exc_info=True)
-            self._report_health_status(False)
-            return web.json_response({"status": "error", "service": "launchpad", "error": str(e)}, status=500)
-
-    async def ready_check(self, request: Request) -> Response:
-        """Readiness check endpoint."""
-
-        # Call health check for detailed logging but ignore the result
-        # await self._log_health_check_details()
-
-        # TODO: Add actual readiness checks (database connectivity, etc.)
+    def health_check(self, request: Request) -> Response:
+        is_healthy = self.health_check_callback()
+        environment = self.config["environment"]
+        self._statsd.service_check(
+            "launchpad.health_check",
+            self._statsd.OK if is_healthy else self._statsd.CRITICAL,
+            tags=[f"environment:{environment}"],
+        )
+        if is_healthy:
+            logger.debug("launchpad healthy")
+        else:
+            logger.warning("launchpad unhealthy - but reporting healthy")
         return web.json_response(
             {
                 "status": "ok",
                 "service": "launchpad",
             }
-            # "environment": self.config["environment"],
         )
 
-    def _report_health_status(self, is_healthy: bool) -> None:
-        """Report health check status to Datadog."""
-        self._statsd.service_check(
-            "launchpad.health_check",
-            self._statsd.OK if is_healthy else self._statsd.CRITICAL,
-            tags=[f"environment:{self.config['environment']}"],
-        )
-
-    async def start(self) -> None:
+    async def start(self):
         """Start the HTTP server."""
-        self.app = await self.create_app()
+        logger.info(f"{self} start commanded")
+        self._task = asyncio.create_task(self.run())
+
+    async def run(self):
+        assert not self._running, "Already running"
+        logger.info(f"{self} running")
+        self._running = True
+        self.app = self.create_app()
 
         runner = web.AppRunner(
             self.app,
@@ -302,15 +156,20 @@ class LaunchpadServer:
             f"(environment: {self.config['environment']}, debug: {self.config['debug']})"
         )
 
-        # Wait for shutdown signal
         await self._shutdown_event.wait()
 
         logger.info("Shutting down server...")
         await runner.cleanup()
+        self._running = False
 
-    def shutdown(self) -> None:
-        """Signal the server to shutdown."""
+    async def stop(self, timeout_s=10):
+        logger.info(f"{self} stop commanded")
         self._shutdown_event.set()
+        try:
+            await asyncio.wait_for(self._task, timeout=timeout_s)
+        except asyncio.TimeoutError:
+            logger.warning(f"{self} did not stop within timeout {timeout_s}s")
+            self._task.cancel()
 
 
 def get_server_config() -> Dict[str, Any]:

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -7,13 +7,12 @@ import json
 import os
 import signal
 import tempfile
+import threading
 import time
 
 from pathlib import Path
 from typing import Any, Dict, cast
 
-from arroyo.backends.kafka import KafkaPayload
-from arroyo.processing.processor import StreamProcessor
 from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import PreprodArtifactEvents
 
 from launchpad.api.update_api_models import AppleAppInfo as AppleAppInfoModel
@@ -26,7 +25,6 @@ from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import Artifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.constants import (
-    HEALTHCHECK_MAX_AGE_SECONDS,
     MAX_RETRY_ATTEMPTS,
     OPERATION_ERRORS,
     ArtifactType,
@@ -44,9 +42,9 @@ from launchpad.utils.file_utils import cleanup_directory
 from launchpad.utils.logging import get_logger
 from launchpad.utils.statsd import DogStatsd, get_statsd
 
-from .kafka import create_kafka_consumer
+from .kafka import LaunchpadKafkaConsumer, create_kafka_consumer
 from .sentry_sdk_init import initialize_sentry_sdk
-from .server import HealthCheckResponse, LaunchpadServer, get_server_config
+from .server import LaunchpadServer, get_server_config
 
 logger = get_logger(__name__)
 
@@ -56,8 +54,7 @@ class LaunchpadService:
 
     def __init__(self) -> None:
         self.server: LaunchpadServer | None = None
-        self.kafka_processor: StreamProcessor[KafkaPayload] | None = None
-        self._shutdown_event = asyncio.Event()
+        self.kafka: LaunchpadKafkaConsumer | None = None
         self._kafka_task: asyncio.Future[Any] | None = None
         self._statsd: DogStatsd | None = None
         self._healthcheck_file: str | None = None
@@ -72,49 +69,60 @@ class LaunchpadService:
         )
         initialize_sentry_sdk()
 
-        # Setup HTTP server with health check callback
         server_config = get_server_config()
         self.server = LaunchpadServer(
+            self.is_healthy,
             host=server_config["host"],
             port=server_config["port"],
-            health_check_callback=self.health_check,
         )
 
-        # Setup healthcheck file if not configured
-        self._healthcheck_file = os.getenv("KAFKA_HEALTHCHECK_FILE")
-        if not self._healthcheck_file:
-            # Create a default healthcheck file in tmp
-            self._healthcheck_file = f"/tmp/launchpad-kafka-health-{os.getpid()}"
-            os.environ["KAFKA_HEALTHCHECK_FILE"] = self._healthcheck_file
-            logger.info(f"Using healthcheck file: {self._healthcheck_file}")
-
-        # Create Kafka consumer with message handler
-        self.kafka_processor = create_kafka_consumer(message_handler=self.handle_kafka_message)
+        self.kafka = create_kafka_consumer(message_handler=self.handle_kafka_message)
 
         logger.info("Service components initialized")
 
     async def start(self) -> None:
         """Start all service components."""
-        if not self.server or not self.kafka_processor:
+        if not self.server or not self.kafka:
             raise RuntimeError("Service not properly initialized. Call setup() first.")
 
         logger.info("Starting Launchpad service...")
 
-        # Set up signal handlers for graceful shutdown
-        self._setup_signal_handlers()
+        shutdown_event = asyncio.Event()
 
-        # Start Kafka processor in a background thread
+        def signal_handler(signum: int) -> None:
+            if shutdown_event.is_set():
+                logger.info(f"Received signal {signum} during shutdown, forcing exit...")
+                # Force exit if we get a second signal
+                os._exit(1)
+                return
+            logger.info(f"Received signal {signum}, initiating shutdown...")
+            shutdown_event.set()
+
+        assert threading.current_thread() is threading.main_thread()
         loop = asyncio.get_event_loop()
-        self._kafka_task = loop.run_in_executor(None, self.kafka_processor.run)
+        loop.add_signal_handler(signal.SIGTERM, signal_handler, signal.SIGTERM)
+        loop.add_signal_handler(signal.SIGINT, signal_handler, signal.SIGINT)
 
-        # Start HTTP server as a background task
-        server_task = asyncio.create_task(self.server.start())
+        await self.kafka.start()
+        await self.server.start()
+
         logger.info("Launchpad service started successfully")
 
         try:
-            await self._shutdown_event.wait()
+            await shutdown_event.wait()
         finally:
-            await self._cleanup(server_task)
+            logger.info("Cleaning up service resources...")
+            awaitable_stop_server = None
+            awaitable_stop_kafka = None
+            if self.kafka:
+                awaitable_stop_kafka = self.kafka.stop()
+            if self.server:
+                awaitable_stop_server = self.server.stop()
+            if awaitable_stop_kafka:
+                await awaitable_stop_kafka
+            if awaitable_stop_server:
+                await awaitable_stop_server
+            logger.info("...service cleanup completed")
 
     def handle_kafka_message(self, payload: PreprodArtifactEvents) -> None:
         """
@@ -534,126 +542,11 @@ class LaunchpadService:
             except Exception as e:
                 logger.warning(f"Failed to clean up {description} {file_path}: {e}")
 
-    def _setup_signal_handlers(self) -> None:
-        """Set up signal handlers for graceful shutdown."""
-
-        def signal_handler(signum: int, frame: Any) -> None:
-            if self._shutdown_event.is_set():
-                logger.info(f"Received signal {signum} during shutdown, forcing exit...")
-                # Force exit if we get a second signal
-                os._exit(1)
-                return
-
-            logger.info(f"Received signal {signum}, initiating shutdown...")
-
-            # Signal Kafka processor shutdown
-            if self.kafka_processor:
-                try:
-                    self.kafka_processor.signal_shutdown()
-                except Exception as e:
-                    logger.warning(f"Error stopping Kafka processor: {e}")
-
-            # Set the shutdown event
-            self._shutdown_event.set()
-
-        signal.signal(signal.SIGTERM, signal_handler)
-        signal.signal(signal.SIGINT, signal_handler)
-
-    async def _cleanup(self, server_task: asyncio.Task[Any]) -> None:
-        """Clean up service resources."""
-        logger.info("Cleaning up service resources...")
-
-        # Stop HTTP server
-        if self.server:
-            try:
-                self.server.shutdown()
-                await asyncio.wait_for(server_task, timeout=5.0)
-                logger.info("HTTP server stopped")
-            except asyncio.TimeoutError:
-                logger.warning("HTTP server did not stop within timeout")
-                server_task.cancel()
-                try:
-                    await server_task
-                except asyncio.CancelledError:
-                    pass
-            except Exception as e:
-                logger.warning(f"Error shutting down server: {e}")
-
-        # Wait for Kafka processor to stop
-        if self._kafka_task:
-            try:
-                logger.info("Waiting for Kafka processor to stop...")
-                await asyncio.wait_for(self._kafka_task, timeout=10.0)
-                logger.info("Kafka processor stopped")
-            except asyncio.TimeoutError:
-                logger.warning("Kafka processor did not stop within timeout")
-                self._kafka_task.cancel()
-            except Exception as e:
-                logger.warning(f"Error waiting for Kafka processor: {e}")
-
-        # Clean up healthcheck file
-        if self._healthcheck_file and os.path.exists(self._healthcheck_file):
-            try:
-                os.remove(self._healthcheck_file)
-                logger.info(f"Removed healthcheck file: {self._healthcheck_file}")
-            except Exception as e:
-                logger.warning(f"Failed to remove healthcheck file: {e}")
-
-        logger.info("Service cleanup completed")
-
-    async def health_check(self) -> HealthCheckResponse:
+    def is_healthy(self) -> bool:
         """Get overall service health status."""
-        health_status = cast(
-            HealthCheckResponse,
-            {
-                "service": "launchpad",
-                "status": "ok",
-                "components": {},
-            },
-        )
-
-        # Check Kafka health via healthcheck file
-        kafka_health: Dict[str, Any] = {"status": "unknown"}
-        if self._healthcheck_file:
-            try:
-                if os.path.exists(self._healthcheck_file):
-                    # Check file modification time
-                    mtime = os.path.getmtime(self._healthcheck_file)
-                    age = time.time() - mtime
-
-                    if age <= HEALTHCHECK_MAX_AGE_SECONDS:
-                        kafka_health = {
-                            "status": "healthy",
-                            "last_heartbeat_age_seconds": round(age, 2),
-                        }
-                    else:
-                        kafka_health = {
-                            "status": "unhealthy",
-                            "last_heartbeat_age_seconds": round(age, 2),
-                            "reason": f"No heartbeat for {round(age, 2)} seconds",
-                        }
-                        health_status["status"] = "degraded"
-                else:
-                    kafka_health = {
-                        "status": "unhealthy",
-                        "reason": "Healthcheck file does not exist",
-                    }
-                    health_status["status"] = "degraded"
-            except Exception as e:
-                kafka_health = {"status": "error", "reason": str(e)}
-                health_status["status"] = "degraded"
-        else:
-            kafka_health = {
-                "status": "unknown",
-                "reason": "No healthcheck file configured",
-            }
-
-        health_status["components"]["kafka"] = kafka_health
-
-        # Check server health
-        health_status["components"]["server"] = {"status": "ok" if self.server else "not_initialized"}
-
-        return health_status
+        is_server_healthy = self.server.is_healthy()
+        is_kafka_healthy = self.kafka.is_healthy()
+        return is_server_healthy and is_kafka_healthy
 
 
 def get_service_config() -> Dict[str, Any]:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -167,8 +167,8 @@ class TestServiceWithMockServer:
         # that would start the actual service and test HTTP endpoints
         # For now, we test the components separately
 
-        server = LaunchpadServer(host="127.0.0.1", port=0)  # Random port
-        app = await server.create_app()
+        server = LaunchpadServer(lambda: True, host="127.0.0.1", port=0)  # Random port
+        app = server.create_app()
 
         # Test that we can create the app without errors
         assert app is not None

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -9,48 +9,42 @@ from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
     PreprodArtifactEvents,
 )
 
-from launchpad.server import HealthCheckResponse, LaunchpadServer
+from launchpad.server import LaunchpadServer
 from launchpad.service import LaunchpadService
 
 
-class TestLaunchpadServer(AioHTTPTestCase):
+class TestHealthyLaunchpadServer(AioHTTPTestCase):
     """Test cases for LaunchpadServer."""
 
     async def get_application(self):
         """Create the application for testing."""
 
-        # Create a mock health check callback
-        async def mock_health_check() -> HealthCheckResponse:
-            return {
-                "service": "launchpad",
-                "status": "ok",
-                "components": {
-                    "kafka": {"status": "healthy"},
-                    "server": {"status": "ok"},
-                },
-            }
+        def mock_health_check() -> bool:
+            return True
 
         server = LaunchpadServer(health_check_callback=mock_health_check)
-        return await server.create_app()
+        return server.create_app()
 
-    # async def test_health_check(self):
-    #     """Test the health check endpoint."""
-    #     resp = await self.client.request("GET", "/health")
-    #     assert resp.status == 200
+    async def test_health_check(self):
+        """Test the health check endpoint."""
+        resp = await self.client.request("GET", "/health")
+        assert resp.status == 200
 
-    #     data = await resp.json()
-    #     assert data["status"] == "ok"
-    #     assert data["service"] == "launchpad"
-    #     assert "components" in data
+        # The health check has to be *precisely* this to pass, you
+        # can't add extra fields without changing the getsentry/ops
+        # repo:
+        assert await resp.text() == '{"status": "ok", "service": "launchpad"}'
 
-    # async def test_ready_check(self):
-    #     """Test the readiness check endpoint."""
-    #     resp = await self.client.request("GET", "/ready")
-    #     assert resp.status == 200
+    async def test_ready_check(self):
+        """Test the readiness check endpoint."""
+        resp = await self.client.request("GET", "/ready")
+        assert resp.status == 200
 
-    #     data = await resp.json()
-    #     assert data["status"] == "ready"
-    #     assert data["service"] == "launchpad"
+        data = await resp.json()
+        assert data == {
+            "status": "ok",
+            "service": "launchpad",
+        }
 
 
 class TestLaunchpadService:


### PR DESCRIPTION
Prepare for reinstating the health check.

- Use asyncio safe signal handlers
- Introduce a new wrapper class (`LaunchpadKafkaConsumer`) around the Kafka processor
- Move all handling of `health_check_file` into this wrapper
- Give `LaunchpadServer` and `LaunchpadKafkaConsumer` a consistent interface
   - `async start()` - start the component, completes as soon as the service is started
   - `async stop(timeout_s)` - stop the component, with a timeout of `timeout_s` seconds
   - `is_healthy() -> bool` - return true iff component is healthy
 - This consistent interface and moving `health_check_file` allows simplifying `LaunchpadService`
- Shutdown all components in parallel
-  Make healthcheck setup non-optional for `LaunchpadStrategyFactory`
 - Remove `HealthCheckResponse` for now and use a bool



