### PR TITLE
tweak memray visualization script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -104,7 +104,9 @@
         "PYTHONMALLOC": "malloc",
         "PATH": "${workspaceFolder}/.devenv/all/bin:${workspaceFolder}/.devenv/aarch64-darwin/bin:${env:PATH}"
       },
-      "justMyCode": false
+      "justMyCode": false,
+      "preLaunchTask": "cleanup-memray-files",
+      "postDebugTask": "generate-memray-flamegraph"
     },
     {
       "name": "Python: Debug Android AAB CLI",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,39 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "cleanup-memray-files",
+      "type": "shell",
+      "command": "rm",
+      "args": ["-f", "output/memray-profile.bin", "output/memray-flamegraph-profile.html"],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "generate-memray-flamegraph",
+      "type": "shell",
+      "command": "python",
+      "args": ["-m", "memray", "flamegraph", "output/memray-profile.bin"],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
After using the vscode run config that @trevor-e added [here](https://github.com/getsentry/launchpad/pull/358), you can run this python script `python scripts/analyze_memray_profiles.py` to generate an HTML page allowing for easy visualizing of the memory profiling