### PR TITLE
Add join_timeout value for kafka consumer to better handle rebalances

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -138,6 +138,7 @@ def create_kafka_consumer() -> LaunchpadKafkaConsumer:
         consumer=arroyo_consumer,
         topic=topic,
         processor_factory=strategy_factory,
+        join_timeout=config.join_timeout_seconds,  # Drop in-flight work during rebalance before Kafka times out
     )
     return LaunchpadKafkaConsumer(processor, healthcheck_path, strategy_factory)
 
@@ -293,6 +294,7 @@ class KafkaConfig:
     sasl_mechanism: str | None
     sasl_username: str | None
     sasl_password: str | None
+    join_timeout_seconds: float
 
 
 def get_kafka_config() -> KafkaConfig:
@@ -327,4 +329,5 @@ def get_kafka_config() -> KafkaConfig:
         sasl_mechanism=os.environ.get("KAFKA_SASL_MECHANISM", None),
         sasl_username=os.environ.get("KAFKA_SASL_USERNAME", None),
         sasl_password=os.environ.get("KAFKA_SASL_PASSWORD", None),
+        join_timeout_seconds=float(os.getenv("KAFKA_JOIN_TIMEOUT_SECONDS", "10")),
     )


### PR DESCRIPTION
A kafka rebalance was triggered (t=0) which caused JoinGroupRequest to be sent. This request has a 246-second timeout.

**t=0s - t=57s**: Consumer stuck in rebalance operation
Main thread blocked coordinating the rebalance
Heartbeat background thread couldn't send heartbeats (or they were queued/blocked)
Session timeout: 45 seconds
**t=45s**: Kafka broker says "No heartbeat for 45 seconds → consumer is dead"
Marks consumer as failed
But requests are still in-flight...
**t=57s**: Connection forcibly closed


Supposedly instead of bumping the `session.timeout.ms` value we should instead provide a `join_timeout` value so that our consumer will drop the work