### PR TITLE
Ensure all asset catalog images are considered

### DIFF
--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -374,14 +374,18 @@ class ZippedXCArchive(AppleArtifact):
         colorspace = item.get("colorspace")
 
         file_extension = Path(filename).suffix.lower()
-        if filename and file_extension in {".png", ".jpg", ".jpeg", ".heic", ".heif"}:
-            potential_path = parent_path / f"{image_id}{file_extension}"
-            if potential_path.exists():
-                full_path = potential_path
-            else:
-                full_path = None
-        else:
-            full_path = None
+        full_path = None
+
+        if filename:
+            if file_extension in {".png", ".jpg", ".jpeg", ".heic", ".heif"}:
+                potential_path = parent_path / f"{image_id}{file_extension}"
+                if potential_path.exists():
+                    full_path = potential_path
+            elif not file_extension:
+                # No extension, try .png as default (for some asset catalog entries)
+                potential_path = parent_path / f"{image_id}.png"
+                if potential_path.exists():
+                    full_path = potential_path
 
         return AssetCatalogElement(
             name=name,

--- a/src/launchpad/size/insights/apple/alternate_icons_optimization.py
+++ b/src/launchpad/size/insights/apple/alternate_icons_optimization.py
@@ -71,7 +71,6 @@ class AlternateIconsOptimizationInsight(BaseImageOptimizationInsight):
         )
 
     def _is_alternate_icon_file(self, file_info: FileInfo, alternate_icon_names: set[str]) -> bool:
-        return (
-            file_info.file_type.lower() in self.OPTIMIZABLE_FORMATS
-            and Path(file_info.path).stem in alternate_icon_names
-        )
+        # Some asset catalog entries have no extension, so we include "other" in the OPTIMIZABLE_FORMATS
+        file_type_match = file_info.file_type.lower() in (self.OPTIMIZABLE_FORMATS | {"other"})
+        return file_type_match and Path(file_info.path).stem in alternate_icon_names


### PR DESCRIPTION
When debugging why alternative icons are not showing up for Firefox, I realized that some asset catalog images will not have a file path because they are multi-sized assets. I've made a change in the CLI to include them into ParsedAssets still, but we need to ensure that they are parsed with the correct path on launchpad to ensure they are considered and fully analyzed for our image insights

For example, here's one in the firefox app that we weren't actually considering:

```
    {
        "vector": false,
        "type": 0,
        "imageId": "42D31467-E63B-49D8-8D9B-1B608059E344",
        "size": 236,
        "height": 1024,
        "name": "AppIcon_Alt_Color_Purple",
        "filename": "AppIcon_Alt_Color_Purple",
        "idiom": "phone",
        "width": 1024
    },
```