### PR TITLE
Always convert bplist and plist to key/value strings format for savings

### DIFF
--- a/src/launchpad/size/insights/apple/localized_strings_minify.py
+++ b/src/launchpad/size/insights/apple/localized_strings_minify.py
@@ -2,6 +2,8 @@ import logging
 import plistlib
 import re
 
+from pathlib import Path
+
 from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.insights.insight import Insight, InsightsInput
 from launchpad.size.models.common import FileInfo
@@ -56,33 +58,15 @@ class MinifyLocalizedStringsInsight(Insight[LocalizedStringCommentsInsightResult
 
             content_bytes = file_path.read_bytes()
 
-            # Binary plist files don't support comments, so we can skip them
+            # Binary plists and regular plists have significant overhead
+            # Calculate the savings from converting to standard strings format
             if content_bytes.startswith(b"bplist"):
-                logger.debug("Skipping strings minification for binary plist: %s", file_info.path)
-                return 0
+                return self._calculate_plist_to_strings_savings(content_bytes, file_path, "binary plist")
 
-            # Try to parse as plist (XML format) if it looks like XML
             if content_bytes.startswith(b"<?xml "):
-                try:
-                    # Strip XML comments before parsing
-                    content_str = content_bytes.decode("utf-8", errors="ignore")
-                    content_no_comments = self._processor.strip_xml_comments(content_str)
-                    stripped_content_bytes = content_no_comments.encode("utf-8")
+                return self._calculate_plist_to_strings_savings(content_bytes, file_path, "XML plist")
 
-                    # Parse and re-serialize to normalize formatting
-                    plist_dict = plistlib.loads(stripped_content_bytes)
-                    if isinstance(plist_dict, dict):
-                        stripped_bytes = plistlib.dumps(plist_dict, fmt=plistlib.FMT_XML)
-                        return self._calculate_savings(content_bytes, stripped_bytes)
-                except Exception:
-                    # Not a valid plist, fall through to treat as text format
-                    logger.error(
-                        "Skipping strings minification because file is not a valid plist",
-                        extra={"file_path": file_path},
-                    )
-                    pass
-
-            # Treat as text format (traditional .strings format)
+            # For regular strings files, strip comments and normalize whitespace for savings
             content = content_bytes.decode("utf-8", errors="ignore")
             stripped_content = self._processor.strip_string_comments_and_whitespace(content)
             return self._calculate_savings(content.encode("utf-8"), stripped_content.encode("utf-8"))
@@ -97,20 +81,37 @@ class MinifyLocalizedStringsInsight(Insight[LocalizedStringCommentsInsightResult
         stripped_size = to_nearest_block_size(len(stripped_bytes), APPLE_FILESYSTEM_BLOCK_SIZE)
         return max(0, original_size - stripped_size)
 
+    def _calculate_plist_to_strings_savings(self, content_bytes: bytes, file_path: Path, plist_type: str) -> int:
+        plist_dict = plistlib.loads(content_bytes)
+        if isinstance(plist_dict, dict):
+            strings_content = self._processor.plist_dict_to_strings(plist_dict)
+            strings_bytes = strings_content.encode("utf-8")
+            return self._calculate_savings(content_bytes, strings_bytes)
+
+        logger.error(
+            "Skipping plist conversion because file is not a valid plist",
+            extra={"file_path": file_path, "plist_type": plist_type},
+        )
+        return 0
+
 
 class MinifyLocalizedStringsProcessor:
     """Processes localized strings files by stripping comments and normalizing whitespace."""
 
     # Match /* ... */ block comments or // line comments
     _COMMENT_RE = re.compile(r"/\*.*?\*/|//.*?$", re.S | re.M)
-    # Match XML comments <!-- ... -->
-    _XML_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
     # Lines that look like:  "key" = "value"; (handles escaped quotes inside strings)
     _KV_RE = re.compile(r'^\s*"(?:[^"\\]|\\.)+"\s*=\s*"(?:[^"\\]|\\.)*"\s*;?\s*$', re.M)
 
-    def strip_xml_comments(self, content: str) -> str:
-        """Strip XML-style comments (<!-- ... -->) from content."""
-        return self._XML_COMMENT_RE.sub("", content)
+    def plist_dict_to_strings(self, plist_dict: dict[str, str]) -> str:
+        """Convert a plist dictionary to standard strings format."""
+        lines: list[str] = []
+        for key, value in sorted(plist_dict.items()):  # Sort for consistent output
+            # Escape quotes and backslashes in key and value
+            escaped_key = str(key).replace("\\", "\\\\").replace('"', '\\"')
+            escaped_value = str(value).replace("\\", "\\\\").replace('"', '\\"')
+            lines.append(f'"{escaped_key}"="{escaped_value}";')
+        return "\n".join(lines) + "\n" if lines else ""
 
     def strip_string_comments_and_whitespace(self, content: str) -> str:
         """

--- a/tests/integration/test_localized_strings_minify_insight.py
+++ b/tests/integration/test_localized_strings_minify_insight.py
@@ -218,36 +218,6 @@ class TestMinifyLocalizedStringsProcessor:
         )
         assert result == expected
 
-    def test_strip_xml_comments(self):
-        """Test stripping XML comments."""
-        processor = MinifyLocalizedStringsProcessor()
-
-        # Test single line XML comment
-        content = "<!-- This is a comment --><key>test</key>"
-        result = processor.strip_xml_comments(content)
-        assert result == "<key>test</key>"
-
-        # Test multiline XML comment
-        content = """<!-- This is a
-        multiline
-        comment -->
-<dict>
-    <key>test</key>
-</dict>"""
-        result = processor.strip_xml_comments(content)
-        assert "<!--" not in result
-        assert "<dict>" in result
-        assert "<key>test</key>" in result
-
-        # Test multiple XML comments
-        content = """<!-- Comment 1 --><key>key1</key>
-<!-- Comment 2 --><string>value1</string>
-<!-- Comment 3 -->"""
-        result = processor.strip_xml_comments(content)
-        assert "<!--" not in result
-        assert "<key>key1</key>" in result
-        assert "<string>value1</string>" in result
-
 
 class TestMinifyLocalizedStringsInsight:
     """Test the MinifyLocalizedStringsInsight functionality."""
@@ -495,7 +465,7 @@ class TestMinifyLocalizedStringsInsight:
             assert result.total_savings > 0
 
     def test_binary_plist_strings_file(self):
-        """Test that insight skips binary plist files (they don't support comments)."""
+        """Test that small binary plist files don't generate insights due to low savings."""
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
 
@@ -537,8 +507,70 @@ class TestMinifyLocalizedStringsInsight:
             )
 
             result = insight.generate(input_data)
-            # Should skip binary plists (no savings possible)
+            # Small plist has savings below threshold, so no insight is generated
             assert result is None
+
+    def test_binary_plist_with_significant_savings(self):
+        """Test that large binary plist files show savings when converted to standard strings format."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create a binary plist strings file with many entries
+            strings_file = temp_path / "en.lproj" / "LargeBinaryPlist.strings"
+            strings_file.parent.mkdir(parents=True)
+
+            # Create a plist dict with enough entries to demonstrate block-aligned savings
+            # Binary plists have overhead from metadata, type info, offset tables, etc.
+            # With 200 short entries: binary ~4425 bytes (2 blocks) vs strings ~3780 bytes (1 block) = 4096 bytes savings
+            plist_dict = {}
+            for i in range(200):
+                plist_dict[f"k{i}"] = f"Value {i}"
+
+            binary_plist = plistlib.dumps(plist_dict, fmt=plistlib.FMT_BINARY)
+            strings_file.write_bytes(binary_plist)
+
+            # Calculate what the strings format would be
+            processor = MinifyLocalizedStringsProcessor()
+            strings_content = processor.plist_dict_to_strings(plist_dict)
+            strings_bytes = strings_content.encode("utf-8")
+
+            # Verify binary plist is actually larger (showing the overhead)
+            assert len(binary_plist) > len(strings_bytes), (
+                f"Binary plist ({len(binary_plist)} bytes) should be larger than "
+                f"strings format ({len(strings_bytes)} bytes)"
+            )
+
+            insight = MinifyLocalizedStringsInsight()
+
+            input_data = InsightsInput(
+                app_info=self._create_test_app_info(),
+                file_analysis=FileAnalysis(
+                    files=[
+                        FileInfo(
+                            full_path=strings_file,
+                            path="en.lproj/LargeBinaryPlist.strings",
+                            size=len(binary_plist),
+                            file_type="strings",
+                            hash="large_binary_hash",
+                            treemap_type=TreemapType.FILES,
+                            is_dir=False,
+                            children=[],
+                        )
+                    ],
+                    directories=[],
+                ),
+                binary_analysis=[],
+                treemap=None,
+                hermes_reports={},
+            )
+
+            result = insight.generate(input_data)
+            # Should find savings from converting binary plist to standard strings format
+            assert result is not None, "Should generate insight for large binary plist"
+            assert len(result.files) == 1
+            assert result.files[0].file_path == "en.lproj/LargeBinaryPlist.strings"
+            assert result.files[0].total_savings > 0
+            assert result.total_savings > insight.THRESHOLD_BYTES
 
     def test_xml_plist_strings_file_with_formatting(self):
         """Test that insight handles XML plist-format .strings files with extra formatting."""


### PR DESCRIPTION
I realized that the XML overhead for these formats will always be greater than the simpler key/value format, so we should always check the conversion savings. This lets me remove the XML comment stripping logic since that's no longer needed. Now this very closely matches the Emerge behavior other than a small difference with the filesystem block size calculation which we can't really avoid.