### PR TITLE
Make arroyo_metrics.py always convert

### DIFF
--- a/src/launchpad/utils/arroyo_metrics.py
+++ b/src/launchpad/utils/arroyo_metrics.py
@@ -35,15 +35,10 @@ class DatadogMetricsBackend(Metrics):
 
     def timing(self, name: MetricName, value: Union[int, float], tags: Optional[Tags] = None) -> None:
         """Records a timing metric."""
-        # DataDog StatsD expects timing values in milliseconds
-        # Check if value is likely in seconds (< 10) and convert, otherwise assume milliseconds
-        if value < 10:
-            # Likely in seconds, convert to milliseconds
-            timing_value = value * 1000
-        else:
-            # Likely already in milliseconds
-            timing_value = value
-        self._statsd.timing(name, timing_value, tags=self._format_tags(tags))
+        # DataDog StatsD expects timing values in milliseconds but
+        # Arroyo uses seconds Python style.
+        # https://github.com/getsentry/arroyo/blob/a8f1bee346acfd6704625065c80674c2bf3bffd3/arroyo/processing/strategies/commit.py#L31
+        self._statsd.timing(name, value * 1000, tags=self._format_tags(tags))
 
     def _format_tags(self, tags: Optional[Tags]) -> Optional[list[str]]:
         """Convert Arroyo tags format to DataDog tags format, merging with constant tags."""


### PR DESCRIPTION
Arroyo emits timing data in seconds but statsd takes timing data in `ms`.
Always convert s->ms rather than trying to guess if the conversion is needed.
Resolves EME-218