### PR TITLE
Add missing is_healthy method

### DIFF
--- a/src/launchpad/server.py
+++ b/src/launchpad/server.py
@@ -112,6 +112,9 @@ class LaunchpadServer:
         app.router.add_get("/ready", self.health_check)
         return app
 
+    def is_healthy(self):
+        return True
+
     def health_check(self, request: Request) -> Response:
         is_healthy = self.health_check_callback()
         environment = self.config["environment"]


### PR DESCRIPTION
Should have been caught by typechecker but seems ty doesn't support this yet.
We also have some tests for this ...but they are commented out until we fully reenable the healthcheck.