### PR TITLE
ref(preprod): clean up duplicate exception logging

### DIFF
--- a/src/launchpad/artifacts/android/manifest/axml.py
+++ b/src/launchpad/artifacts/android/manifest/axml.py
@@ -97,8 +97,8 @@ class BinaryXmlParser:
 
             return convert_node(parsed_node)
 
-        except Exception as e:
-            logger.error(f"Failed to parse binary XML: {e}")
+        except Exception:
+            logger.exception("Failed to parse binary XML")
             return None
 
 

--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -66,7 +66,7 @@ class ZippedXCArchive(AppleArtifact):
             self._plist = plist_data
             return plist_data
         except Exception as e:
-            raise RuntimeError(f"Failed to parse Info.plist: {e}")
+            raise RuntimeError("Failed to parse Info.plist") from e
 
     def generate_ipa(self, output_path: Path):
         """Generate an IPA file
@@ -115,7 +115,7 @@ class ZippedXCArchive(AppleArtifact):
                 logger.info(f"IPA file generated successfully: {output_path}")
                 return output_path
             except subprocess.CalledProcessError as e:
-                raise RuntimeError(f"Failed to generate IPA file with zip: {e}")
+                raise RuntimeError("Failed to generate IPA file with zip") from e
             except FileNotFoundError:
                 raise RuntimeError("zip command not found. This tool is required for IPA generation.")
 
@@ -238,8 +238,8 @@ class ZippedXCArchive(AppleArtifact):
                                     is_main_binary=True,  # App extension main executables are main binaries
                                 )
                             )
-                    except Exception as e:
-                        logger.warning(f"Failed to read extension Info.plist at {extension_path}: {e}")
+                    except Exception:
+                        logger.exception(f"Failed to read extension Info.plist at {extension_path}")
 
         # Find Watch app binaries
         for watch_path in app_bundle_path.rglob("Watch/*.app"):
@@ -267,8 +267,8 @@ class ZippedXCArchive(AppleArtifact):
                                     is_main_binary=True,  # Watch app main executables are main binaries
                                 )
                             )
-                    except Exception as e:
-                        logger.warning(f"Failed to read Watch app Info.plist at {watch_path}: {e}")
+                    except Exception:
+                        logger.exception(f"Failed to read Watch app Info.plist at {watch_path}")
 
         return binaries
 
@@ -295,8 +295,8 @@ class ZippedXCArchive(AppleArtifact):
                 data = json.load(f)
 
             return [self._parse_asset_element(item, parent_path) for item in data]
-        except Exception as e:
-            logger.error(f"Failed to get asset catalog details for {relative_path}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get asset catalog details for {relative_path}")
             return []
 
     def _get_main_binary_path(self) -> Path:
@@ -358,8 +358,8 @@ class ZippedXCArchive(AppleArtifact):
                 logger.debug(f"No UUID command found in binary: {binary_path}")
                 return None
 
-        except Exception as e:
-            logger.error(f"Failed to extract UUID from binary {binary_path}: {e}")
+        except Exception:
+            logger.exception(f"Failed to extract UUID from binary {binary_path}")
             return None
 
     def _find_dsym_files(self) -> dict[str, Path]:

--- a/src/launchpad/artifacts/artifact_factory.py
+++ b/src/launchpad/artifacts/artifact_factory.py
@@ -65,11 +65,9 @@ class ArtifactFactory:
                         return APK(path)
 
             except BadZipFile as e:
-                logger.error(f"ZIP file is corrupted: {e}")
-                raise ValueError(f"Corrupted ZIP file: {e}")
+                raise ValueError("File appears to be a corrupted ZIP archive") from e
             except Exception as e:
-                logger.error(f"Unexpected error reading ZIP: {e}")
-                raise ValueError(f"Error reading ZIP file: {e}")
+                raise ValueError("Failed to read ZIP archive") from e
 
         # Check if it's a direct APK or AAB by looking for AndroidManifest.xml in specific locations
         try:

--- a/src/launchpad/artifacts/providers/zip_provider.py
+++ b/src/launchpad/artifacts/providers/zip_provider.py
@@ -32,12 +32,8 @@ class ZipProvider:
         temp_dir = create_temp_directory("zip-extract-")
         self._temp_dirs.append(temp_dir)
 
-        try:
-            self._safe_extract(str(self.path), str(temp_dir))
-            logger.debug(f"Extracted zip contents to {temp_dir} using system unzip")
-        except Exception as e:
-            logger.error(f"Failed to extract zip contents to {temp_dir}: {e}")
-            raise e
+        self._safe_extract(str(self.path), str(temp_dir))
+        logger.debug(f"Extracted zip contents to {temp_dir} using system unzip")
 
         return temp_dir
 

--- a/src/launchpad/parsers/apple/macho_parser.py
+++ b/src/launchpad/parsers/apple/macho_parser.py
@@ -110,8 +110,8 @@ class MachOParser:
 
             return content[offset : offset + size]
 
-        except Exception as e:
-            logger.error(f"Failed to get section bytes at offset for {section_name}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get section bytes at offset for {section_name}")
             return None
 
     @trace(name="get_section_bytes")
@@ -137,8 +137,8 @@ class MachOParser:
             logger.debug(f"Section {section_name} not found")
             return None
 
-        except Exception as e:
-            logger.error(f"Failed to get section content for {section_name}: {e}")
+        except Exception:
+            logger.exception(f"Failed to get section content for {section_name}")
             return None
 
     @trace(name="is_encrypted")
@@ -155,8 +155,8 @@ class MachOParser:
 
             # If encryption_info exists and crypt_id is non-zero, the binary is encrypted
             return bool(self.binary.encryption_info.crypt_id)
-        except Exception as e:
-            logger.error(f"Failed to check encryption status: {e}")
+        except Exception:
+            logger.exception("Failed to check encryption status")
             return False
 
     @trace(name="parse_swift_protocol_conformances")
@@ -232,8 +232,8 @@ class MachOParser:
             logger.debug(f"Parsed {len(method_names)} Objective-C method names")
             return method_names
 
-        except Exception as e:
-            logger.error(f"Failed to parse Objective-C method names: {e}")
+        except Exception:
+            logger.exception("Failed to parse Objective-C method names")
             return []
 
     @trace(name="has_swift_imageinfo")
@@ -260,8 +260,8 @@ class MachOParser:
                 )
                 return has_swift_info
             return False
-        except Exception as e:
-            logger.error("Could not parse __objc_imageinfo: %s", e)
+        except Exception:
+            logger.exception("Could not parse __objc_imageinfo")
             return False
 
     @trace(name="static_inits")

--- a/src/launchpad/service.py
+++ b/src/launchpad/service.py
@@ -18,9 +18,7 @@ from typing import Any, Dict, Iterator, cast
 
 import sentry_sdk
 
-from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import (
-    PreprodArtifactEvents,
-)
+from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import PreprodArtifactEvents
 
 from launchpad.api.update_api_models import AppleAppInfo as AppleAppInfoModel
 from launchpad.api.update_api_models import UpdateData
@@ -236,7 +234,7 @@ class LaunchpadService:
         try:
             return ArtifactFactory.from_path(path)
         except Exception as e:
-            logger.exception(e)
+            logger.exception("Failed to parse artifact")
             self._update_artifact_error_from_exception(
                 organization_id,
                 project_id,

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -18,20 +18,14 @@ from launchpad.artifacts.artifact import AppleArtifact
 from launchpad.parsers.apple.macho_parser import MachOParser
 from launchpad.parsers.apple.macho_symbol_sizes import MachOSymbolSizes
 from launchpad.parsers.apple.objc_symbol_type_aggregator import ObjCSymbolTypeAggregator
-from launchpad.parsers.apple.swift_symbol_type_aggregator import (
-    SwiftSymbolTypeAggregator,
-)
+from launchpad.parsers.apple.swift_symbol_type_aggregator import SwiftSymbolTypeAggregator
 from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.hermes.utils import make_hermes_reports
 from launchpad.size.insights.apple.image_optimization import ImageOptimizationInsight
 from launchpad.size.insights.apple.localized_strings import LocalizedStringsInsight
-from launchpad.size.insights.apple.localized_strings_minify import (
-    MinifyLocalizedStringsInsight,
-)
+from launchpad.size.insights.apple.localized_strings_minify import MinifyLocalizedStringsInsight
 from launchpad.size.insights.apple.loose_images import LooseImagesInsight
-from launchpad.size.insights.apple.main_binary_export_metadata import (
-    MainBinaryExportMetadataInsight,
-)
+from launchpad.size.insights.apple.main_binary_export_metadata import MainBinaryExportMetadataInsight
 from launchpad.size.insights.apple.small_files import SmallFilesInsight
 from launchpad.size.insights.apple.strip_symbols import StripSymbolsInsight
 from launchpad.size.insights.apple.unnecessary_files import UnnecessaryFilesInsight
@@ -292,7 +286,7 @@ class AppleAppAnalyzer:
             validator = CodeSignatureValidator(xcarchive)
             is_code_signature_valid, code_signature_errors = validator.validate()
         except Exception as e:
-            logger.warning(f"Failed to validate code signature: {e}")
+            logger.exception("Failed to validate code signature")
             is_code_signature_valid = False
             code_signature_errors = [str(e)]
 
@@ -376,8 +370,8 @@ class AppleAppAnalyzer:
                 if earliest_expiration is None or expiration_date < earliest_expiration:
                     earliest_expiration = expiration_date
 
-            except Exception as e:
-                logger.error(f"Failed to parse certificate: {e}")
+            except Exception:
+                logger.exception("Failed to parse certificate")
                 continue
 
         if earliest_expiration:
@@ -535,8 +529,8 @@ class AppleAppAnalyzer:
 
             return actual_savings
 
-        except Exception as e:
-            logger.error(f"Error testing symbol removal for {binary_path}: {e}")
+        except Exception:
+            logger.exception(f"Error testing symbol removal for {binary_path}")
             return 0
 
     def _extract_segments_info(self, binary: lief.MachO.Binary) -> List[SegmentInfo]:
@@ -560,8 +554,8 @@ class AppleAppAnalyzer:
                             size=command.file_size,
                         )
                     )
-        except Exception as e:
-            logger.warning(f"Error extracting segments info: {e}")
+        except Exception:
+            logger.exception("Error extracting segments info")
 
         return segments
 

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -286,7 +286,7 @@ class AppleAppAnalyzer:
             validator = CodeSignatureValidator(xcarchive)
             is_code_signature_valid, code_signature_errors = validator.validate()
         except Exception as e:
-            logger.exception("Failed to validate code signature")
+            logger.warning("Failed to validate code signature", exc_info=True)
             is_code_signature_valid = False
             code_signature_errors = [str(e)]
 

--- a/src/launchpad/size/hermes/parser.py
+++ b/src/launchpad/size/hermes/parser.py
@@ -7,6 +7,7 @@ import struct
 from typing import List, Union
 
 from launchpad.parsers.buffer_wrapper import BufferWrapper
+from launchpad.utils.logging import get_logger
 
 from .types import (
     BytecodeFileHeader,
@@ -30,6 +31,8 @@ from .types import (
 MAGIC = 0x1F1903C103BC1FC6
 DELTA_MAGIC = ~MAGIC & 0xFFFFFFFFFFFFFFFF
 SHA1_NUM_BYTES = 20
+
+logger = get_logger(__name__)
 
 
 class HermesBytecodeParser:
@@ -416,7 +419,8 @@ class HermesBytecodeParser:
                 else:
                     strings.append(string_bytes.decode("utf-8"))
             except Exception as e:
-                strings.append(f"[Error reading string: {e}]")
+                logger.warning(f"Error reading string: {e}")
+                strings.append("")
 
         return strings
 

--- a/src/launchpad/size/utils/android_bundle_size.py
+++ b/src/launchpad/size/utils/android_bundle_size.py
@@ -38,8 +38,7 @@ def calculate_apk_download_size(apk_path: Path) -> int:
         return download_size
 
     except Exception as e:
-        logger.error(f"Error calculating APK download size: {e}")
-        raise ValueError(f"Failed to calculate download size for {apk_path}: {e}")
+        raise ValueError("Failed to calculate download size for APK") from e
 
 
 def calculate_apk_install_size(apk_file: typing.BinaryIO) -> int:

--- a/src/launchpad/size/utils/apple_bundle_size.py
+++ b/src/launchpad/size/utils/apple_bundle_size.py
@@ -102,8 +102,8 @@ def _lzfse_compressed_size(file_path: Path) -> int:
 
         return compressed_size if compressed_size < source_size else source_size
 
-    except Exception as e:
-        logger.error(f"Error compressing {file_path}: {e}")
+    except Exception:
+        logger.exception(f"Error lzfse compressing file {file_path}")
         return os.path.getsize(file_path)
 
 
@@ -172,8 +172,8 @@ def _zip_metadata_size_for_bundle(bundle_url: Path) -> int:
 
         return metadata_size
 
-    except Exception as e:
-        logger.error(f"Error calculating ZIP metadata size: {e}")
+    except Exception:
+        logger.exception("Error calculating ZIP metadata size")
         return 0
 
     finally:

--- a/src/launchpad/utils/apple/code_signature_validator.py
+++ b/src/launchpad/utils/apple/code_signature_validator.py
@@ -111,7 +111,7 @@ class CodeSignatureValidator:
             return len(errors) == 0, errors
 
         except Exception as e:
-            logger.exception("Failed to validate code signature")
+            logger.warning("Failed to validate code signature", exc_info=True)
             return False, [str(e)]
 
     def _validate_executable(self) -> BinaryCheckResult:

--- a/src/launchpad/utils/apple/code_signature_validator.py
+++ b/src/launchpad/utils/apple/code_signature_validator.py
@@ -214,8 +214,8 @@ class CodeSignatureValidator:
                     # For regular files, read the file contents
                     with open(full_file_path, "rb") as f:
                         file_buffer = f.read()
-            except Exception as e:
-                logger.error(f"Failed to read file {file_path}: {e}")
+            except Exception:
+                logger.exception(f"Failed to read file {file_path}")
                 errors.append(f"file modified: {file_path}")
                 return
 
@@ -300,7 +300,7 @@ class CodeSignatureValidator:
                 bytes = f.read()
                 return self._get_buffer_hash(bytes)
         except Exception as e:
-            raise RuntimeError(f"Failed to parse file: {e}")
+            raise RuntimeError(f"Failed to parse file {file_path}") from e
 
     def _get_buffer_hash(self, buffer: bytes) -> str:
         """Get buffer hash."""

--- a/src/launchpad/utils/apple/cwl_demangle.py
+++ b/src/launchpad/utils/apple/cwl_demangle.py
@@ -105,8 +105,8 @@ class CwlDemangler:
 
             try:
                 result = subprocess.run(command_parts, capture_output=True, text=True, check=True)
-            except subprocess.CalledProcessError as e:
-                logger.error(f"cwl-demangle failed: {e}")
+            except subprocess.CalledProcessError:
+                logger.exception("cwl-demangle failed")
                 return {}
 
             batch_result = json.loads(result.stdout)


### PR DESCRIPTION
I'm seeing duplicate issues get created, e.g. https://sentry.sentry.io/issues/6901677123/?project=4509667577233409&query=is%3Aunresolved&referrer=issue-stream and https://sentry.sentry.io/issues/6901677118/?project=4509667577233409&query=is%3Aunresolved&referrer=issue-stream

I also went through and got rid of some unnecessary `{e}` printing since the `exc_info` automatically captures that.