### PR TITLE
Temporarily bump kafka healthcheck max age to 5 minutes

### DIFF
--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -35,8 +35,8 @@ class PreprodFeature(Enum):
 # Retry configuration
 MAX_RETRY_ATTEMPTS = 3
 
-# Health check threshold - consider unhealthy if file not touched in 60 seconds
-HEALTHCHECK_MAX_AGE_SECONDS = 60.0
+# Health check threshold - consider unhealthy if file not touched in 5 minutes
+HEALTHCHECK_MAX_AGE_SECONDS = 300.0
 
 
 class OperationName(Enum):


### PR DESCRIPTION
An attempt to temporarily quell crash looping that is currently going on. The better fix would be something more like https://github.com/getsentry/launchpad/pull/484

its too late for me to cobble that PR together properly though... a task for tomorrow

the hope though is that this temporarily reduces the number of builds that are requeued due to the rebalance shenanigans going on right now

it's also low risk