### PR TITLE
Fix statsd tests

### DIFF
--- a/src/launchpad/server.py
+++ b/src/launchpad/server.py
@@ -24,7 +24,7 @@ from aiohttp.web import (
 )
 
 from .utils.logging import get_logger
-from .utils.statsd import get_statsd
+from .utils.statsd import OK, NullStatsd, StatsdInterface
 
 logger = get_logger(__name__)
 
@@ -61,13 +61,14 @@ class LaunchpadServer:
         port: int | None = None,
         config: ServerConfig | None = None,
         setup_logging: bool = True,
+        statsd: StatsdInterface | None = None,
     ) -> None:
         self.app: Application | None = None
         self._running = False
         self._shutdown_event = asyncio.Event()
         self.config = config or get_server_config()
         self.health_check_callback = health_check_callback
-        self._statsd = get_statsd()
+        self._statsd = statsd or NullStatsd()
 
         # Override config with explicit parameters if provided
         if host is not None or port is not None:
@@ -124,11 +125,11 @@ class LaunchpadServer:
         # is_healthy = self.health_check_callback()
         # if is_healthy:
         json_status = "ok"
-        statsd_status = self._statsd.OK
+        statsd_status = OK
         http_status = 200
         # else:
         #     json_status = "error"
-        #     statsd_status = self._statsd.CRITICAL
+        #     statsd_status = CRITICAL
         #     http_status = 500
 
         sentry_region = self.config.sentry_region

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -44,7 +44,7 @@ from launchpad.size.models.apple import AppleAppInfo
 from launchpad.size.models.common import BaseAppInfo
 from launchpad.size.runner import do_preprocess, do_size
 from launchpad.utils.logging import get_logger
-from launchpad.utils.statsd import DogStatsd, get_statsd
+from launchpad.utils.statsd import NullStatsd, StatsdInterface, get_statsd
 
 from .kafka import LaunchpadKafkaConsumer, create_kafka_consumer
 from .sentry_sdk_init import initialize_sentry_sdk
@@ -56,18 +56,17 @@ logger = get_logger(__name__)
 class LaunchpadService:
     """Main service that orchestrates HTTP server and Kafka consumer."""
 
-    def __init__(self) -> None:
+    def __init__(self, statsd: StatsdInterface | None = None) -> None:
         self.server: LaunchpadServer | None = None
         self.kafka: LaunchpadKafkaConsumer | None = None
         self._kafka_task: asyncio.Future[Any] | None = None
-        self._statsd: DogStatsd | None = None
+        self._statsd = statsd or NullStatsd()
         self._healthcheck_file: str | None = None
         self._service_config: ServiceConfig | None = None
 
     async def setup(self) -> None:
         """Set up the service components."""
         self._service_config = get_service_config()
-        self._statsd = get_statsd()
         initialize_sentry_sdk()
 
         server_config = get_server_config()
@@ -75,6 +74,7 @@ class LaunchpadService:
             self.is_healthy,
             host=server_config.host,
             port=server_config.port,
+            statsd=self._statsd,
         )
 
         self.kafka = create_kafka_consumer(message_handler=self.handle_kafka_message)
@@ -140,18 +140,14 @@ class LaunchpadService:
 
             try:
                 logger.info(f"Processing artifact: {artifact_id} (project: {project_id}, org: {organization_id})")
-                if self._statsd:
-                    self._statsd.increment("artifact.processing.started")
+                self._statsd.increment("artifact.processing.started")
 
-                    timing_tags = [f"project_id:{project_id}", f"organization_id:{organization_id}"]
-                    with self._statsd.timed("artifact.processing.duration", tags=timing_tags):
-                        self.process_artifact(artifact_id, project_id, organization_id)
-                else:
+                timing_tags = [f"project_id:{project_id}", f"organization_id:{organization_id}"]
+                with self._statsd.timed("artifact.processing.duration", tags=timing_tags):
                     self.process_artifact(artifact_id, project_id, organization_id)
                 logger.info(f"Analysis completed for artifact {artifact_id}")
 
-                if self._statsd:
-                    self._statsd.increment("artifact.processing.completed")
+                self._statsd.increment("artifact.processing.completed")
 
             except Exception as e:
                 logger.error(
@@ -159,8 +155,7 @@ class LaunchpadService:
                     exc_info=True,
                 )
 
-                if self._statsd:
-                    self._statsd.increment("artifact.processing.failed")
+                self._statsd.increment("artifact.processing.failed")
 
     def process_artifact(self, artifact_id: str, project_id: str, organization_id: str) -> None:
         """
@@ -356,17 +351,15 @@ class LaunchpadService:
         # Use detailed error message if provided, otherwise use enum value
         final_error_message = f"{error_message.value}: {detailed_error}" if detailed_error else error_message.value
 
-        # Log error to datadog with tags for better monitoring
-        if self._statsd:
-            self._statsd.increment(
-                "artifact.processing.error",
-                tags=[
-                    f"error_code:{error_code.value}",
-                    f"error_type:{error_message.name}",
-                    f"project_id:{project_id}",
-                    f"organization_id:{organization_id}",
-                ],
-            )
+        self._statsd.increment(
+            "artifact.processing.error",
+            tags=[
+                f"error_code:{error_code.value}",
+                f"error_type:{error_message.name}",
+                f"project_id:{project_id}",
+                f"organization_id:{organization_id}",
+            ],
+        )
 
         try:
             sentry_client.update_artifact(
@@ -399,15 +392,7 @@ class LaunchpadService:
                 temp_file = tf.name
 
                 timing_tags = [f"project_id:{project_id}", f"organization_id:{organization_id}"]
-                if self._statsd:
-                    with self._statsd.timed("artifact.download.duration", tags=timing_tags):
-                        file_size = sentry_client.download_artifact_to_file(
-                            org=organization_id,
-                            project=project_id,
-                            artifact_id=artifact_id,
-                            out=tf,
-                        )
-                else:
+                with self._statsd.timed("artifact.download.duration", tags=timing_tags):
                     file_size = sentry_client.download_artifact_to_file(
                         org=organization_id,
                         project=project_id,
@@ -415,7 +400,6 @@ class LaunchpadService:
                         out=tf,
                     )
 
-                # Success case
                 logger.info(f"Downloaded artifact {artifact_id}: {file_size} bytes ({file_size / 1024 / 1024:.2f} MB)")
                 logger.info(f"Saved artifact to temporary file: {temp_file}")
                 return temp_file
@@ -559,6 +543,7 @@ def get_service_config() -> ServiceConfig:
 
 async def run_service() -> None:
     """Run the Launchpad service."""
-    service = LaunchpadService()
+    statsd = get_statsd()
+    service = LaunchpadService(statsd)
     await service.setup()
     await service.start()

--- a/src/launchpad/utils/statsd.py
+++ b/src/launchpad/utils/statsd.py
@@ -1,6 +1,8 @@
 import os
 
-from typing import Literal
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any, Literal
 
 from datadog.dogstatsd.base import DogStatsd
 
@@ -14,14 +16,135 @@ from datadog.dogstatsd.base import DogStatsd
 # - not using the global initialize() and statsd instances.
 
 
-_statsd_instances: dict[str, DogStatsd] = {}
+OK = DogStatsd.OK
+WARNING = DogStatsd.WARNING
+CRITICAL = DogStatsd.CRITICAL
+UNKNOWN = DogStatsd.UNKNOWN
 
 
-def get_statsd(environment: Literal["default", "consumer"] = "default") -> DogStatsd:
-    global _statsd_instances
+class StatsdInterface(ABC):
+    @abstractmethod
+    def increment(self, metric: str, value: int = 1, tags: list[str] | None = None) -> None:
+        pass
 
-    if environment in _statsd_instances:
-        return _statsd_instances[environment]
+    @abstractmethod
+    def gauge(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        pass
+
+    @abstractmethod
+    def timing(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        pass
+
+    @abstractmethod
+    def service_check(
+        self,
+        name: str,
+        status: int,
+        tags: list[str] | None = None,
+        hostname: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    @contextmanager
+    def timed(self, metric: str, tags: list[str] | None = None) -> Any:
+        pass
+
+
+class NullStatsd(StatsdInterface):
+    def increment(self, metric: str, value: int = 1, tags: list[str] | None = None) -> None:
+        pass
+
+    def gauge(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        pass
+
+    def timing(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        pass
+
+    def service_check(
+        self,
+        name: str,
+        status: int,
+        tags: list[str] | None = None,
+        hostname: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        pass
+
+    @contextmanager
+    def timed(self, metric: str, tags: list[str] | None = None) -> Any:
+        yield
+
+
+class FakeStatsd(StatsdInterface):
+    def __init__(self):
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def increment(self, metric: str, value: int = 1, tags: list[str] | None = None) -> None:
+        self.calls.append(("increment", {"metric": metric, "value": value, "tags": tags}))
+
+    def gauge(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        self.calls.append(("gauge", {"metric": metric, "value": value, "tags": tags}))
+
+    def timing(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        self.calls.append(("timing", {"metric": metric, "value": value, "tags": tags}))
+
+    def service_check(
+        self,
+        name: str,
+        status: int,
+        tags: list[str] | None = None,
+        hostname: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.calls.append(
+            ("service_check", {"name": name, "status": status, "tags": tags, "hostname": hostname, "message": message})
+        )
+
+    @contextmanager
+    def timed(self, metric: str, tags: list[str] | None = None) -> Any:
+        self.calls.append(("timed", {"metric": metric, "tags": tags}))
+        yield
+
+
+class DogStatsdWrapper(StatsdInterface):
+    def __init__(self, dogstatsd: DogStatsd):
+        self._dogstatsd = dogstatsd
+
+    def increment(self, metric: str, value: int = 1, tags: list[str] | None = None) -> None:
+        self._dogstatsd.increment(metric, value, tags)
+
+    def gauge(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        self._dogstatsd.gauge(metric, value, tags)
+
+    def timing(self, metric: str, value: float, tags: list[str] | None = None) -> None:
+        self._dogstatsd.timing(metric, value, tags)
+
+    def service_check(
+        self,
+        name: str,
+        status: int,
+        tags: list[str] | None = None,
+        hostname: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        self._dogstatsd.service_check(name, status, tags, hostname, message)
+
+    @contextmanager
+    def timed(self, metric: str, tags: list[str] | None = None) -> Any:
+        with self._dogstatsd.timed(metric, tags):
+            yield
+
+
+_namespace_to_statsd: dict[str, StatsdInterface] = {}
+
+
+def get_statsd(namespace_suffix: Literal[None, "consumer"] = None) -> StatsdInterface:
+    namespace = f"launchpad_{namespace_suffix}" if namespace_suffix else "launchpad"
+
+    if namespace in _namespace_to_statsd:
+        return _namespace_to_statsd[namespace]
 
     disable_telemetry = True
     origin_detection_enabled = False
@@ -34,14 +157,14 @@ def get_statsd(environment: Literal["default", "consumer"] = "default") -> DogSt
     except ValueError:
         raise ValueError(f"STATSD_PORT must be a valid integer, got: {port_str}")
 
-    # Create namespace with environment
-    namespace = "launchpad" if environment == "default" else "launchpad_consumer"
-
-    _statsd_instances[environment] = DogStatsd(
-        host=host,
-        port=port,
-        namespace=namespace,
-        disable_telemetry=disable_telemetry,
-        origin_detection_enabled=origin_detection_enabled,
+    wrapper = DogStatsdWrapper(
+        DogStatsd(
+            host=host,
+            port=port,
+            namespace=namespace,
+            disable_telemetry=disable_telemetry,
+            origin_detection_enabled=origin_detection_enabled,
+        )
     )
-    return _statsd_instances[environment]
+    _namespace_to_statsd[namespace] = wrapper
+    return wrapper

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -12,19 +12,17 @@ from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
 
 from launchpad.server import LaunchpadServer
 from launchpad.service import LaunchpadService
+from launchpad.utils.statsd import FakeStatsd
 
 
 class TestServiceIntegration:
     """Integration tests for the full service."""
 
-    @pytest.mark.xfail
     @pytest.mark.asyncio
     async def test_kafka_message_processing(self):
         """Test processing of different Kafka message types."""
-        service = LaunchpadService()
-
-        # Mock statsd
-        service._statsd = Mock()
+        fake_statsd = FakeStatsd()
+        service = LaunchpadService(fake_statsd)
 
         # Mock service config to make the service appear initialized
         service._service_config = {
@@ -49,12 +47,13 @@ class TestServiceIntegration:
             mock_process.assert_called_once_with("ios-test-123", "test-project-ios", "test-org-123")
 
             # Verify statsd metrics were sent
-            service._statsd.increment.assert_any_call("artifact.processing.started")
-            service._statsd.increment.assert_any_call("artifact.processing.completed")
+            calls = fake_statsd.calls
+            assert ("increment", {"metric": "artifact.processing.started", "value": 1, "tags": None}) in calls
+            assert ("increment", {"metric": "artifact.processing.completed", "value": 1, "tags": None}) in calls
 
             # Reset mocks for next test
             mock_process.reset_mock()
-            service._statsd.reset_mock()
+            fake_statsd.calls.clear()
 
             # Test artifact analysis message with Android artifact
             android_payload: PreprodArtifactEvents = {
@@ -72,10 +71,8 @@ class TestServiceIntegration:
     @pytest.mark.asyncio
     async def test_error_handling_in_message_processing(self):
         """Test that errors in message processing are handled properly."""
-        service = LaunchpadService()
-
-        # Mock statsd
-        service._statsd = Mock()
+        fake_statsd = FakeStatsd()
+        service = LaunchpadService(fake_statsd)
 
         # Create a valid payload
         payload: PreprodArtifactEvents = {
@@ -84,27 +81,29 @@ class TestServiceIntegration:
             "organization_id": "test-org",
         }
 
-        # Mock the handler to raise an exception
-        with patch.object(service, "_statsd") as mock_statsd:
-            mock_statsd.increment.side_effect = [
-                None,  # First call: processing.started
-                Exception("Processing failed"),  # Second call: processing.completed (raises)
-                None,  # Third call: processing.failed
-            ]
+        # Mock process_artifact to raise an exception
+        with patch.object(service, "process_artifact") as mock_process:
+            mock_process.side_effect = Exception("Processing failed")
 
-            # This should raise the exception (to be handled by Arroyo)
-            with pytest.raises(Exception, match="Processing failed"):
-                service.handle_kafka_message(payload)
+            # This should handle the exception gracefully
+            service.handle_kafka_message(payload)
+
+            # Verify the processing method was called
+            mock_process.assert_called_once_with("test-123", "test-project", "test-org")
+
+            # Verify statsd metrics were sent including failure metric
+            calls = fake_statsd.calls
+            increment_calls = [call for call in calls if call[0] == "increment"]
+            assert len(increment_calls) == 2  # started and failed
+            assert increment_calls[0][1]["metric"] == "artifact.processing.started"
+            assert increment_calls[1][1]["metric"] == "artifact.processing.failed"
 
     @pytest.mark.asyncio
     async def test_concurrent_message_processing(self):
         """Test that multiple messages can be processed concurrently."""
-        service = LaunchpadService()
+        fake_statsd = FakeStatsd()
+        service = LaunchpadService(fake_statsd)
 
-        # Mock statsd
-        service._statsd = Mock()
-
-        # Create multiple messages
         messages = [
             {
                 "artifact_id": f"test-artifact-{i}",
@@ -114,12 +113,14 @@ class TestServiceIntegration:
             for i in range(10)
         ]
 
-        # Process all messages
-        for msg in messages:
-            service.handle_kafka_message(msg)  # type: ignore
+        with patch.object(service, "process_artifact"):
+            for msg in messages:
+                service.handle_kafka_message(msg)  # type: ignore
 
-        # Verify all messages were processed
-        assert service._statsd.increment.call_count == 20  # 2 calls per message
+        # Verify all messages were processed (2 increment calls per message: started + completed)
+        calls = fake_statsd.calls
+        increment_calls = [call for call in calls if call[0] == "increment"]
+        assert len(increment_calls) == 20
 
 
 @pytest.mark.integration
@@ -133,7 +134,8 @@ class TestServiceWithMockServer:
         # that would start the actual service and test HTTP endpoints
         # For now, we test the components separately
 
-        server = LaunchpadServer(lambda: True, host="127.0.0.1", port=0)  # Random port
+        fake_statsd = FakeStatsd()
+        server = LaunchpadServer(lambda: True, host="127.0.0.1", port=0, statsd=fake_statsd)  # Random port
         app = server.create_app()
 
         # Test that we can create the app without errors

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
-
-import pytest
+from unittest.mock import patch
 
 from aiohttp.test_utils import AioHTTPTestCase
 from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
@@ -13,6 +11,7 @@ from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
 
 from launchpad.server import LaunchpadServer
 from launchpad.service import LaunchpadService
+from launchpad.utils.statsd import FakeStatsd
 
 
 class TestHealthyLaunchpadServer(AioHTTPTestCase):
@@ -24,7 +23,8 @@ class TestHealthyLaunchpadServer(AioHTTPTestCase):
         def mock_health_check() -> bool:
             return True
 
-        server = LaunchpadServer(health_check_callback=mock_health_check)
+        fake_statsd = FakeStatsd()
+        server = LaunchpadServer(health_check_callback=mock_health_check, statsd=fake_statsd)
         return server.create_app()
 
     async def test_health_check(self):
@@ -52,14 +52,11 @@ class TestHealthyLaunchpadServer(AioHTTPTestCase):
 class TestLaunchpadService:
     """Test cases for LaunchpadService."""
 
-    @pytest.mark.xfail
     @patch.object(LaunchpadService, "process_artifact")
     def test_handle_kafka_message_ios(self, mock_process):
         """Test handling iOS artifact messages."""
-        service = LaunchpadService()
-
-        # Mock statsd
-        service._statsd = Mock()
+        fake_statsd = FakeStatsd()
+        service = LaunchpadService(fake_statsd)
 
         # Create a payload for iOS artifact
         payload: PreprodArtifactEvents = {
@@ -75,17 +72,15 @@ class TestLaunchpadService:
         mock_process.assert_called_once_with("ios-test-123", "test-project-ios", "test-org-123")
 
         # Verify metrics were recorded
-        service._statsd.increment.assert_any_call("artifact.processing.started")
-        service._statsd.increment.assert_any_call("artifact.processing.completed")
+        calls = fake_statsd.calls
+        assert ("increment", {"metric": "artifact.processing.started", "value": 1, "tags": None}) in calls
+        assert ("increment", {"metric": "artifact.processing.completed", "value": 1, "tags": None}) in calls
 
-    @pytest.mark.xfail
     @patch.object(LaunchpadService, "process_artifact")
     def test_handle_kafka_message_android(self, mock_process):
         """Test handling Android artifact messages."""
-        service = LaunchpadService()
-
-        # Mock statsd
-        service._statsd = Mock()
+        fake_statsd = FakeStatsd()
+        service = LaunchpadService(fake_statsd)
 
         # Create a payload for Android artifact
         payload: PreprodArtifactEvents = {
@@ -101,17 +96,15 @@ class TestLaunchpadService:
         mock_process.assert_called_once_with("android-test-456", "test-project-android", "test-org-456")
 
         # Verify metrics were recorded
-        service._statsd.increment.assert_any_call("artifact.processing.started")
-        service._statsd.increment.assert_any_call("artifact.processing.completed")
+        calls = fake_statsd.calls
+        assert ("increment", {"metric": "artifact.processing.started", "value": 1, "tags": None}) in calls
+        assert ("increment", {"metric": "artifact.processing.completed", "value": 1, "tags": None}) in calls
 
-    @pytest.mark.xfail
     @patch.object(LaunchpadService, "process_artifact")
     def test_handle_kafka_message_error(self, mock_process):
         """Test error handling in message processing."""
-        service = LaunchpadService()
-
-        # Mock statsd
-        service._statsd = Mock()
+        fake_statsd = FakeStatsd()
+        service = LaunchpadService(fake_statsd)
 
         # Make process_artifact raise an exception
         mock_process.side_effect = RuntimeError("Download failed: HTTP 404")
@@ -130,7 +123,8 @@ class TestLaunchpadService:
         mock_process.assert_called_once_with("test-123", "test-project", "test-org")
 
         # Verify the metrics were called correctly
-        calls = service._statsd.increment.call_args_list
-        assert len(calls) == 2
-        assert calls[0][0][0] == "artifact.processing.started"
-        assert calls[1][0][0] == "artifact.processing.failed"
+        calls = fake_statsd.calls
+        increment_calls = [call for call in calls if call[0] == "increment"]
+        assert len(increment_calls) == 2
+        assert increment_calls[0][1]["metric"] == "artifact.processing.started"
+        assert increment_calls[1][1]["metric"] == "artifact.processing.failed"


### PR DESCRIPTION
Clean up how Statsd is used:
- Add a NullStatsd so the code does not have to have lots of `if statsd:` branches
- Add a FakeStatsd so tests don't have to do fragile mocking.

This allows us to remove xfail from a number of tests.