### PR TITLE
Parallelize pytest runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             -e KAFKA_BOOTSTRAP_SERVERS="localhost:9092" \
             -e KAFKA_GROUP_ID="launchpad-test" \
             -e KAFKA_TOPICS="preprod-artifact-events" \
-            launchpad-test python -m pytest tests/ -v
+            launchpad-test python -m pytest -n auto tests/ -v
 
       - name: Test CLI installation and basic functionality in Docker
         run: |
@@ -121,7 +121,7 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             --user $(id -u):$(id -g) \
-            launchpad-test python -m pytest tests/unit/ tests/integration/ -v --cov --cov-branch --cov-report=xml --junitxml=junit.xml
+            launchpad-test python -m pytest -n auto tests/unit/ tests/integration/ -v --cov --cov-branch --cov-report=xml --junitxml=junit.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ install-dev: $(VENV_DIR)
 	$(VENV_DIR)/bin/pre-commit install
 
 test:
-	$(PYTHON_VENV) -m pytest tests/unit/ tests/integration/ -v
+	$(PYTHON_VENV) -m pytest -n auto tests/unit/ tests/integration/ -v
 
 test-unit:
-	$(PYTHON_VENV) -m pytest tests/unit/ -v
+	$(PYTHON_VENV) -m pytest -n auto tests/unit/ -v
 
 test-integration:
-	$(PYTHON_VENV) -m pytest tests/integration/ -v
+	$(PYTHON_VENV) -m pytest -n auto tests/integration/ -v
 
 coverage:
 	$(PYTHON_VENV) -m pytest tests/unit/ tests/integration/ -v --cov --cov-branch --cov-report=xml --junitxml=junit.xml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ devservices>=1.2.1
 
 # Development dependencies
 pytest>=8.4.2
+pytest-xdist>=3.8.0
 pytest-mock>=3.15.0
 pytest-asyncio>=1.1.0
 pytest-cov>=6.2.1


### PR DESCRIPTION
Add pytest-xdist and use it in CI / Makefile.

pytest-xdist adds the ability for pytest (when run with
`-n <auto/job count>`) to use multiple worker processes to speed up
running tests. For us this is good for a ~1.8x speed up (27s -> 15s
for unittests, 92s -> 47s for integration tests).

$ time pytest  tests/unit/
________________________________________________________
Executed in   27.06 secs    fish           external
   usr time   18.82 secs  130.00 micros   18.82 secs
   sys time    2.19 secs  691.00 micros    2.19 secs

$ time pytest -n auto tests/unit/
________________________________________________________
Executed in   14.81 secs    fish           external
   usr time   31.00 secs   58.00 micros   31.00 secs
   sys time    5.00 secs  614.00 micros    5.00 secs

$ time pytest tests/integration/
________________________________________________________
Executed in   92.11 secs    fish           external
   usr time  135.90 secs    0.09 millis  135.90 secs
   sys time   21.05 secs    1.75 millis   21.05 secs

$ time pytest -n auto tests/integration/
________________________________________________________
Executed in   46.70 secs    fish           external
   usr time  151.14 secs   44.86 millis  151.09 secs
   sys time   25.20 secs    7.29 millis   25.19 secs
