### PR TITLE
Don't store lief machO data classes directly if possible

### DIFF
--- a/src/launchpad/parsers/apple/macho_symbol_sizes.py
+++ b/src/launchpad/parsers/apple/macho_symbol_sizes.py
@@ -10,9 +10,9 @@ logger = get_logger(__name__)
 
 @dataclass
 class SymbolSize:
-    symbol: lief.MachO.Symbol
     mangled_name: str
-    section: lief.MachO.Section | None
+    section_name: str | None
+    segment_name: str | None
     address: int
     size: int
 
@@ -28,12 +28,12 @@ class MachOSymbolSizes:
         symbol_tuples = list(self._symbol_sizes(self.binary))
 
         symbol_sizes: list[SymbolSize] = []
-        for sym, mangled_name, section, address, size in symbol_tuples:
+        for mangled_name, section_name, segment_name, address, size in symbol_tuples:
             symbol_sizes.append(
                 SymbolSize(
-                    symbol=sym,
                     mangled_name=mangled_name,
-                    section=section,
+                    section_name=section_name,
+                    segment_name=segment_name,
                     address=address,
                     size=size,
                 )
@@ -51,10 +51,8 @@ class MachOSymbolSizes:
             and sym.value > 0
         )
 
-    def _symbol_sizes(
-        self, bin: lief.MachO.Binary
-    ) -> Generator[tuple[lief.MachO.Symbol, str, lief.MachO.Section | None, int, int]]:
-        """Yield (name, addr, size) via the distance-to-next-symbol heuristic."""
+    def _symbol_sizes(self, bin: lief.MachO.Binary) -> Generator[tuple[str, str | None, str | None, int, int]]:
+        """Yield (name, section_name, segment_name, addr, size) via the distance-to-next-symbol heuristic."""
 
         # sort symbols by their address so we can calculate the distance between them
         syms = sorted((s for s in bin.symbols if self._is_measurable(s)), key=lambda s: s.value)
@@ -65,8 +63,24 @@ class MachOSymbolSizes:
             section = bin.section_from_virtual_address(start)
             if section:
                 max_section_addr = section.virtual_address + section.size
+                raw_name = section.name
+                section_name = (
+                    raw_name.decode("utf-8", errors="replace") if isinstance(raw_name, bytes) else str(raw_name)
+                )
+
+                if section.segment:
+                    raw_seg_name = section.segment.name
+                    segment_name = (
+                        raw_seg_name.decode("utf-8", errors="replace")
+                        if isinstance(raw_seg_name, bytes)
+                        else str(raw_seg_name)
+                    )
+                else:
+                    segment_name = None
             else:
                 max_section_addr = None
+                section_name = None
+                segment_name = None
                 logger.warning("size.macho.symbol_not_found_in_section", extra={"symbol": sym.name})
                 continue
 
@@ -75,7 +89,11 @@ class MachOSymbolSizes:
                 if idx + 1 < len(syms):
                     next_sym = syms[idx + 1]
                     next_sym_section = bin.section_from_virtual_address(next_sym.value)
-                    end = next_sym.value if next_sym_section.name == section.name else max_section_addr
+                    end = (
+                        next_sym.value
+                        if next_sym_section and next_sym_section.name == section.name
+                        else max_section_addr
+                    )
                 else:
                     end = max_section_addr
             else:
@@ -90,4 +108,4 @@ class MachOSymbolSizes:
             else:
                 logger.warning(f"Failed to calculate size for symbol {sym.name}")
 
-            yield (sym, str(sym.name), section, start, size)
+            yield (str(sym.name), section_name, segment_name, start, size)

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -180,7 +180,7 @@ class SymbolInfo:
 
         for group in self.swift_type_groups:
             for symbol in group.symbols:
-                section_name = str(symbol.section.name) if symbol.section else "unknown"
+                section_name = symbol.section_name or "unknown"
                 if section_name not in symbols_by_section:
                     symbols_by_section[section_name] = []
 
@@ -188,7 +188,7 @@ class SymbolInfo:
 
         for group in self.objc_type_groups:
             for symbol in group.symbols:
-                section_name = str(symbol.section.name) if symbol.section else "unknown"
+                section_name = symbol.section_name or "unknown"
                 if section_name not in symbols_by_section:
                     symbols_by_section[section_name] = []
 

--- a/src/launchpad/size/treemap/macho_element_builder.py
+++ b/src/launchpad/size/treemap/macho_element_builder.py
@@ -97,13 +97,13 @@ class MachOElementBuilder(TreemapElementBuilder):
 
                 # While we have the symbol handy, start tracking section usage
                 for sym in grp.symbols:
-                    if sym.section:
+                    if sym.section_name and sym.segment_name:
                         # Use unique section name to avoid conflicts since the same section name can be used in multiple segments
-                        segment_name = str(sym.section.segment.name) if sym.section.segment else "unknown"
-                        section_name = str(sym.section.name)
-                        unique_sec = f"{segment_name}.{section_name}"
+                        unique_sec = f"{sym.segment_name}.{sym.section_name}"
                         section_subtractions[unique_sec] = section_subtractions.get(unique_sec, 0) + sym.size
-                        segment_subtractions[segment_name] = segment_subtractions.get(segment_name, 0) + sym.size
+                        segment_subtractions[sym.segment_name] = (
+                            segment_subtractions.get(sym.segment_name, 0) + sym.size
+                        )
 
             # ---- 1b.  For every module build a nested tree --------------- #
             for module_name, type_groups in swift_modules.items():
@@ -209,13 +209,13 @@ class MachOElementBuilder(TreemapElementBuilder):
             for grp in symbol_info.objc_type_groups:
                 objc_classes.setdefault(grp.class_name, []).append((grp.method_name or "class", grp.total_size))
                 for sym in grp.symbols:
-                    if sym.section:
+                    if sym.section_name and sym.segment_name:
                         # Use unique section name to avoid conflicts
-                        segment_name = str(sym.section.segment.name) if sym.section.segment else "unknown"
-                        section_name = str(sym.section.name)
-                        unique_sec = f"{segment_name}.{section_name}"
+                        unique_sec = f"{sym.segment_name}.{sym.section_name}"
                         section_subtractions[unique_sec] = section_subtractions.get(unique_sec, 0) + sym.size
-                        segment_subtractions[segment_name] = segment_subtractions.get(segment_name, 0) + sym.size
+                        segment_subtractions[sym.segment_name] = (
+                            segment_subtractions.get(sym.segment_name, 0) + sym.size
+                        )
 
             for cls_name, meths in objc_classes.items():
                 meth_elems: List[TreemapElement] = [

--- a/src/launchpad/size/treemap/macho_element_builder.py
+++ b/src/launchpad/size/treemap/macho_element_builder.py
@@ -97,13 +97,12 @@ class MachOElementBuilder(TreemapElementBuilder):
 
                 # While we have the symbol handy, start tracking section usage
                 for sym in grp.symbols:
-                    if sym.section_name and sym.segment_name:
+                    if sym.section_name:
+                        segment_name = sym.segment_name or "unknown"
                         # Use unique section name to avoid conflicts since the same section name can be used in multiple segments
-                        unique_sec = f"{sym.segment_name}.{sym.section_name}"
+                        unique_sec = f"{segment_name}.{sym.section_name}"
                         section_subtractions[unique_sec] = section_subtractions.get(unique_sec, 0) + sym.size
-                        segment_subtractions[sym.segment_name] = (
-                            segment_subtractions.get(sym.segment_name, 0) + sym.size
-                        )
+                        segment_subtractions[segment_name] = segment_subtractions.get(segment_name, 0) + sym.size
 
             # ---- 1b.  For every module build a nested tree --------------- #
             for module_name, type_groups in swift_modules.items():
@@ -209,13 +208,12 @@ class MachOElementBuilder(TreemapElementBuilder):
             for grp in symbol_info.objc_type_groups:
                 objc_classes.setdefault(grp.class_name, []).append((grp.method_name or "class", grp.total_size))
                 for sym in grp.symbols:
-                    if sym.section_name and sym.segment_name:
+                    if sym.section_name:
+                        segment_name = sym.segment_name or "unknown"
                         # Use unique section name to avoid conflicts
-                        unique_sec = f"{sym.segment_name}.{sym.section_name}"
+                        unique_sec = f"{segment_name}.{sym.section_name}"
                         section_subtractions[unique_sec] = section_subtractions.get(unique_sec, 0) + sym.size
-                        segment_subtractions[sym.segment_name] = (
-                            segment_subtractions.get(sym.segment_name, 0) + sym.size
-                        )
+                        segment_subtractions[segment_name] = segment_subtractions.get(segment_name, 0) + sym.size
 
             for cls_name, meths in objc_classes.items():
                 meth_elems: List[TreemapElement] = [

--- a/tests/unit/test_objc_symbol_type_aggregator.py
+++ b/tests/unit/test_objc_symbol_type_aggregator.py
@@ -1,16 +1,5 @@
-from typing import cast
-
-import lief
-
 from launchpad.parsers.apple.macho_symbol_sizes import SymbolSize
 from launchpad.parsers.apple.objc_symbol_type_aggregator import ObjCSymbolTypeAggregator, ObjCSymbolTypeGroup
-
-
-class MockSymbol:
-    """Mock symbol class for testing purposes."""
-
-    def __init__(self, name: str = "mock_symbol"):
-        self.name = name
 
 
 class TestObjCSymbolTypeAggregator:
@@ -28,16 +17,16 @@ class TestObjCSymbolTypeAggregator:
 
         swift_symbols = [
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="_$s6Sentry0A14OnDemandReplayC",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x1000,
                 size=100,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="_$s6Sentry0A18UserFeedbackWidgetC",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x2000,
                 size=200,
             ),
@@ -52,16 +41,16 @@ class TestObjCSymbolTypeAggregator:
 
         cpp_symbols = [
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="_ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE4sizeEv",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x1000,
                 size=100,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC1ERKS5_",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x2000,
                 size=200,
             ),
@@ -77,45 +66,45 @@ class TestObjCSymbolTypeAggregator:
         mixed_symbols = [
             # Swift symbols (should be filtered out)
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="_$s6Sentry0A14OnDemandReplayC",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x1000,
                 size=100,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="_$s6Sentry0A18UserFeedbackWidgetC",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x2000,
                 size=200,
             ),
             # Objective-C symbols
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="-[NSString stringByAppendingString:]",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x3000,
                 size=150,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="-[NSString stringByAppendingPathComponent:]",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x4000,
                 size=180,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="+[NSArray arrayWithObject:]",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x5000,
                 size=120,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="_OBJC_CLASS_$_NSString",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x6000,
                 size=300,
             ),
@@ -172,23 +161,23 @@ class TestObjCSymbolTypeAggregator:
 
         symbols = [
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="-[NSString(MyCategory) customMethod]",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x1000,
                 size=100,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="-[NSString stringByAppendingString:]",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x2000,
                 size=150,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="-[NSString(AnotherCategory) anotherMethod]",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x3000,
                 size=120,
             ),
@@ -232,23 +221,23 @@ class TestObjCSymbolTypeAggregator:
         """Test ObjCSymbolTypeGroup total_size property."""
         symbols = [
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="test1",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x1000,
                 size=100,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="test2",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x2000,
                 size=200,
             ),
             SymbolSize(
-                symbol=cast(lief.MachO.Symbol, MockSymbol()),
                 mangled_name="test3",
-                section=None,
+                section_name=None,
+                segment_name=None,
                 address=0x3000,
                 size=300,
             ),


### PR DESCRIPTION
We've been storing lief.MachO.Symbol and lief.MachO.Section objects in a dataclass that gets returned and kept around. These C++ objects managed by nanobind create circular references that never get cleaned up properly.

We shouldn't store lief objects if not needed. Lets instead extract only the data needed as python primitives

This change makes the nanobind memory leak warning go away
<img width="1614" height="2534" alt="image" src="https://github.com/user-attachments/assets/3c24ccc0-2d92-4f1c-8054-a5f95631552c" />

