### PR TITLE
Remove OldUpdateResponse from sentry_client.py

### DIFF
--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -83,15 +83,6 @@ class UpdateResponse(BaseModel):
     updated_fields: list[str]
 
 
-class OldUpdateResponse(BaseModel):
-    # Deliberately no alias_generator=to_camel the old version of the
-    # endpoint returns snake case unlike the others.
-    model_config = ConfigDict(strict=True)
-    success: bool
-    artifact_id: str
-    updated_fields: list[str]
-
-
 class ChunkOptionsResponse(BaseModel):
     model_config = ConfigDict(strict=True, alias_generator=to_camel)
     url: str
@@ -196,15 +187,10 @@ class SentryClient:
 
         return file_size
 
-    def update_artifact(
-        self, org: str, project: str, artifact_id: str, data: Dict[str, Any]
-    ) -> UpdateResponse | OldUpdateResponse:
+    def update_artifact(self, org: str, project: str, artifact_id: str, data: Dict[str, Any]) -> UpdateResponse:
         """Update preprod artifact."""
         endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/update/"
-        try:
-            return self._make_json_request("PUT", endpoint, UpdateResponse, data=data)
-        except SentryClientError:
-            return self._make_json_request("PUT", endpoint, OldUpdateResponse, data=data)
+        return self._make_json_request("PUT", endpoint, UpdateResponse, data=data)
 
     def upload_size_analysis_file(
         self,

--- a/tests/unit/test_sentry_client.py
+++ b/tests/unit/test_sentry_client.py
@@ -10,7 +10,6 @@ from responses.matchers import multipart_matcher
 
 from launchpad.sentry_client import (
     ChunkOptionsResponse,
-    OldUpdateResponse,
     SentryClient,
     SentryClientError,
     UpdateResponse,
@@ -126,24 +125,6 @@ class TestSentryClientRetry:
         client = SentryClient(base_url="https://example.com", shared_secret="password")
         response = client.update_artifact("test-org", "test-project", "test-artifact", {"version": "1.0"})
         assert response == UpdateResponse(success=True, artifactId="test-artifact", updatedFields=["version"])
-
-    @responses.activate
-    def test_update_artifact_old(self):
-        """Test that update_artifact uses the retry session."""
-
-        responses.add(
-            responses.PUT,
-            "https://example.com/api/0/internal/test-org/test-project/files/preprodartifacts/test-artifact/update/",
-            json={
-                "success": True,
-                "artifact_id": "test-artifact",
-                "updated_fields": ["version"],
-            },
-        )
-
-        client = SentryClient(base_url="https://example.com", shared_secret="password")
-        response = client.update_artifact("test-org", "test-project", "test-artifact", {"version": "1.0"})
-        assert response == OldUpdateResponse(success=True, artifact_id="test-artifact", updated_fields=["version"])
 
     @responses.activate
     def test_upload_installable_app_previously_uploaded(self):


### PR DESCRIPTION
This completes the three way patch to update the field names.
