### PR TITLE
Tweak icon parsing once more to handle adjusted name format

### DIFF
--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -430,18 +430,14 @@ class ZippedXCArchive(AppleArtifact):
         colorspace = item.get("colorspace")
 
         file_extension = Path(filename).suffix.lower()
-        full_path = None
-
-        if filename:
-            if file_extension in {".png", ".jpg", ".jpeg", ".heic", ".heif"}:
-                potential_path = parent_path / f"{image_id}{file_extension}"
-                if potential_path.exists():
-                    full_path = potential_path
-            elif not file_extension:
-                # No extension, try .png as default (for some asset catalog entries)
-                potential_path = parent_path / f"{image_id}.png"
-                if potential_path.exists():
-                    full_path = potential_path
+        if filename and file_extension in {".png", ".jpg", ".jpeg", ".heic", ".heif"}:
+            potential_path = parent_path / f"{image_id}{file_extension}"
+            if potential_path.exists():
+                full_path = potential_path
+            else:
+                full_path = None
+        else:
+            full_path = None
 
         return AssetCatalogElement(
             name=name,

--- a/src/launchpad/size/insights/apple/alternate_icons_optimization.py
+++ b/src/launchpad/size/insights/apple/alternate_icons_optimization.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 
-from pathlib import Path
 from typing import List
 
 from PIL import Image
@@ -69,8 +68,3 @@ class AlternateIconsOptimizationInsight(BaseImageOptimizationInsight):
         return img.resize((self.IPHONE_3X_ICON_SIZE, self.IPHONE_3X_ICON_SIZE), Image.Resampling.LANCZOS).resize(
             (self.APP_STORE_ICON_SIZE, self.APP_STORE_ICON_SIZE), Image.Resampling.LANCZOS
         )
-
-    def _is_alternate_icon_file(self, file_info: FileInfo, alternate_icon_names: set[str]) -> bool:
-        # Some asset catalog entries have no extension, so we include "other" in the OPTIMIZABLE_FORMATS
-        file_type_match = file_info.file_type.lower() in (self.OPTIMIZABLE_FORMATS | {"other"})
-        return file_type_match and Path(file_info.path).stem in alternate_icon_names

--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -182,6 +182,24 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
             logger.exception("HEIC image minification failed")
             return None
 
+    def _is_alternate_icon_file(self, file_info: FileInfo, alternate_icon_names: set[str]) -> bool:
+        file_type_match = file_info.file_type.lower() in self.OPTIMIZABLE_FORMATS
+
+        if not file_type_match:
+            return False
+
+        stem = Path(file_info.path).stem
+        parent_str = str(Path(file_info.path).parent)
+
+        if stem in alternate_icon_names:
+            return True
+
+        for name in alternate_icon_names:
+            if parent_str == f"Assets.car/{name}":
+                return True
+
+        return False
+
 
 class ImageOptimizationInsight(BaseImageOptimizationInsight):
     """Analyse image optimisation opportunities in iOS apps."""
@@ -225,4 +243,14 @@ class ImageOptimizationInsight(BaseImageOptimizationInsight):
             return not Path(file_info.path).name.startswith(("AppIcon", "iMessage App Icon"))
 
         stem = Path(file_info.path).stem
-        return stem != primary_icon_name and stem not in alternate_icon_names
+        parent_str = str(Path(file_info.path).parent)
+
+        # Exclude primary icon
+        if stem == primary_icon_name or parent_str == f"Assets.car/{primary_icon_name}":
+            return False
+
+        # Exclude alternate icons (they have their own insight)
+        if self._is_alternate_icon_file(file_info, alternate_icon_names):
+            return False
+
+        return True


### PR DESCRIPTION
This change is in tandem with [this sentry-cli PR](https://github.com/getsentry/sentry-cli/pull/2889). It does three main things:

1. Reverts the changes from yesterday's [multiset icon parsing launchpad PR](https://github.com/getsentry/sentry-cli/pull/2879)
2. Ensures that any alternative icons won't be considered for the image optimization insight as well (they now share the same method)
3. Tweaks the file name parsing when performing the `_is_alternate_icon_file` and `_is_optimizable_image_file` checks. A change in [the CLI PR ](https://github.com/getsentry/sentry-cli/pull/2889) causes the file_info.path to now be: 

```
Assets.car/AppIcon_Alt_Color_Red/red-light-min.png
```

where before it was `Assets.car/AppIcon_Alt_Color_Red`. So the name matching logic had to be slightly tweaked
