### PR TITLE
[iOS] Refactor get_all_binary_paths + add lief cache

### DIFF
--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -361,6 +361,10 @@ class ZippedXCArchive(AppleArtifact):
 
         return binaries
 
+    def get_lief_cache(self) -> dict[Path, lief.MachO.FatBinary]:
+        """Get the LIEF cache of pre-parsed binaries"""
+        return self._lief_cache
+
     @sentry_sdk.trace
     def get_asset_catalog_details(self, relative_path: Path) -> List[AssetCatalogElement]:
         """Get the details of an asset catalog file (Assets.car) by returning the

--- a/src/launchpad/artifacts/artifact.py
+++ b/src/launchpad/artifacts/artifact.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Any, Callable
 
+import lief
+
 from launchpad.parsers.android.dex.dex_mapping import DexMapping
 
 from .android.manifest.manifest import AndroidManifest
@@ -49,6 +51,10 @@ class AppleArtifact(Artifact):
     def get_plist(self) -> dict[str, Any]:
         """Get the plist from the artifact."""
         raise NotImplementedError("Not implemented")
+
+    def get_lief_cache(self) -> dict[Path, lief.MachO.FatBinary]:
+        """Get the LIEF cache of pre-parsed binaries"""
+        return {}
 
     def generate_ipa(self, output_path: Path):
         raise NotImplementedError("Not implemented")

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -151,7 +151,7 @@ class AppleAppAnalyzer:
             binaries = artifact.get_all_binary_paths()
             logger.debug(f"Found {len(binaries)} binaries to analyze")
 
-            lief_cache = getattr(artifact, "_lief_cache", {})
+            lief_cache = artifact.get_lief_cache()
             for binary_info in binaries:
                 logger.info(
                     "size.apple.binary_analysis_started",
@@ -450,6 +450,8 @@ class AppleAppAnalyzer:
 
         logger.debug(f"Analyzing binary: {binary_path}")
 
+        # Only binaries with dSYMs are pre-cached. Pop from cache to free memory immediately.
+        # Binaries without dSYMs will be parsed on-demand here.
         fat_binary = lief_cache.pop(binary_path, None) if lief_cache else None
         if fat_binary is None:
             logger.debug(f"Binary not in LIEF cache, parsing now: {binary_path.name}")


### PR DESCRIPTION
Added a cache to avoid a second parse. It only caches a binary if it contains a dSYM, since the second parse only concerns itself with binaries containing dSYMs.

In the process, I also cleaned up the structure of get_all_binary_paths a bit