### PR TITLE
[DNM] Add Arroyo batch timeout logic

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -63,14 +63,12 @@ class LaunchpadRunTaskWithMultiprocessing(RunTaskWithMultiprocessing[TStrategyPa
         self,
         function: Callable[[Message[TStrategyPayload]], Any],
         next_step: ProcessingStrategy[FilteredPayload | Any],
-        max_batch_size: int,
-        max_batch_time: float,
         pool: MultiprocessingPool,
         input_block_size: int | None = None,
         output_block_size: int | None = None,
         batch_timeout: float | None = None,
     ) -> None:
-        super().__init__(function, next_step, max_batch_size, max_batch_time, pool, input_block_size, output_block_size)
+        super().__init__(function, next_step, 1, 1, pool, input_block_size, output_block_size)
 
         self._batch_timeout = batch_timeout
         self._batch_submit_times: dict[int, float] = {}  # Maps batch id to submission timestamp
@@ -143,7 +141,7 @@ class LaunchpadRunTaskWithMultiprocessing(RunTaskWithMultiprocessing[TStrategyPa
                 invalid_msg = InvalidMessage(
                     message.value.partition,
                     message.value.offset,
-                    reason=f"Batch processing exceeded {self._batch_timeout}s timeout"
+                    reason=f"Batch processing exceeded {self._batch_timeout}s timeout",
                 )
                 invalid_messages.append(invalid_msg)
 
@@ -339,8 +337,6 @@ class LaunchpadStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         strategy = LaunchpadRunTaskWithMultiprocessing(
             process_kafka_message_with_service,
             next_step=next_step,
-            max_batch_size=1,
-            max_batch_time=1,
             pool=self._pool,
             input_block_size=None,
             output_block_size=None,


### PR DESCRIPTION
**Goal**: we are processing third-party apps and cannot predict the input will always cleanly succeed, it's fine and expected that some processing jobs will fail. We do need some guarantees that jobs will only take a certain amount of time and not clog up the system for everyone else, though.

For context, we ran into an edge case where our `lief` library essentially deadlocked our topic. It wasn't technically deadlocked, but it would have taken several hours to finish processing the message. Fixing this was rather painful in prod once it happened since we had to skip over that message. Instead, we want a hard processing timeout per message.

I originally looked into supporting timeouts per message batch in Arroyo itself, however this runs into an undesirable case where we don't know exactly which messages in a batch succeeded or failed and we might erroneously mark successful messages to the DLQ. This might be fine, but I'm not sure of the idempotency guarantees Arroyo makes. In our case this doesn't matter since we always set the batch size to 1, but since this is a general purpose library I could see this being confusing/unexpected behavior to others. The streaming team mentioned we could have per-message timeouts but it might be a larger undertaking/refactor to achieve that.

Instead, in the meantime we can implement timeouts in our subclass. This works by overriding the `poll()` method, recording the start times of batches, and then checking for batches exceeding our timeout threshold. Since we are the only team requesting this feature we can live with this for now until it's potentially supported upstream. I tried a few other methods such as running the processing logic in a thread with a join timeout, but those never trigger.

Testing this with the stuck build in question I now correctly see:
```
[17:22:13] ERROR    Batch exceeded timeout of 720.0s (elapsed=720.70s).
           DEBUG    Worker process exited normally (SIGCHLD 20)
           DEBUG    Worker process exited normally (SIGCHLD 20)
           INFO     Terminated worker and sent 1 messages to DLQ
```