### PR TITLE
Skip parsing Obj-C method names for encrypted binaries

### DIFF
--- a/src/launchpad/parsers/apple/macho_parser.py
+++ b/src/launchpad/parsers/apple/macho_parser.py
@@ -218,6 +218,11 @@ class MachOParser:
             List of method names found in the section, or empty list if section not found
         """
         try:
+            is_encrypted = self.is_encrypted()
+            if is_encrypted:
+                logger.debug("__objc_methname section is encrypted, skipping")
+                return []
+
             content = self.get_section_bytes("__objc_methname")
             if content is None:
                 logger.debug("__objc_methname section not found")
@@ -248,7 +253,10 @@ class MachOParser:
                 swift_version = (flags >> 8) & 0xFF
                 has_swift_info = swift_version != 0
                 logger.debug(
-                    "objc_imageinfo flags=0x%08x  swift=%d  objcFlags=0x%02x", flags, swift_version, flags & 0xFF
+                    "objc_imageinfo flags=0x%08x  swift=%d  objcFlags=0x%02x",
+                    flags,
+                    swift_version,
+                    flags & 0xFF,
                 )
                 return has_swift_info
             return False
@@ -297,6 +305,6 @@ class MachOParser:
         dyld_chained_fixups = self.binary.dyld_chained_fixups
         dyld_exports_trie = self.binary.dyld_exports_trie
         return DyldInfo(
-            chained_fixups_size=dyld_chained_fixups.data_size if dyld_chained_fixups else 0,
+            chained_fixups_size=(dyld_chained_fixups.data_size if dyld_chained_fixups else 0),
             export_trie_size=dyld_exports_trie.data_size if dyld_exports_trie else 0,
         )


### PR DESCRIPTION
Should fix https://sentry.sentry.io/issues/6873959750/?project=4509667577233409&query=is%3Aunresolved&referrer=issue-stream from what I can tell testing locally.

The `__objc_methname` segment is part of the encrypted __TEXT section of the binary so we can't simply parse the names from it.