### PR TITLE
Fix ZIP file corruption in download retry logic

### DIFF
--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -182,6 +182,7 @@ class SentryClient:
             # Restart download from the beginning (endpoint does not
             # currently support Range header).
             out.seek(0)
+            out.truncate()  # Clear any partial data from failed download
             file_size = 0
 
         return file_size


### PR DESCRIPTION
## Summary
- Add missing `out.truncate()` call after `out.seek(0)` in download retry logic
- Fixes ZIP file corruption causing "BadZipFile: File is not a zip file" errors

## Root Cause
When artifact downloads fail due to network errors and retry, the existing code rewinds the file pointer with `out.seek(0)` but doesn't clear the partial data already written. On retry, new data overwrites the beginning but leaves corrupted trailing data, creating files with valid ZIP magic bytes but invalid ZIP structure.

## Solution
Add `out.truncate()` after `out.seek(0)` to ensure partial data is completely cleared before retrying the download.

## Issues Fixed
- Fixes LAUNCHPAD-5J: `ValueError: Corrupted ZIP file: File is not a zip file`  
- Fixes LAUNCHPAD-5K: `ZIP file is corrupted: File is not a zip file`

These errors have been occurring since commit 7cfcce8 (Sept 22) which introduced the retry logic but forgot to truncate the file.

🤖 Generated with [Claude Code](https://claude.ai/code)