### PR TITLE
Ping lief to 0.16.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.12.15
 click>=8.1.0
 confluent-kafka>=2.9.0,<2.10.0
-lief>=0.14.0
+lief==0.16.6
 pillow>=11.3.0
 pillow_heif>=1.1.0
 pydantic>=2.9.2,<2.10.0


### PR DESCRIPTION
lief renames:
lief.MachO.Symbol.ORIGIN.LC_SYMTAB
to:
lief.MachO.Symbol.ORIGIN.SYMTAB

Among other changes: https://lief.re/doc/stable/changelog.html

Pin lief to 0.16.6 for now so we can upgrade on our own timeline.
