### PR TITLE
Update healthcheck url

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -30,7 +30,7 @@ services:
       - serve
       - --verbose
     healthcheck:
-      test: curl -f http://localhost:2218/health || exit 1
+      test: curl -f http://0.0.0.0:2218/health || exit 1
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
I think this is why `devservices up --mode launchpad` is failing with `Container launchpad did not become healthy within 120 seconds.`