### PR TITLE
Temporarily skip insights for Apple Analyzer to monitor memory usage

### DIFF
--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -485,7 +485,7 @@ class LaunchpadService:
     def _create_analyzer(self, app_info: AppleAppInfo | BaseAppInfo) -> AndroidAnalyzer | AppleAppAnalyzer:
         """Create analyzer with preprocessed app info."""
         if isinstance(app_info, AppleAppInfo):
-            analyzer = AppleAppAnalyzer()
+            analyzer = AppleAppAnalyzer(skip_insights=True)
             analyzer.app_info = app_info
             return analyzer
         else:  # Android


### PR DESCRIPTION
Generating insights is spiking the memory to OOM level in GCP. I increased the memory but am curious what our memory consumption for size processing is without the insights step