### PR TITLE
Pipe dequeued_at and processed_at back to monolith

### DIFF
--- a/src/launchpad/api/update_api_models.py
+++ b/src/launchpad/api/update_api_models.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class AppleAppInfo(BaseModel):
@@ -15,6 +16,11 @@ class AppleAppInfo(BaseModel):
     # TODO: add "date_built" field once exposed in 'AppleAppInfo'
 
 
+class ExtraInfo(BaseModel):
+    dequeued_at: datetime | None = Field(None, description="Timestamp when message was dequeued from Kafka")
+    processed_at: datetime | None = Field(None, description="Timestamp when processing completed")
+
+
 class UpdateData(BaseModel):
     app_name: str
     app_id: str
@@ -22,4 +28,5 @@ class UpdateData(BaseModel):
     build_number: Optional[int]
     artifact_type: int
     apple_app_info: Optional[AppleAppInfo] = None
+    extra_info: Optional[ExtraInfo] = None
     # TODO: add "date_built" and custom android fields

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -11,6 +11,7 @@ import threading
 import time
 
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, cast
 
@@ -19,7 +20,7 @@ from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
 )
 
 from launchpad.api.update_api_models import AppleAppInfo as AppleAppInfoModel
-from launchpad.api.update_api_models import UpdateData
+from launchpad.api.update_api_models import ExtraInfo, UpdateData
 from launchpad.artifacts.android.aab import AAB
 from launchpad.artifacts.android.apk import APK
 from launchpad.artifacts.android.zipped_aab import ZippedAAB
@@ -165,6 +166,7 @@ class LaunchpadService:
         if not self._service_config:
             raise RuntimeError("Service not properly initialized. Call setup() first.")
 
+        dequeued_at = datetime.now()
         sentry_client = SentryClient(base_url=self._service_config.sentry_base_url)
         temp_file = None
         artifact = None
@@ -240,6 +242,11 @@ class LaunchpadService:
                 OperationName.SIZE_ANALYSIS,
             )
             logger.info(f"Size analysis completed for artifact {artifact_id}")
+
+            processed_at = datetime.now()
+            self._send_final_update_with_timestamps(
+                sentry_client, artifact_id, project_id, organization_id, dequeued_at, processed_at
+            )
 
             self._upload_results(sentry_client, results, artifact_id, project_id, organization_id)
 
@@ -518,6 +525,28 @@ class LaunchpadService:
             raise e
         else:
             logger.info(f"Successfully uploaded analysis results for artifact {artifact_id}")
+
+    def _send_final_update_with_timestamps(
+        self,
+        sentry_client: SentryClient,
+        artifact_id: str,
+        project_id: str,
+        organization_id: str,
+        dequeued_at: datetime,
+        processed_at: datetime,
+    ) -> None:
+        """Send final update with dequeued_at and processed_at timestamps."""
+        extra_info = ExtraInfo(dequeued_at=dequeued_at, processed_at=processed_at)
+        try:
+            sentry_client.update_artifact(
+                org=organization_id,
+                project=project_id,
+                artifact_id=artifact_id,
+                data={"extra_info": extra_info.model_dump(mode="json")},
+            )
+            logger.info(f"Successfully sent final update with timestamps for artifact {artifact_id}")
+        except SentryClientError as e:
+            logger.error(f"Failed to send final update with timestamps for artifact {artifact_id}: {e}")
 
     def _safe_cleanup(self, file_path: str, description: str) -> None:
         """Safely clean up a file with error handling."""


### PR DESCRIPTION
This involves calling the update endpoint at the very end. We will then pass these new fields in and have it saved to the `extra_info` column in the database. 