### PR TITLE
Add check_reasonable_zip

### DIFF
--- a/src/launchpad/artifacts/artifact_factory.py
+++ b/src/launchpad/artifacts/artifact_factory.py
@@ -9,6 +9,7 @@ from .android.zipped_aab import ZippedAAB
 from .android.zipped_apk import ZippedAPK
 from .apple.zipped_xcarchive import ZippedXCArchive
 from .artifact import Artifact
+from .providers.zip_provider import check_reasonable_zip
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,8 @@ class ArtifactFactory:
         if magic_bytes.startswith(b"PK\x03\x04"):
             try:
                 with ZipFile(path) as zip_file:
+                    check_reasonable_zip(zip_file)
+
                     # Check if zip contains a Info.plist in the root of the .xcarchive folder (ZippedXCArchive)
                     plist_files = [f for f in zip_file.namelist() if f.endswith(".xcarchive/Info.plist")]
                     if plist_files:
@@ -72,6 +75,7 @@ class ArtifactFactory:
         # Check if it's a direct APK or AAB by looking for AndroidManifest.xml in specific locations
         try:
             with ZipFile(path) as zip_file:
+                check_reasonable_zip(zip_file)
                 if any(f.endswith("base/manifest/AndroidManifest.xml") for f in zip_file.namelist()):
                     return AAB(path)
 

--- a/src/launchpad/artifacts/providers/zip_provider.py
+++ b/src/launchpad/artifacts/providers/zip_provider.py
@@ -8,6 +8,65 @@ from launchpad.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_MAX_FILE_COUNT = 100000
+DEFAULT_MAX_UNCOMPRESSED_SIZE = 10 * 1024 * 1024 * 1024
+
+
+class UnreasonableZipError(ValueError):
+    """Raised when a zip file exceeds reasonable limits."""
+
+    pass
+
+
+class UnsafePathError(ValueError):
+    """Raised when a zip file contains unsafe path entries that could lead to path traversal attacks."""
+
+    pass
+
+
+def check_reasonable_zip(
+    zf: zipfile.ZipFile,
+    max_file_count: int = DEFAULT_MAX_FILE_COUNT,
+    max_uncompressed_size: int = DEFAULT_MAX_UNCOMPRESSED_SIZE,
+) -> None:
+    """Check if a zip file is reasonable based on file count and total uncompressed size.
+
+    Args:
+        zf: The ZipFile to check
+        max_file_count: Maximum number of files allowed (default: 100,000)
+        max_uncompressed_size: Maximum total uncompressed size in bytes (default: 10GB)
+
+    Raises:
+        UnreasonableZipError: If the zip exceeds the specified limits
+    """
+    info_list = zf.infolist()
+    file_count = len(info_list)
+    total_uncompressed_size = sum(info.file_size for info in info_list)
+
+    if file_count > max_file_count:
+        raise UnreasonableZipError(f"Zip file contains {file_count} files, exceeding the limit of {max_file_count}")
+
+    if total_uncompressed_size > max_uncompressed_size:
+        size_mb = total_uncompressed_size / (1024 * 1024)
+        limit_mb = max_uncompressed_size / (1024 * 1024)
+        raise UnreasonableZipError(
+            f"Zip file uncompressed size is {size_mb:.1f}MB, exceeding the limit of {limit_mb:.1f}MB"
+        )
+
+
+def is_safe_path(base_dir: Path, requested_path: str) -> bool:
+    """
+    Ensure file operations occur within the intended directory
+    Based on: https://medium.com/@contactomyna/securing-zip-file-operations-understanding-and-preventing-path-traversal-attacks-74d79f696c46
+    """
+    try:
+        base_dir = base_dir.resolve()
+        target_path = Path(base_dir, requested_path).resolve()
+        return target_path.is_relative_to(base_dir)
+    except RuntimeError:
+        # Resolve raises RuntimeError prior to 3.13 for symlink loops.
+        return False
+
 
 class ZipProvider:
     """Provider for handling zip file operations."""
@@ -41,27 +100,15 @@ class ZipProvider:
         """Extract the zip contents to a temporary directory, ensuring that the paths are safe from path traversal attacks."""
         base_dir = Path(extract_path)
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            check_reasonable_zip(zip_ref)
             for member in zip_ref.namelist():
-                if self._is_safe_path(base_dir, member):
+                if is_safe_path(base_dir, member):
                     zip_ref.extract(member, extract_path)
                 else:
-                    raise ValueError(f"Potential path traversal attack: {member}")
-
-    def _is_safe_path(self, base_dir: Path, requested_path: str) -> bool:
-        """
-        Ensure file operations occur within the intended directory
-        Based on: https://medium.com/@contactomyna/securing-zip-file-operations-understanding-and-preventing-path-traversal-attacks-74d79f696c46
-        """
-        try:
-            base_dir = base_dir.resolve()
-            target_path = Path(base_dir, requested_path).resolve()
-            return target_path.is_relative_to(base_dir)
-        except (RuntimeError, ValueError):
-            return False
+                    raise UnsafePathError(f"Potential path traversal attack: {member}")
 
     def __del__(self) -> None:
         """Clean up resources when object is destroyed."""
-        # Clean up any temporary directories
         for temp_dir in self._temp_dirs:
             if temp_dir.exists():
                 cleanup_directory(temp_dir)

--- a/src/launchpad/size/utils/android_bundle_size.py
+++ b/src/launchpad/size/utils/android_bundle_size.py
@@ -44,6 +44,8 @@ def calculate_apk_download_size(apk_path: Path) -> int:
 def calculate_apk_install_size(apk_file: typing.BinaryIO) -> int:
     size = 0
     with zipfile.ZipFile(apk_file) as z:
+        # No need to check_reasonable_zip here if all we are doing is
+        # counting the size.
         for info in z.infolist():
             size += info.file_size
     return size

--- a/tests/unit/artifacts/providers/test_zip_provider.py
+++ b/tests/unit/artifacts/providers/test_zip_provider.py
@@ -1,0 +1,137 @@
+import tempfile
+import zipfile
+
+from pathlib import Path
+
+import pytest
+
+from launchpad.artifacts.providers.zip_provider import (
+    UnreasonableZipError,
+    UnsafePathError,
+    ZipProvider,
+    check_reasonable_zip,
+    is_safe_path,
+)
+
+
+@pytest.fixture
+def sample_ios_zip() -> Path:
+    return Path("tests/_fixtures/ios/HackerNews.xcarchive.zip")
+
+
+@pytest.fixture
+def sample_android_zip() -> Path:
+    return Path("tests/_fixtures/android/zipped_apk.zip")
+
+
+class TestZipProvider:
+    @pytest.fixture
+    def malicious_zip(self) -> Path:
+        with tempfile.NamedTemporaryFile(suffix=".zip") as temp_file:
+            temp_path = Path(temp_file.name)
+
+            with zipfile.ZipFile(temp_path, "w") as zf:
+                zf.writestr("normal.txt", "normal content")
+                zf.writestr("../../../etc/passwd", "malicious content")
+
+            yield temp_path
+
+    def test_init(self, sample_ios_zip: Path) -> None:
+        provider = ZipProvider(sample_ios_zip)
+        assert provider.path == sample_ios_zip
+
+    def test_extract_to_temp_directory_ios(self, sample_ios_zip: Path) -> None:
+        provider = ZipProvider(sample_ios_zip)
+        temp_dir = provider.extract_to_temp_directory()
+
+        assert temp_dir.exists()
+        assert temp_dir.is_dir()
+        assert len(provider._temp_dirs) == 1
+        assert provider._temp_dirs[0] == temp_dir
+        extracted_files = list(temp_dir.rglob("*"))
+        assert len(extracted_files) > 0
+
+    def test_extract_to_temp_directory_android(self, sample_android_zip: Path) -> None:
+        provider = ZipProvider(sample_android_zip)
+        temp_dir = provider.extract_to_temp_directory()
+
+        assert temp_dir.exists()
+        assert temp_dir.is_dir()
+        assert len(provider._temp_dirs) == 1
+
+        extracted_files = list(temp_dir.rglob("*"))
+        assert len(extracted_files) > 0
+
+    def test_multiple_extractions(self, sample_ios_zip: Path) -> None:
+        provider = ZipProvider(sample_ios_zip)
+
+        temp_dir1 = provider.extract_to_temp_directory()
+        temp_dir2 = provider.extract_to_temp_directory()
+
+        assert temp_dir1 != temp_dir2
+        assert len(provider._temp_dirs) == 2
+        assert temp_dir1 in provider._temp_dirs
+        assert temp_dir2 in provider._temp_dirs
+        assert temp_dir1.exists()
+        assert temp_dir2.exists()
+
+    def test_safe_extract_blocks_traversal(self, malicious_zip: Path) -> None:
+        provider = ZipProvider(malicious_zip)
+
+        with pytest.raises(UnsafePathError, match="Potential path traversal attack"):
+            provider.extract_to_temp_directory()
+
+    def test_nonexistent_zip_file(self) -> None:
+        nonexistent_path = Path("/nonexistent/file.zip")
+        provider = ZipProvider(nonexistent_path)
+
+        with pytest.raises(FileNotFoundError):
+            provider.extract_to_temp_directory()
+
+    def test_invalid_zip_file(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".zip") as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(b"not a zip file")
+
+            provider = ZipProvider(temp_path)
+
+            with pytest.raises(zipfile.BadZipFile):
+                provider.extract_to_temp_directory()
+
+
+class TestIsSafePath:
+    def test_valid_paths(self) -> None:
+        base_dir = Path("/tmp/test")
+        assert is_safe_path(base_dir, "file.txt")
+        assert is_safe_path(base_dir, "subdir/file.txt")
+        assert is_safe_path(base_dir, "a/b/c/file.txt")
+
+    def test_path_traversal_attempts(self) -> None:
+        base_dir = Path("/tmp/test")
+        assert not is_safe_path(base_dir, "../file.txt")
+        assert not is_safe_path(base_dir, "../../file.txt")
+        assert not is_safe_path(base_dir, "../../../etc/passwd")
+        assert not is_safe_path(base_dir, "subdir/../../file.txt")
+
+    def test_absolute_paths(self) -> None:
+        base_dir = Path("/tmp/test")
+        assert not is_safe_path(base_dir, "/etc/passwd")
+        assert not is_safe_path(base_dir, "/tmp/other/file.txt")
+
+
+class TestCheckReasonableZip:
+    def test_reasonable_zip_passes(self, sample_ios_zip: Path) -> None:
+        with zipfile.ZipFile(sample_ios_zip, "r") as zf:
+            check_reasonable_zip(zf)
+
+    def test_max_file_count(self, sample_ios_zip: Path) -> None:
+        with zipfile.ZipFile(sample_ios_zip, "r") as zf:
+            # iOS fixture has 113 files, so limit of 50 should fail
+            with pytest.raises(UnreasonableZipError, match="exceeding the limit of 50"):
+                check_reasonable_zip(zf, max_file_count=50)
+
+    def test_max_file_size(self, sample_ios_zip: Path) -> None:
+        with zipfile.ZipFile(sample_ios_zip, "r") as zf:
+            # iOS fixture is ~32MB uncompressed, so limit of 10MB should fail
+            with pytest.raises(UnreasonableZipError, match="exceeding the limit of 10.0MB"):
+                check_reasonable_zip(zf, max_uncompressed_size=10 * 1024 * 1024)


### PR DESCRIPTION
One of the main things we do is parse ZIPs and evaluate their contents.
This (and more generally parsing untrusted input) is the major attack
surface for launchpad. There are a couple well known avenues for
malicious zips:
1. ZIP bombs, where a small ZIP expands to many TB/PB when unzipped
   using fancy aliasing tricks.
2. Abusing absolute and relative paths to overwrite files the unzipper
   did not intend.
3. Being very large / having many files when expanded.

- 1 and 2 are mitigated by Python
- 2 was is also prevented by additional code in ZipProvider
- 3 is resolved by this PR which adds limits on the number of files
   (100,000) and maximum unzipped size (10GB).

These limits have to be quite large (since people will mostly want to
use launchpad on large apps) but should be small enough to avoid people
taking down the whole consumer by uploading a carefully constructed
file.

See also: https://www.bamsoftware.com/hacks/zipbomb/

Resolves: EME-381
