### PR TITLE
Add run configuration for memray

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -80,6 +80,33 @@
       "justMyCode": false
     },
     {
+      "name": "Python: Memray Debug iOS CLI",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${workspaceFolder}/.venv/bin/python",
+      "module": "memray",
+      "args": [
+        "run",
+        "--native",
+        "--output",
+        "output/memray-profile.bin",
+        "-m",
+        "launchpad.cli",
+        "size",
+        "tests/_fixtures/ios/HackerNews.xcarchive.zip",
+        "--output",
+        "output/apple-size-output.json"
+      ],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "PYTHONMALLOC": "malloc",
+        "PATH": "${workspaceFolder}/.devenv/all/bin:${workspaceFolder}/.devenv/aarch64-darwin/bin:${env:PATH}"
+      },
+      "justMyCode": false
+    },
+    {
       "name": "Python: Debug Android AAB CLI",
       "type": "debugpy",
       "request": "launch",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ bandit>=1.7.0
 pip-audit>=2.6.0
 debugpy>=1.8.16
 responses>=0.25.8
+memray>=1.0.0
 
 # Testing web endpoints
 aiohttp-test-utils>=0.5.0


### PR DESCRIPTION
Adding a built-in way to run `memray` against our project which is a neat memory profiling tool Nico shared.