### PR TITLE
Try to force subprocess logs to write to sdout

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import multiprocessing
 import os
 import signal
+import sys
 import time
 
 from dataclasses import dataclass
@@ -205,7 +207,20 @@ class LaunchpadStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
     @staticmethod
     def _initialize_worker_logging() -> None:
-        """Initialize logging in worker process."""
+        """Initialize logging in worker process.
+
+        With multiprocessing spawn context, subprocesses don't inherit
+        parent's stdout/stderr. We need to explicitly configure logging
+        to write to stdout for Docker/GCP log collection.
+        """
+        logging.getLogger().handlers.clear()
+
+        # Ensure stdout/stderr are unbuffered for immediate log visibility
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+        if hasattr(sys.stderr, "reconfigure"):
+            sys.stderr.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
         server_config = get_server_config()
         setup_logging(verbose=server_config.debug, quiet=not server_config.debug)
 

--- a/src/launchpad/utils/logging.py
+++ b/src/launchpad/utils/logging.py
@@ -142,6 +142,7 @@ def setup_logging(verbose: bool = False, quiet: bool = False) -> None:
     # Set levels for third-party libraries
     logging.getLogger("datadog.dogstatsd").setLevel(logging.ERROR)
     logging.getLogger("arroyo.processing.processor").setLevel(logging.ERROR)
+    logging.getLogger("arroyo.processing.strategies.run_task_with_multiprocessing").setLevel(logging.ERROR)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
 


### PR DESCRIPTION
Another potential fix for subprocess logs to show up in GCP

In GCP/Docker, logs are captured from the container's main process (PID 1), and spawned subprocesses might not have their stdout/stderr properly connected, despite our previous attempts

If this doesn't work, then I will implement a logging queue