### PR TITLE
flush() when uploading

### DIFF
--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -294,6 +294,9 @@ class SentryClient:
 
         chunk_size = options.chunk_size
 
+        file.flush()
+
+        file.seek(0)
         checksum = hashlib.file_digest(file, "sha1").hexdigest()
         size = file.tell()
         file.seek(0)

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 from datetime import datetime, timezone
 
 from launchpad.artifacts.android.aab import AAB
@@ -69,6 +71,7 @@ class AndroidAnalyzer:
         return self.app_info
 
     def analyze(self, artifact: AndroidArtifact) -> AndroidAnalysisResults:
+        start_time = time.time()
         # Use preprocessed app info if available, otherwise extract it
         if not self.app_info:
             self.app_info = self.preprocess(artifact)
@@ -126,6 +129,7 @@ class AndroidAnalyzer:
                 hermes_debug_info=HermesDebugInfoInsight().generate(insights_input),
             )
 
+        analysis_duration = time.time() - start_time
         return AndroidAnalysisResults(
             generated_at=datetime.now(timezone.utc),
             app_info=app_info,
@@ -134,7 +138,7 @@ class AndroidAnalyzer:
             insights=insights,
             download_size=download_size,
             install_size=install_size,
-            analysis_duration=None,
+            analysis_duration=analysis_duration,
             use_si_units=False,
         )
 

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gc
 import tempfile
+import time
 
 from datetime import datetime
 from pathlib import Path
@@ -109,6 +110,7 @@ class AppleAppAnalyzer:
         Returns:
             Analysis results including file sizes, binary analysis, and treemap
         """
+        start_time = time.time()
         if not isinstance(artifact, ZippedXCArchive):
             raise NotImplementedError(f"Only ZippedXCArchive artifacts are supported, got {type(artifact)}")
 
@@ -234,13 +236,14 @@ class AppleAppAnalyzer:
                 # ),
             )
 
+        analysis_duration = time.time() - start_time
         results = AppleAnalysisResults(
             app_info=app_info,
             file_analysis=file_analysis,
             binary_analysis=binary_analysis,
             treemap=treemap,
             insights=insights,
-            analysis_duration=None,
+            analysis_duration=analysis_duration,
             use_si_units=True,
             download_size=download_size,
             install_size=install_size,


### PR DESCRIPTION
This changes two things:
- Adds a flush() prior to uploading. As with the previous issue with
  downloading it's possible we get into a bad state by reading from a
  file when the file has been written to but not flushed to disk.
- Re-add the duration to the analyzers.

In a previous patch I ended up removing the analyze_duration from the
reported results. I did this because it seemed misleading since:
a) it did not include artifact parsing which is a cost shared between
   size and distro
b) it did not include the duration of retries (if any)

However one theory is that this exacerbates problems with corrupt
uploads due to the size results being too deterministic (e.g. on a
retry you attempt to upload an identical file again but since it has
the same hash you end up seeing some of the state from the previous
upload).
