### PR TITLE
Check if binaries exist before processing

### DIFF
--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -318,6 +318,9 @@ class ZippedXCArchive(AppleArtifact):
         if main_executable is None:
             raise RuntimeError("CFBundleExecutable not found in Info.plist")
         main_binary_path = self._get_main_binary_path()
+        if not main_binary_path.exists():
+            logger.error("Main binary not found", extra={"path": main_binary_path})
+            return []
 
         # Find corresponding dSYM for main executable
         main_uuid = self._extract_binary_uuid(main_binary_path)


### PR DESCRIPTION
In some cases we are seeing a `com.apple.WatchPlaceholder` stub folder being created with a seemingly correct `Info.plist` file. We were trusting the `CFBundleExecutable` executable referenced here exists which isn't true in this case. I'm guessing that the OS can download the executable separately at runtime on-demand.

Resolves EME-651, EME-652