### PR TITLE
Make artifact_factory.py more memory efficient

### DIFF
--- a/src/launchpad/artifacts/artifact_factory.py
+++ b/src/launchpad/artifacts/artifact_factory.py
@@ -38,7 +38,7 @@ class ArtifactFactory:
             magic_bytes = f.read(4)
 
         # Check if it's a zip file by looking at magic bytes
-        if magic_bytes.startswith(b"PK"):
+        if magic_bytes.startswith(b"PK\x03\x04"):
             try:
                 with ZipFile(path) as zip_file:
                     # Check if zip contains a Info.plist in the root of the .xcarchive folder (ZippedXCArchive)


### PR DESCRIPTION
changes:

1. Only read 4 bytes into memory rather than the whole file
2. Open ZIP file directly from path instead of loading into memory