### PR TITLE
Fix Datadog setup

### DIFF
--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -63,10 +63,7 @@ class LaunchpadService:
     async def setup(self) -> None:
         """Set up the service components."""
         self._service_config = get_service_config()
-        self._statsd = get_statsd(
-            host=self._service_config["statsd_host"],
-            port=self._service_config["statsd_port"],
-        )
+        self._statsd = get_statsd()
         initialize_sentry_sdk()
 
         server_config = get_server_config()
@@ -551,21 +548,11 @@ class LaunchpadService:
 
 def get_service_config() -> Dict[str, Any]:
     """Get service configuration from environment."""
-    statsd_host = os.getenv("STATSD_HOST", "127.0.0.1")
-    statsd_port_str = os.getenv("STATSD_PORT", "8125")
-
     sentry_base_url = os.getenv("SENTRY_BASE_URL")
     if sentry_base_url is None:
         sentry_base_url = "http://getsentry.default"
 
-    try:
-        statsd_port = int(statsd_port_str)
-    except ValueError:
-        raise ValueError(f"STATSD_PORT must be a valid integer, got: {statsd_port_str}")
-
     return {
-        "statsd_host": statsd_host,
-        "statsd_port": statsd_port,
         "sentry_base_url": sentry_base_url,
     }
 

--- a/src/launchpad/utils/statsd.py
+++ b/src/launchpad/utils/statsd.py
@@ -1,3 +1,5 @@
+import os
+
 from datadog.dogstatsd.base import DogStatsd
 
 # There are a few weird issues with DataDog documented in other Sentry repos.
@@ -10,9 +12,29 @@ from datadog.dogstatsd.base import DogStatsd
 # - not using the global initialize() and statsd instances.
 
 
-def get_statsd(host: str = "127.0.0.1", port: int = 8125) -> DogStatsd:
-    disable_telemetry = True
-    origin_detection_enabled = False
-    return DogStatsd(
-        host=host, port=port, disable_telemetry=disable_telemetry, origin_detection_enabled=origin_detection_enabled
-    )
+_statsd: DogStatsd | None = None
+
+
+def get_statsd() -> DogStatsd:
+    global _statsd
+
+    if s := _statsd:
+        # Type checker does not seem to be able to work out _statsd
+        # must be set here hence the :=.
+        return s
+    else:
+        disable_telemetry = True
+        origin_detection_enabled = False
+
+        host = os.getenv("STATSD_HOST", "127.0.0.1")
+        port_str = os.getenv("STATSD_PORT", "8125")
+
+        try:
+            port = int(port_str)
+        except ValueError:
+            raise ValueError(f"STATSD_PORT must be a valid integer, got: {port_str}")
+
+        _statsd = DogStatsd(
+            host=host, port=port, disable_telemetry=disable_telemetry, origin_detection_enabled=origin_detection_enabled
+        )
+        return _statsd

--- a/tests/unit/utils/test_statsd.py
+++ b/tests/unit/utils/test_statsd.py
@@ -1,0 +1,6 @@
+from launchpad.utils.statsd import get_statsd
+
+
+def test_statsd_is_singleton():
+    assert get_statsd()
+    assert get_statsd() is get_statsd()


### PR DESCRIPTION
We:
- constructed multiple DataDog instances
- with different configs

Fix this by making `get_statsd()` a singleton and configure it in just one place.