### PR TITLE
One more alt icon tweak to ensure accurate insight numbers

### DIFF
--- a/src/launchpad/size/insights/apple/alternate_icons_optimization.py
+++ b/src/launchpad/size/insights/apple/alternate_icons_optimization.py
@@ -56,9 +56,15 @@ class AlternateIconsOptimizationInsight(BaseImageOptimizationInsight):
     def _preprocess_image(self, img: Image.Image, file_info: FileInfo) -> tuple[Image.Image, int, int]:
         resized = self._resize_icon_for_analysis(img)
 
+        # Specify quality=85 for HEICs to avoid inflating already-optimized files.
+        # Without it, PIL uses a higher default quality (~95), which would incorrectly
+        # show savings for files that are already at our target quality.
         fmt = img.format or "PNG"
         with io.BytesIO() as buf:
-            resized.save(buf, format=fmt)
+            if fmt.upper() in {"HEIF", "HEIC"}:
+                resized.save(buf, format="HEIF", quality=self.TARGET_HEIC_QUALITY)
+            else:
+                resized.save(buf, format=fmt)
             resized_size = buf.tell()
 
         baseline_savings = max(0, file_info.size - resized_size)


### PR DESCRIPTION
Fix false positive savings in alternate icons optimization insight

After users optimized alternate icons using our recommended script (resize to 180px→1024px + convert to HEIC@85), re-uploading the optimized build still showed ~680KB of potential savings. This created a poor UX where the insight would never be fully resolved.

### Root Cause
In `AlternateIconsOptimizationInsight._preprocess_image()`, when resizing HEIC images, we weren't specifying a quality parameter. This caused PIL to use its default quality (~95), which inflated already-optimized HEIC@85 files. The code would then detect "savings" by re-compressing them back to quality 85.

### Fix
Now explicitly specify `quality=self.TARGET_HEIC_QUALITY` (85) when saving HEIC images during preprocessing. This ensures:
- Already-optimized HEIC@85 files show ~0 savings ✅
- Actual optimization opportunities (PNG→HEIC, high-quality HEIC→85) are still detected ✅
- Predictions accurately match what users achieve with the recommended script ✅

### Testing
Existing tests continue to pass. Manually verified that:
- Original PNG uploads: Still show correct ~8.5MB savings
- Re-uploaded optimized HEICs: Now show minimal/no savings (down from 680KB false positive)