### PR TITLE
Small BufferWrapper optimizations

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ pytest-cov>=6.2.1
 pytest-mock>=3.15.0
 pytest-verbose-parametrize>=1.7.0
 pytest-xdist>=3.8.0
+pytest-benchmark>=5.1.0
 pytest>=8.4.2
 responses>=0.25.8
 ruff>=0.12.12
@@ -24,3 +25,4 @@ ty==0.0.1a20
 sortedcontainers-stubs>=2.4.0
 kafka-python>=2.0.0
 sentry-protos==0.2.0
+

--- a/src/launchpad/parsers/android/dex/dex_class_parser.py
+++ b/src/launchpad/parsers/android/dex/dex_class_parser.py
@@ -106,9 +106,10 @@ class DexClassParser:
             size += 16  # 4 * 4 bytes (uint) for fields in directory
 
             annotations = annotations_directory.class_annotations
-            if annotations.__len__() > 0:
+            annotations_length = len(annotations)
+            if annotations_length > 0:
                 # 4 bytes (uint) for size + 4 bytes (uint) per annotation
-                size += 4 + annotations.__len__() * 4
+                size += 4 + annotations_length * 4
 
         # Class data item overhead
         # actual class data size is calculated with methods & fields below

--- a/src/launchpad/parsers/buffer_wrapper.py
+++ b/src/launchpad/parsers/buffer_wrapper.py
@@ -1,40 +1,33 @@
 from __future__ import annotations
 
+import contextlib
 import struct
-import types
-
-from dataclasses import dataclass
+import typing
 
 from launchpad.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-@dataclass
-class DebugLogContext:
-    """Context manager for debug logging groups."""
+def group(name: str):
+    def decorator(wrapped):
+        def wrapper(self, *args):
+            if self.debug:
+                logger.debug("=== %s ===", name)
+            result = wrapped(self, *args)
+            if self.debug:
+                logger.debug("=== End %s ===", name)
+            return result
 
-    name: str
-    enabled: bool
+        return wrapper
 
-    def __enter__(self) -> None:
-        """Enter debug group."""
-        if self.enabled:
-            logger.debug("=== %s ===", self.name)
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: types.TracebackType | None,
-    ) -> None:
-        """Exit debug group."""
-        if self.enabled:
-            logger.debug("=== End %s ===", self.name)
+    return decorator
 
 
 class BufferWrapper:
     """Wrapper for binary buffer parsing with cursor tracking and debugging."""
+
+    __slots__ = "cursor", "buffer", "debug"
 
     def __init__(self, buffer: bytes, debug: bool = False) -> None:
         """Initialize buffer wrapper.
@@ -63,113 +56,121 @@ class BufferWrapper:
         """
         self.cursor += length
 
-    def _debug_group(self, name: str) -> DebugLogContext:
+    @contextlib.contextmanager
+    def _debug_group(self, name: str) -> typing.Iterator[None]:
         """Create debug logging context.
 
         Args:
             name: Name of the debug group
-
-        Returns:
-            Debug context manager
         """
-        return DebugLogContext(name, self.debug)
+        if self.debug:
+            logger.debug("=== %s ===", name)
+        yield
+        if self.debug:
+            logger.debug("=== End %s ===", name)
 
     def read_u8(self) -> int:
         """Read unsigned 8-bit integer."""
-        with self._debug_group("read_u8"):
-            if self.debug:
-                logger.debug(f"cursor: {self.cursor}")
-            val = self.buffer[self.cursor]
-            if self.debug:
-                logger.debug(f"value: {val}")
-            self.cursor += 1
-            return val
+        if self.debug:
+            # read_u8 is called so often it is worth embedding the
+            # group() logging.
+            logger.debug("=== read_u8 ===")
+            logger.debug(f"cursor: {self.cursor}")
+        val = self.buffer[self.cursor]
+        if self.debug:
+            logger.debug(f"value: {val}")
+            logger.debug("=== End read_u8 ===")
+        self.cursor += 1
+        return val
 
+    @group("read_s8")
     def read_s8(self) -> int:
         """Read signed 8-bit integer."""
-        with self._debug_group("read_s8"):
-            if self.debug:
-                logger.debug(f"cursor: {self.cursor}")
-            val = struct.unpack("<b", self.buffer[self.cursor : self.cursor + 1])[0]
-            if self.debug:
-                logger.debug(f"value: {val}")
-            self.cursor += 1
-            return val  # type: ignore[no-any-return]
+        if self.debug:
+            logger.debug(f"cursor: {self.cursor}")
+        val = struct.unpack("<b", self.buffer[self.cursor : self.cursor + 1])[0]
+        if self.debug:
+            logger.debug(f"value: {val}")
+        self.cursor += 1
+        return val  # type: ignore[no-any-return]
 
+    @group("read_u16")
     def read_u16(self) -> int:
         """Read unsigned 16-bit integer (little-endian)."""
-        with self._debug_group("read_u16"):
-            if self.debug:
-                logger.debug(f"cursor: {self.cursor}")
-            val = struct.unpack("<H", self.buffer[self.cursor : self.cursor + 2])[0]
-            if self.debug:
-                logger.debug(f"value: {val}")
-            self.cursor += 2
-            return val  # type: ignore[no-any-return]
+        if self.debug:
+            logger.debug(f"cursor: {self.cursor}")
+        val = struct.unpack("<H", self.buffer[self.cursor : self.cursor + 2])[0]
+        if self.debug:
+            logger.debug(f"value: {val}")
+        self.cursor += 2
+        return val  # type: ignore[no-any-return]
 
+    @group("read_s32")
     def read_s32(self) -> int:
         """Read signed 32-bit integer (little-endian)."""
-        with self._debug_group("read_s32"):
-            if self.debug:
-                logger.debug(f"cursor: {self.cursor}")
-            val = struct.unpack("<i", self.buffer[self.cursor : self.cursor + 4])[0]
-            if self.debug:
-                logger.debug(f"value: {val}")
-            self.cursor += 4
-            return val  # type: ignore[no-any-return]
+        if self.debug:
+            logger.debug(f"cursor: {self.cursor}")
+        val = struct.unpack("<i", self.buffer[self.cursor : self.cursor + 4])[0]
+        if self.debug:
+            logger.debug(f"value: {val}")
+        self.cursor += 4
+        return val  # type: ignore[no-any-return]
 
     def read_u32(self) -> int:
         """Read unsigned 32-bit integer (little-endian)."""
-        with self._debug_group("read_u32"):
-            if self.debug:
-                logger.debug(f"cursor: {self.cursor}")
-            val = struct.unpack("<I", self.buffer[self.cursor : self.cursor + 4])[0]
-            if self.debug:
-                logger.debug(f"value: {val} 0x{val:08x}")
-            self.cursor += 4
-            return val  # type: ignore[no-any-return]
+        if self.debug:
+            # read_u32 is called so often it is worth embedding the
+            # group() logging.
+            logger.debug("=== read_u32 ===")
+            logger.debug(f"cursor: {self.cursor}")
+        val = struct.unpack("<I", self.buffer[self.cursor : self.cursor + 4])[0]
+        if self.debug:
+            logger.debug(f"value: {val} 0x{val:08x}")
+            logger.debug("=== End read_u32 ===")
+        self.cursor += 4
+        return val  # type: ignore[no-any-return]
 
+    @group("read_u32be")
     def read_u32be(self) -> int:
         """Read unsigned 32-bit integer (big-endian)."""
-        with self._debug_group("read_u32be"):
-            if self.debug:
-                logger.debug(f"cursor: {self.cursor}")
-            val = struct.unpack(">I", self.buffer[self.cursor : self.cursor + 4])[0]
-            if self.debug:
-                logger.debug(f"value: {val} 0x{val:08x}")
-            self.cursor += 4
-            return val  # type: ignore[no-any-return]
+        if self.debug:
+            logger.debug(f"cursor: {self.cursor}")
+        val = struct.unpack(">I", self.buffer[self.cursor : self.cursor + 4])[0]
+        if self.debug:
+            logger.debug(f"value: {val} 0x{val:08x}")
+        self.cursor += 4
+        return val  # type: ignore[no-any-return]
 
+    @group("read_u64")
     def read_u64(self) -> int:
         """Read unsigned 64-bit integer (little-endian)."""
-        with self._debug_group("read_u64"):
-            if self.debug:
-                logger.debug(f"cursor: {self.cursor}")
-            val = struct.unpack("<Q", self.buffer[self.cursor : self.cursor + 8])[0]
-            if self.debug:
-                logger.debug(f"value: {val} 0x{val:016x}")
-            self.cursor += 8
-            return val  # type: ignore[no-any-return]
+        if self.debug:
+            logger.debug(f"cursor: {self.cursor}")
+        val = struct.unpack("<Q", self.buffer[self.cursor : self.cursor + 8])[0]
+        if self.debug:
+            logger.debug(f"value: {val} 0x{val:016x}")
+        self.cursor += 8
+        return val  # type: ignore[no-any-return]
 
+    @group("read_length8")
     def read_length8(self) -> int:
         """Read length-prefixed 8-bit integer."""
-        with self._debug_group("read_length8"):
-            length = self.read_u8()
-            if length & 0x80:
-                length = ((length & 0x7F) << 8) | self.read_u8()
-            if self.debug:
-                logger.debug(f"length: {length}")
-            return length
+        length = self.read_u8()
+        if length & 0x80:
+            length = ((length & 0x7F) << 8) | self.read_u8()
+        if self.debug:
+            logger.debug(f"length: {length}")
+        return length
 
+    @group("read_length16")
     def read_length16(self) -> int:
         """Read length-prefixed 16-bit integer."""
-        with self._debug_group("read_length16"):
-            length = self.read_u16()
-            if length & 0x8000:
-                length = ((length & 0x7FFF) << 16) | self.read_u16()
-            if self.debug:
-                logger.debug(f"length: {length}")
-            return length
+        length = self.read_u16()
+        if length & 0x8000:
+            length = ((length & 0x7FFF) << 16) | self.read_u16()
+        if self.debug:
+            logger.debug(f"length: {length}")
+        return length
 
     def read_uleb128(self) -> int:
         """Read unsigned LEB128 integer.
@@ -180,7 +181,8 @@ class BufferWrapper:
         result = 0
         shift = 0
         while True:
-            byte = self.read_u8()
+            byte = self.buffer[self.cursor]
+            self.cursor += 1
             result |= (byte & 0x7F) << shift
             if not (byte & 0x80):
                 break

--- a/tests/unit/parsers/test_buffer_wrapper.py
+++ b/tests/unit/parsers/test_buffer_wrapper.py
@@ -36,3 +36,58 @@ def test_read_leb128(data, expected):
     assert result == expected
     # Cursor should be at the end
     assert buf.cursor == len(data)
+
+
+def test_read_u8(benchmark):
+    buffer = b"\x42"
+    wrapper = BufferWrapper(buffer)
+    assert wrapper.read_u8() == 0x42
+
+
+def test_benchmark_read_u8(benchmark):
+    buffer = b"\x42"
+    wrapper = BufferWrapper(buffer)
+
+    def parse():
+        wrapper.seek(0)
+        return wrapper.read_u8()
+
+    final = benchmark(parse)
+    assert final == 0x42
+
+
+def test_benchmark_read_u32(benchmark):
+    buffer = b"\x01\x02\x04\x08"
+    wrapper = BufferWrapper(buffer)
+
+    def parse():
+        wrapper.seek(0)
+        return wrapper.read_u32()
+
+    final = benchmark(parse)
+    assert final == (0x01) + (0x02 << 8) + (0x04 << 16) + (0x08 << 24)
+
+
+def test_benchmark_read_uleb128(benchmark):
+    pairs = [
+        (b"\x00", 0),
+        (b"\x01", 1),
+        (b"\xe5\x8e\x26", 624485),
+        (b"\xff\x00", 127),
+        (b"\x80\x01", 128),
+        (b"\xff\xff\xff\xff\x07", 2147483647),
+    ]
+
+    buffer = b"".join([buf for buf, _ in pairs])
+    expected_total = sum([value for _, value in pairs])
+    wrapper = BufferWrapper(buffer)
+
+    def parse():
+        wrapper.seek(0)
+        total = 0
+        for _ in range(len(pairs)):
+            total += wrapper.read_uleb128()
+        return total
+
+    final = benchmark(parse)
+    assert final == expected_total


### PR DESCRIPTION
Profiling an Android app (total time 134.791) shows we spend ~45s (33%)
self-time in the combination of read_u8, read_u32, read_uleb128, and
_debug_group:

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
...
  4802055    4.445    0.000   25.891    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/android/dex/dex_base_utils.py:540(get_string)
  4843334    3.750    0.000    6.214    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:99(read_u16)
  4920612    5.074    0.000    8.503    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:317(read_string_with_length)
  4940286    0.760    0.000    0.767    0.000 {method 'decode' of 'bytes' objects}
  5226031    0.603    0.000    0.603    0.000 {method 'replace' of 'str' objects}
  6570153    0.674    0.000    0.674    0.000 {method 'append' of 'list' objects}
 13070542    4.154    0.000   21.984    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:174(read_uleb128)
 14244714   11.413    0.000   18.692    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:121(read_u32)
 14458538    1.250    0.000    1.250    0.000 /Users/chromy/.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/enum.py:795(<genexpr>)
 19121508    1.828    0.000    1.828    0.000 {built-in method _struct.unpack}
 22236754   13.114    0.000   22.275    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:77(read_u8)
 27626383    1.929    0.000    1.929    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:50(seek)
 47300341    2.830    0.000    2.830    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:25(__exit__)
 47300341    2.902    0.000    2.902    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:20(__enter__)
 47300341   11.009    0.000   13.919    0.000 /Users/chromy/work/launchpad/src/launchpad/parsers/buffer_wrapper.py:66(_debug_group)

Replace _debug_group with a decorator and a few other things
saves around 10% of processing time:

$ time launchpad size ~/Downloads/app-release.apk >/dev/null

________________________________________________________
Executed in   67.61 secs    fish           external
   usr time   54.03 secs    0.08 millis   54.03 secs
   sys time    7.13 secs    2.17 millis    7.13 secs

$ time launchpad size ~/Downloads/app-release.apk >/dev/null

________________________________________________________
Executed in   67.76 secs    fish           external
   usr time   54.00 secs    0.09 millis   54.00 secs
   sys time    7.25 secs    3.71 millis    7.24 secs

$ git co chromy/2025-10-07-opt
Switched to branch 'chromy/2025-10-07-opt'
$ time launchpad size ~/Downloads/app-release.apk >/dev/null

________________________________________________________
Executed in   60.82 secs    fish           external
   usr time   47.15 secs    0.06 millis   47.15 secs
   sys time    7.13 secs    1.38 millis    7.12 secs

$ time launchpad size ~/Downloads/app-release.apk >/dev/null

________________________________________________________
Executed in   60.77 secs    fish           external
   usr time   47.11 secs    0.06 millis   47.11 secs
   sys time    7.22 secs    1.46 millis    7.21 secs

Also add some benchmarks which were useful for investigating this.
