### PR TITLE
Add optional cleanup to Artifacts

### DIFF
--- a/src/launchpad/artifacts/android/aab.py
+++ b/src/launchpad/artifacts/android/aab.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import shutil
+import tempfile
+
 from pathlib import Path
+from typing import Callable
 
 from launchpad.parsers.android.dex.dex_mapping import DexMapping
 from launchpad.utils.android.bundletool import Bundletool, DeviceSpec
@@ -20,9 +24,8 @@ logger = get_logger(__name__)
 
 
 class AAB(AndroidArtifact):
-    def __init__(self, path: Path) -> None:
-        super().__init__(path)
-        self._path = path
+    def __init__(self, path: Path, cleanup: None | Callable[[], None] = None) -> None:
+        super().__init__(path, cleanup=cleanup)
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._manifest: AndroidManifest | None = None
@@ -74,11 +77,14 @@ class AAB(AndroidArtifact):
         apks_dir = create_temp_directory("apks-")
         try:
             bundletool = Bundletool()
-            bundletool.build_apks(bundle_path=self._path, output_dir=apks_dir, device_spec=device_spec)
+            bundletool.build_apks(bundle_path=self.path, output_dir=apks_dir, device_spec=device_spec)
 
             apks = []
             for apk_path in apks_dir.glob("*.apk"):
-                apks.append(APK(apk_path, self.get_dex_mapping()))
+                tmp_dir = Path(tempfile.mkdtemp())
+                new_apk_path = tmp_dir / apk_path.name
+                shutil.copyfile(apk_path, new_apk_path)
+                apks.append(APK(new_apk_path, self.get_dex_mapping(), cleanup=lambda: shutil.rmtree(tmp_dir)))
 
             self._primary_apks = apks
             return apks
@@ -91,7 +97,7 @@ class AAB(AndroidArtifact):
 
         bundletool = Bundletool()
         bundletool.build_apks(
-            bundle_path=self._path,
+            bundle_path=self.path,
             output_dir=apk_dir,
             device_spec=device_spec,
             universal_apk=True,

--- a/src/launchpad/artifacts/android/apk.py
+++ b/src/launchpad/artifacts/android/apk.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import IO, Iterator
+from typing import IO, Callable, Iterator
 
 from launchpad.parsers.android.dex.dex_mapping import DexMapping
 from launchpad.utils.android.apksigner import Apksigner
@@ -22,9 +22,10 @@ logger = get_logger(__name__)
 
 
 class APK(AndroidArtifact):
-    def __init__(self, path: Path, dex_mapping: DexMapping | None = None) -> None:
-        super().__init__(path)
-        self._path = path
+    def __init__(
+        self, path: Path, dex_mapping: DexMapping | None = None, cleanup: None | Callable[[], None] = None
+    ) -> None:
+        super().__init__(path, cleanup=cleanup)
         self._dex_mapping = dex_mapping
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
@@ -34,7 +35,7 @@ class APK(AndroidArtifact):
 
     @contextmanager
     def raw_file(self) -> Iterator[IO[bytes]]:
-        f = open(self._path, "rb")
+        f = open(self.path, "rb")
         try:
             yield f
         finally:
@@ -102,4 +103,4 @@ class APK(AndroidArtifact):
 
     def get_apksigner_certs(self) -> str:
         apksigner = Apksigner()
-        return apksigner.get_certs(self._path)
+        return apksigner.get_certs(self.path)

--- a/src/launchpad/artifacts/android/zipped_aab.py
+++ b/src/launchpad/artifacts/android/zipped_aab.py
@@ -1,4 +1,8 @@
+import shutil
+import tempfile
+
 from pathlib import Path
+from typing import Callable
 
 from ..artifact import AndroidArtifact
 from ..providers.zip_provider import ZipProvider
@@ -8,8 +12,8 @@ from .manifest.manifest import AndroidManifest
 
 
 class ZippedAAB(AndroidArtifact):
-    def __init__(self, path: Path) -> None:
-        super().__init__(path)
+    def __init__(self, path: Path, cleanup: None | Callable[[], None] = None) -> None:
+        super().__init__(path, cleanup=cleanup)
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._aab: AAB | None = None
@@ -23,7 +27,10 @@ class ZippedAAB(AndroidArtifact):
 
         for path in self._extract_dir.rglob("*.aab"):
             if path.is_file():
-                self._aab = AAB(path)
+                tmp_dir = Path(tempfile.mkdtemp())
+                new_path = tmp_dir / path.name
+                shutil.copyfile(path, new_path)
+                self._aab = AAB(new_path, cleanup=lambda: shutil.rmtree(tmp_dir))
                 return self._aab
 
         raise FileNotFoundError(f"No AAB found in {self._extract_dir}")

--- a/src/launchpad/artifacts/android/zipped_apk.py
+++ b/src/launchpad/artifacts/android/zipped_apk.py
@@ -1,4 +1,8 @@
+import shutil
+import tempfile
+
 from pathlib import Path
+from typing import Callable
 
 from ..artifact import AndroidArtifact
 from ..providers.zip_provider import ZipProvider
@@ -7,9 +11,8 @@ from .manifest.manifest import AndroidManifest
 
 
 class ZippedAPK(AndroidArtifact):
-    def __init__(self, path: Path) -> None:
-        super().__init__(path)
-        self.path = path
+    def __init__(self, path: Path, cleanup: None | Callable[[], None] = None) -> None:
+        super().__init__(path, cleanup=cleanup)
         self._zip_provider = ZipProvider(path)
         self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._primary_apk: APK | None = None
@@ -23,7 +26,10 @@ class ZippedAPK(AndroidArtifact):
 
         for path in self._extract_dir.rglob("*.apk"):
             if path.is_file():
-                self._primary_apk = APK(path)
+                tmp_dir = Path(tempfile.mkdtemp())
+                new_path = tmp_dir / path.name
+                shutil.copyfile(path, new_path)
+                self._primary_apk = APK(new_path, None, cleanup=lambda: shutil.rmtree(tmp_dir))
                 return self._primary_apk
 
         raise FileNotFoundError(f"No primary APK found in {self._extract_dir}")

--- a/src/launchpad/artifacts/artifact.py
+++ b/src/launchpad/artifacts/artifact.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .android.manifest.manifest import AndroidManifest
 from .android.resources.resource_table import ResourceTable
@@ -8,8 +8,17 @@ from .android.resources.resource_table import ResourceTable
 class Artifact:
     """Base class for all artifacts that can be analyzed."""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, cleanup: None | Callable[[], None] = None) -> None:
         self.path = path
+        self.cleanup = cleanup
+
+    def __del__(self):
+        # __del__ can be called prior to __init__ finishing
+        # if e.g. __init__ throws an exception so we have to be very
+        # careful what we rely on:
+        cleanup = getattr(self, "cleanup", None)
+        if cleanup:
+            cleanup()
 
 
 class AndroidArtifact(Artifact):

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -287,7 +287,7 @@ class AndroidAnalyzer:
 
         for apk in apks:
             # Get the original APK file path
-            apk_path = apk._path
+            apk_path = apk.path
             logger.debug("Calculating sizes for APK: %s", apk_path)
 
             try:


### PR DESCRIPTION
Artifacts are created using a path and the file/folder at that path has to live at least at long as the artifact.

Sometimes the path lives forever (e.g. when using a test fixture):
```
apk = APK(test_fixtures / "hn.apk")
```

Sometimes that path lifetime is managed external to the artifact:
```
with download_apk_to_path() as path:
  apk = APK(path)
```

And sometimes ideally the path lifetime would live exactly as long as the artifact:
```
class ZippedAAB(AndroidArtifact):
  def get_primary_apk(self):
    # ...
    for path in self._extract_dir.rglob("*.aab"):
      if path.is_file():
         self._aab = AAB(path)
         return self._aab
```

This latter case is hard to solve at the moment since it's easy for the lifetime of
the path to become detached from the lifetime of APK. This leads to either:
- leaking disk
- accidentally cleaning up the path while the Artifact still lives

This adds an optional cleanup method called by __del__ so that we
can cause a path to be cleaned up only after the last reference to an artifact is
gc'ed.

The above code can now be written as:

```
class ZippedAAB(AndroidArtifact):
  def get_primary_apk(self):
    # ...
    for path in self._extract_dir.rglob("*.aab"):
      if path.is_file():
        tmp_dir = Path(tempfile.mkdtemp())
        new_path = tmp_dir / path.name
        shutil.copyfile(path, new_path)
        self._aab = AAB(new_path, cleanup=lambda: shutil.rmtree(tmp_dir))
        return self._aab
```

Which is not the nicest but at least aligns the lifetimes.

Resolves: EME-273