### PR TITLE
Make symObjAddr optional

### DIFF
--- a/src/launchpad/parsers/apple/dwarf_relocations_parser.py
+++ b/src/launchpad/parsers/apple/dwarf_relocations_parser.py
@@ -19,7 +19,7 @@ class DwarfRelocation:
     size: int
     addend: int
     sym_name: str
-    sym_obj_addr: int
+    sym_obj_addr: int | None
     sym_bin_addr: int
     sym_size: int
 
@@ -30,7 +30,7 @@ class DwarfRelocation:
             size=data["size"],
             addend=data["addend"],
             sym_name=data["symName"],
-            sym_obj_addr=data["symObjAddr"],
+            sym_obj_addr=data["symObjAddr"] if "symObjAddr" in data else None,
             sym_bin_addr=data["symBinAddr"],
             sym_size=data["symSize"],
         )


### PR DESCRIPTION
I'm seeing this missing for a few relocation entries in various apps.