### PR TITLE
ref: use structured logging for Apple analysis

### DIFF
--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -49,6 +49,9 @@ class ZippedXCArchive(AppleArtifact):
         self._provisioning_profile: dict[str, Any] | None = None
         self._dsym_files: dict[str, Path] | None = None
 
+    def get_extract_dir(self) -> Path:
+        return self._extract_dir
+
     def get_plist(self) -> dict[str, Any]:
         if self._plist is not None:
             return self._plist
@@ -199,7 +202,12 @@ class ZippedXCArchive(AppleArtifact):
                 framework_dsym_path = dsym_files.get(framework_uuid) if framework_uuid else None
 
                 binaries.append(
-                    BinaryInfo(framework_name, framework_binary_path, framework_dsym_path, is_main_binary=False)
+                    BinaryInfo(
+                        framework_name,
+                        framework_binary_path,
+                        framework_dsym_path,
+                        is_main_binary=False,
+                    )
                 )
 
         # Find app extension binaries
@@ -277,7 +285,10 @@ class ZippedXCArchive(AppleArtifact):
             file_path = parent_path / json_name
 
             if not file_path.exists():
-                logger.warning(f"Assets.json not found at {file_path}")
+                logger.warning(
+                    "size.apple.assets_json_not_found",
+                    extra={"file_path": file_path.relative_to(self._extract_dir)},
+                )
                 return []
 
             with open(file_path, "r", encoding="utf-8") as f:

--- a/src/launchpad/parsers/apple/macho_symbol_sizes.py
+++ b/src/launchpad/parsers/apple/macho_symbol_sizes.py
@@ -39,7 +39,7 @@ class MachOSymbolSizes:
                 )
             )
 
-        logger.info(f"Found {len(symbol_sizes)} symbol sizes")
+        logger.debug(f"Found {len(symbol_sizes)} symbol sizes")
         symbol_sizes.sort(key=lambda x: x.size, reverse=True)
         return symbol_sizes
 
@@ -67,7 +67,7 @@ class MachOSymbolSizes:
                 max_section_addr = section.virtual_address + section.size
             else:
                 max_section_addr = None
-                logger.warning(f"Symbol {sym.name} not found in any section, skipping")
+                logger.warning("size.macho.symbol_not_found_in_section", extra={"symbol": sym.name})
                 continue
 
             # Only calculate the distance between symbols in the same section

--- a/src/launchpad/parsers/apple/objc_symbol_type_aggregator.py
+++ b/src/launchpad/parsers/apple/objc_symbol_type_aggregator.py
@@ -68,7 +68,7 @@ class ObjCSymbolTypeAggregator:
                 class_name = self._class_from_metadata(mname)
                 buckets[(class_name, None)].append(sym)
 
-        logger.info(
+        logger.debug(
             "Aggregated %d Objective-C symbols into %d groups",
             sum(len(v) for v in buckets.values()),
             len(buckets),

--- a/src/launchpad/parsers/apple/swift_symbol_type_aggregator.py
+++ b/src/launchpad/parsers/apple/swift_symbol_type_aggregator.py
@@ -50,7 +50,7 @@ class SwiftSymbolTypeAggregator:
             for symbol in symbol_sizes
             if symbol.mangled_name.startswith("_$s") or symbol.mangled_name.startswith("_Tt")
         ]
-        logger.info(f"Found {len(swift_symbols)} Swift symbols out of {len(symbol_sizes)} total symbols")
+        logger.debug(f"Found {len(swift_symbols)} Swift symbols out of {len(symbol_sizes)} total symbols")
 
         mangled_names = [symbol.mangled_name for symbol in swift_symbols]
 
@@ -99,5 +99,5 @@ class SwiftSymbolTypeAggregator:
         # Sort by total size (descending)
         result.sort(key=lambda x: x.total_size, reverse=True)
 
-        logger.info(f"Aggregated {len(swift_symbols)} Swift symbols into {len(result)} type groups")
+        logger.debug(f"Aggregated {len(swift_symbols)} Swift symbols into {len(result)} type groups")
         return result

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -121,14 +121,23 @@ class AppleAppAnalyzer:
             self.app_info = self.preprocess(artifact)
 
         app_info = self.app_info
-        logger.info(f"Analyzing app: {app_info.name} v{app_info.version}")
+        logger.info(
+            "size.apple.analyze_app",
+            extra={"app_name": app_info.name, "app_version": app_info.version},
+        )
 
         file_analysis = analyze_apple_files(artifact)
-        logger.info(f"Found {file_analysis.file_count} files, total size: {file_analysis.total_size} bytes")
+        logger.debug(f"Found {file_analysis.file_count} files, total size: {file_analysis.total_size} bytes")
 
         app_bundle_path = artifact.get_app_bundle_path()
         download_size, install_size = calculate_bundle_sizes(app_bundle_path)
-        logger.info(f"Download size: {download_size} bytes, Install size: {install_size} bytes")
+        logger.info(
+            "size.apple.bundle_sizes",
+            extra={
+                "download_size": download_size,
+                "install_size": install_size,
+            },
+        )
 
         treemap = None
         binary_analysis: List[MachOBinaryAnalysis] = []
@@ -137,16 +146,37 @@ class AppleAppAnalyzer:
 
         if not self.skip_treemap and not self.skip_component_analysis:
             binaries = artifact.get_all_binary_paths()
-            logger.info(f"Found {len(binaries)} binaries to analyze")
+            logger.debug(f"Found {len(binaries)} binaries to analyze")
 
             for binary_info in binaries:
-                logger.info(f"Analyzing binary {binary_info.name} at {binary_info.path}")
+                logger.info(
+                    "size.apple.binary_analysis_started",
+                    extra={
+                        "event": "size.binary_analysis_started",
+                        "binary_name": binary_info.name,
+                        "binary_path": str(binary_info.path.relative_to(app_bundle_path)),
+                        "has_dsym": binary_info.dsym_path is not None,
+                    },
+                )
                 if binary_info.dsym_path:
-                    logger.debug(f"Found dSYM file for {binary_info.name} at {binary_info.dsym_path}")
+                    logger.debug(
+                        f"Found dSYM file for {binary_info.name} at {binary_info.dsym_path.relative_to(artifact.get_extract_dir())}"
+                    )
                 binary = self._analyze_binary(binary_info, app_bundle_path)
                 if binary is not None:
                     binary_analysis.append(binary)
                     binary_analysis_map[str(binary_info.path.relative_to(app_bundle_path))] = binary
+
+                logger.info(
+                    "size.apple.binary_analysis_completed",
+                    extra={
+                        "event": "size.binary_analysis_completed",
+                        "binary_name": binary_info.name,
+                        "symbol_count": (len(binary.symbol_info.symbol_sizes) if binary.symbol_info else 0),
+                        "swift_types_count": (len(binary.symbol_info.swift_type_groups) if binary.symbol_info else 0),
+                        "objc_types_count": (len(binary.symbol_info.objc_type_groups) if binary.symbol_info else 0),
+                    },
+                )
 
             hermes_reports = make_hermes_reports(app_bundle_path)
 
@@ -160,7 +190,7 @@ class AppleAppAnalyzer:
 
         insights: AppleInsightResults | None = None
         if not self.skip_insights:
-            logger.info("Generating insights from analysis results")
+            logger.info("size.apple.generate_insights")
             insights_input = InsightsInput(
                 app_info=app_info,
                 file_analysis=file_analysis,
@@ -218,6 +248,11 @@ class AppleAppAnalyzer:
             use_si_units=True,
             download_size=download_size,
             install_size=install_size,
+        )
+
+        logger.info(
+            "size.apple.analyze_app_completed",
+            extra={"app_name": app_info.name, "app_version": app_info.version},
         )
 
         return results
@@ -410,7 +445,12 @@ class AppleAppAnalyzer:
                     strippable_symbols_size=strippable_symbols_size,
                 )
             else:
-                logger.warning(f"Failed to parse dwarf binary: {dwarf_binary_path}")
+                logger.error(
+                    "size.apple.skip_symbol_analysis.dwarf_binary_parse_failed",
+                    extra={
+                        "binary_name": binary_info.name,
+                    },
+                )
         else:
             if strippable_symbols_size > 0:
                 symbol_info = SymbolInfo(
@@ -420,7 +460,12 @@ class AppleAppAnalyzer:
                     static_inits=static_inits,
                     strippable_symbols_size=strippable_symbols_size,
                 )
-            logger.info("No dwarf binary path provided, skipping detailed symbol analysis")
+            logger.info(
+                "size.apple.skip_symbol_analysis.no_dwarf_binary",
+                extra={
+                    "binary_name": binary_info.name,
+                },
+            )
 
         # Extract Swift metadata if enabled
         swift_metadata = None

--- a/src/launchpad/size/cli.py
+++ b/src/launchpad/size/cli.py
@@ -1,10 +1,8 @@
-from contextlib import ExitStack
 from pathlib import Path
 from typing import Dict, TextIO
 
 import click
 
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from launchpad.size.models.android import AndroidAnalysisResults
@@ -92,27 +90,14 @@ def size_command(
         flags["working_dir"] = working_dir
 
     try:
-        with ExitStack() as stack:
-            progress = stack.enter_context(
-                Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                    disable=quiet,
-                )
-            )
+        results = do_size(input_path, **flags)
+        if output_format == "json":
+            write_results_as_json(results, output)
+        else:
+            _print_results_as_table(results)
 
-            task = progress.add_task("Analyzing...", total=None)
-            results = do_size(input_path, **flags)
-            if output_format == "json":
-                write_results_as_json(results, output)
-            else:
-                _print_results_as_table(results)
-
-            if isinstance(results, AppleAnalysisResults) and not quiet:
-                _print_apple_summary(results)
-
-            progress.update(task, description="Analysis complete!")
+        if isinstance(results, AppleAnalysisResults) and not quiet:
+            _print_apple_summary(results)
 
     except Exception:
         console.print_exception()

--- a/src/launchpad/size/treemap/treemap_builder.py
+++ b/src/launchpad/size/treemap/treemap_builder.py
@@ -61,7 +61,7 @@ class TreemapBuilder:
         )
 
     def build_file_treemap(self, file_analysis: FileAnalysis) -> TreemapResults:
-        logger.info(f"Building file-based treemap for {self.platform} platform")
+        logger.info("size.treemap.build_file_treemap", extra={"platform": self.platform})
 
         children = self._build_file_hierarchy(file_analysis)
         total_size = sum(child.size for child in children)

--- a/src/launchpad/size/utils/apple_bundle_size.py
+++ b/src/launchpad/size/utils/apple_bundle_size.py
@@ -48,9 +48,9 @@ def _calculate_app_store_size(bundle_url: Path) -> int:
     file_count = 0
 
     for file_path in bundle_url.rglob("*"):
-        logger.info(f"Processing file: {file_path.relative_to(bundle_url)}")
+        logger.debug(f"Processing file: {file_path.relative_to(bundle_url)}")
         if file_path.is_symlink():
-            logger.info("Skipping symlink")
+            logger.debug("Skipping symlink")
             continue
 
         file_count += 1
@@ -67,9 +67,9 @@ def _calculate_app_store_size(bundle_url: Path) -> int:
             file_size = to_nearest_block_size(get_file_size(file_path), APPLE_FILESYSTEM_BLOCK_SIZE)
 
         total_size += file_size
-        logger.info(f"File size: {file_size}, Total size: {total_size}")
+        logger.debug(f"File size: {file_size}, Total size: {total_size}")
 
-    logger.info(f"App Store size calculation: {file_count} files, {total_size} bytes")
+    logger.debug(f"App Store size calculation: {file_count} files, {total_size} bytes")
 
     return total_size
 
@@ -115,7 +115,7 @@ def _zip_metadata_size_for_bundle(bundle_url: Path) -> int:
     bundle_name = bundle_url.name
 
     try:
-        logger.info(f"Creating ZIP file: zip -r {zip_file_path} {bundle_name}")
+        logger.debug(f"Creating ZIP file: zip -r {zip_file_path} {bundle_name}")
         result = subprocess.run(
             ["zip", "-r", str(zip_file_path), str(bundle_name)],
             shell=False,
@@ -127,7 +127,7 @@ def _zip_metadata_size_for_bundle(bundle_url: Path) -> int:
             logger.error(f"ZIP command failed: {result.stderr}")
             return 0
 
-        logger.info(f"Getting ZIP info: unzip -v {zip_file_path}")
+        logger.debug(f"Getting ZIP info: unzip -v {zip_file_path}")
         with open(zip_info_file_path, "w") as zip_info_file:
             result = subprocess.run(
                 ["unzip", "-v", str(zip_file_path)],

--- a/src/launchpad/utils/logging.py
+++ b/src/launchpad/utils/logging.py
@@ -7,6 +7,52 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 
+class StructuredRichHandler(RichHandler):
+    """RichHandler that shows structured logging extras."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = super().format(record)
+
+        # Default attributes to ignore
+        standard_attrs = {
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+            "getMessage",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "message",
+            "taskName",
+        }
+
+        extras = {k: v for k, v in record.__dict__.items() if k not in standard_attrs and not k.startswith("_")}
+
+        if extras:
+            extra_parts = []
+            for key, value in extras.items():
+                extra_parts.append(f"[dim]{key}[/dim]=[yellow]{value}[/yellow]")
+
+            if extra_parts:
+                message += f" [dim]|[/dim] {' '.join(extra_parts)}"
+
+        return message
+
+
 def setup_logging(verbose: bool = False, quiet: bool = False) -> None:
     """Setup logging configuration.
 
@@ -31,7 +77,7 @@ def setup_logging(verbose: bool = False, quiet: bool = False) -> None:
             format="%(message)s",
             datefmt="[%X]",
             handlers=[
-                RichHandler(
+                StructuredRichHandler(
                     console=console,
                     show_time=True,
                     show_path=False,

--- a/src/launchpad/utils/performance.py
+++ b/src/launchpad/utils/performance.py
@@ -10,6 +10,8 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Callable, List, TypeVar
 
+from launchpad.utils.logging import get_logger
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 # --------------------------------------------------------------------------- #
@@ -164,12 +166,10 @@ class Registry:
 
     def log_summary(self, logger_name: str | None = None, level: str = "info") -> None:
         """Emit summary through the logger (never prints)."""
-        from launchpad.utils.logging import get_logger
 
         log = get_logger(logger_name) if logger_name else get_logger(__name__)
-        log_fn = getattr(log, level, log.info)
         for line in self.summary_lines():
-            log_fn(line)
+            log.debug(line)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Cleans up much of our logging for Apple to be consistent and use structured logging:
- only important log messages are kept as INFO+ level
- uses a stable log name with `extras` for fields
- removes the Progress loader which made the local output annoying to follow
- formats many of the file names to be relative to the app root so they look nicer

For debug statements I think it's fine to stick with narrative based logging since that's easier, but don't have a strong opinion. Once we get this deployed we'll be bumping the server log level to INFO so it won't matter much in that environment.

New output looks like:
```
[16:27:46] INFO     size.apple.analyze_app | app_name=HackerNews app_version=3.8                         
           WARNING  size.apple.assets_json_not_found | file_path=HackerNews 5-19-25,                     
                    12.15ΓÇ»PM.xcarchive/ParsedAssets/Products/Applications/HackerNews.app/Assets.json   
           WARNING  size.apple.assets_json_not_found | file_path=HackerNews 5-19-25,                     
                    12.15ΓÇ»PM.xcarchive/ParsedAssets/Products/Applications/HackerNews.app/PlugIns/Hacker
                    NewsHomeWidgetExtension.appex/Assets.json                                            
[16:27:47] INFO     size.apple.bundle_sizes | download_size=4200266 install_size=7340032                 
           INFO     size.apple.binary_analysis_started | event=size.binary_analysis_started              
                    binary_name=HackerNews binary_path=HackerNews has_dsym=True                          
[16:27:48] WARNING  size.macho.symbol_not_found_in_section | symbol=__mh_execute_header                  
[16:27:51] INFO     size.apple.binary_analysis_completed | event=size.binary_analysis_completed          
                    binary_name=HackerNews symbol_count=24465 swift_types_count=708 objc_types_count=3244
           INFO     size.apple.binary_analysis_started | event=size.binary_analysis_started              
                    binary_name=Sentry binary_path=Frameworks/Sentry.framework/Sentry has_dsym=False     
           INFO     size.apple.skip_symbol_analysis.no_dwarf_binary | binary_name=Sentry                 
           INFO     size.apple.binary_analysis_completed | event=size.binary_analysis_completed          
                    binary_name=Sentry symbol_count=0 swift_types_count=0 objc_types_count=0             
           INFO     size.apple.binary_analysis_started | event=size.binary_analysis_started              
                    binary_name=Common binary_path=Frameworks/Common.framework/Common has_dsym=True      
           INFO     size.apple.binary_analysis_completed | event=size.binary_analysis_completed          
                    binary_name=Common symbol_count=1345 swift_types_count=60 objc_types_count=0         
           INFO     size.apple.binary_analysis_started | event=size.binary_analysis_started              
                    binary_name=Reaper binary_path=Frameworks/Reaper.framework/Reaper has_dsym=False     
           INFO     size.apple.skip_symbol_analysis.no_dwarf_binary | binary_name=Reaper                 
           INFO     size.apple.binary_analysis_completed | event=size.binary_analysis_completed          
                    binary_name=Reaper symbol_count=0 swift_types_count=0 objc_types_count=0             
           INFO     size.apple.binary_analysis_started | event=size.binary_analysis_started              
                    binary_name=HackerNewsHomeWidgetExtension/HackerNewsHomeWidgetExtension              
                    binary_path=PlugIns/HackerNewsHomeWidgetExtension.appex/HackerNewsHomeWidgetExtension
                    has_dsym=True                                                                        
           WARNING  size.macho.symbol_not_found_in_section | symbol=__mh_execute_header                  
           INFO     size.apple.binary_analysis_completed | event=size.binary_analysis_completed          
                    binary_name=HackerNewsHomeWidgetExtension/HackerNewsHomeWidgetExtension              
                    symbol_count=444 swift_types_count=57 objc_types_count=0                             
           INFO     size.treemap.build_file_treemap | platform=ios                                       
           INFO     size.apple.generate_insights                                                         
           INFO     size.apple.analyze_app_completed | app_name=HackerNews app_version=3.8 
```