### PR TITLE
Set correct statsd namespace for consumer arroyo metrics

### DIFF
--- a/src/launchpad/utils/arroyo_metrics.py
+++ b/src/launchpad/utils/arroyo_metrics.py
@@ -17,7 +17,7 @@ class DatadogMetricsBackend(Metrics):
     """
 
     def __init__(self, group_id: str) -> None:
-        self._statsd = get_statsd("consumer")
+        self._statsd = get_statsd("sentry.consumer")
         self._constant_tags = {"consumer_group": group_id}
 
     def increment(

--- a/src/launchpad/utils/statsd.py
+++ b/src/launchpad/utils/statsd.py
@@ -140,8 +140,8 @@ class DogStatsdWrapper(StatsdInterface):
 _namespace_to_statsd: dict[str, StatsdInterface] = {}
 
 
-def get_statsd(namespace_suffix: Literal[None, "consumer"] = None) -> StatsdInterface:
-    namespace = f"launchpad_{namespace_suffix}" if namespace_suffix else "launchpad"
+def get_statsd(custom_namespace: Literal[None, "sentry.consumer"] = None) -> StatsdInterface:
+    namespace = custom_namespace or "launchpad"
 
     if namespace in _namespace_to_statsd:
         return _namespace_to_statsd[namespace]


### PR DESCRIPTION
vanity improvement :P 

To match convention so our arroyo consumer metrics use the same metric name as the others