### PR TITLE
Don't throw on unexceptional cases for code signing

### DIFF
--- a/src/launchpad/utils/apple/code_signature_validator.py
+++ b/src/launchpad/utils/apple/code_signature_validator.py
@@ -253,13 +253,13 @@ class CodeSignatureValidator:
             raise ValueError("MachO parser not initialized")
 
         code_signature = self.macho_parser.parse_code_signature()
-        code_directory = code_signature.code_directory if code_signature else None
-        if not code_directory:
-            logger.info("No code directory found")
-            return BinaryCheckResult(valid=False)
-
         if not code_signature:
             logger.info("No code signature found")
+            return BinaryCheckResult(valid=False)
+
+        code_directory = code_signature.code_directory
+        if not code_directory:
+            logger.info("No code directory found")
             return BinaryCheckResult(valid=False)
 
         is_valid_signature = self._check_is_valid_signature(code_signature)


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/6889322282/?alert_rule_id=16138328&alert_type=issue&notification_uuid=e3cb1951-9db1-49d8-96dc-78fb94402efd&project=4509667577233409&referrer=slack

This is a valid app and we should only throw in exceptional cases.