### PR TITLE
Tweak Sentry SDK setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,5 +109,8 @@ USER app
 # Expose ports
 EXPOSE 2218
 
+ARG LAUNCHPAD_VERSION_SHA
+ENV LAUNCHPAD_VERSION_SHA=$LAUNCHPAD_VERSION_SHA
+
 # Default command
 CMD ["launchpad", "serve", "--verbose"]

--- a/cloudbuild.ci.yaml
+++ b/cloudbuild.ci.yaml
@@ -15,6 +15,7 @@ steps:
         set -euxo pipefail
         docker buildx build \
             --platform linux/amd64,linux/arm64 \
+            --build-arg LAUNCHPAD_VERSION_SHA=$COMMIT_SHA \
             -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:$COMMIT_SHA \
             --label org.opencontainers.image.revision=$COMMIT_SHA \
             --label org.opencontainers.image.version=$COMMIT_SHA \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
         docker buildx build \
             --push \
             --platform linux/amd64 \
+            --build-arg LAUNCHPAD_VERSION_SHA=$COMMIT_SHA \
             -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:$COMMIT_SHA \
             -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:$SHORT_SHA \
             -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:nightly \

--- a/src/launchpad/sentry_sdk_init.py
+++ b/src/launchpad/sentry_sdk_init.py
@@ -46,14 +46,13 @@ def initialize_sentry_sdk() -> None:
         dsn=config.dsn,
         integrations=integrations,
         send_default_pii=True,
+        # Release is the git sha
         release=config.release,
-        environment=config.environment,
+        # Convention is to set the Sentry environment to the region (us, de, etc).
+        environment=config.region,
     )
 
-    if config.region:
-        sentry_sdk.set_tag("sentry_region", config.region)
-
-    logger.info(f"Sentry SDK initialized for environment: {config.environment}")
+    logger.info(f"Sentry SDK initialized for environment: {config.region}")
 
 
 @dataclass
@@ -75,6 +74,6 @@ def get_sentry_config() -> SentryConfig:
     return SentryConfig(
         dsn=os.getenv("SENTRY_DSN"),
         environment=environment.lower(),
-        release=os.getenv("LAUNCHPAD_VERSION_SHA", "unknown"),  # TODO: auto fetch latest git commit hash
-        region=os.getenv("SENTRY_REGION"),
+        release=os.getenv("LAUNCHPAD_VERSION_SHA", "unknown"),
+        region=os.getenv("SENTRY_REGION", "unknown"),
     )


### PR DESCRIPTION
Make two changes to what we report to Sentry for crashes:
1. Set 'environment' to SENTRY_REGION / SENTRY_ENVIRONMENT so rather
   than being 'production' or 'development' it's 'us', 'de', etc.
2. Set 'release' to the git sha we are building at.
