### PR TITLE
Change log level for urllib related logs

### DIFF
--- a/src/launchpad/utils/logging.py
+++ b/src/launchpad/utils/logging.py
@@ -142,6 +142,8 @@ def setup_logging(verbose: bool = False, quiet: bool = False) -> None:
     # Set levels for third-party libraries
     logging.getLogger("datadog.dogstatsd").setLevel(logging.ERROR)
     logging.getLogger("arroyo.processing.processor").setLevel(logging.ERROR)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
 
 
 def get_logger(name: str) -> logging.Logger:


### PR DESCRIPTION
Our logs are swamped by this log

<img width="1048" height="749" alt="image" src="https://github.com/user-attachments/assets/bd439072-6a38-4088-8c32-c3778ffb0cc3" />

I think it's related to sentry tracing, but either way, we should reduce the accepted severity level