### PR TITLE
[iOS] Improve lief parsing performance with configs

### DIFF
--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -504,6 +504,11 @@ class ZippedXCArchive(AppleArtifact):
         if self._dsym_info is None:
             self._find_dsym_files()
 
+        config = lief.MachO.ParserConfig()
+        config.parse_dyld_exports = False
+        config.parse_dyld_bindings = False
+        config.parse_dyld_rebases = False
+
         for binary_path in binary_paths:
             if not binary_path.exists():
                 logger.warning(f"Binary path does not exist: {binary_path}")
@@ -511,7 +516,7 @@ class ZippedXCArchive(AppleArtifact):
 
             try:
                 with open(binary_path, "rb") as f:
-                    fat_binary: lief.MachO.FatBinary | None = lief.MachO.parse(f)  # type: ignore
+                    fat_binary: lief.MachO.FatBinary | None = lief.MachO.parse(f, config)  # type: ignore
 
                 if fat_binary is None or fat_binary.size == 0:
                     logger.debug(f"Failed to parse binary with LIEF: {binary_path}")
@@ -533,6 +538,7 @@ class ZippedXCArchive(AppleArtifact):
                     continue
 
                 self._binary_uuid_cache[binary_path] = extracted_uuid
+
                 if extracted_uuid in self._dsym_info:
                     self._lief_cache[binary_path] = fat_binary
                     logger.debug(f"Cached LIEF object for {binary_path.name} (has dSYM)")

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -456,7 +456,13 @@ class AppleAppAnalyzer:
         if fat_binary is None:
             logger.debug(f"Binary not in LIEF cache, parsing now: {binary_path.name}")
             with open(binary_path, "rb") as f:
-                fat_binary = lief.MachO.parse(f)  # type: ignore
+                config = lief.MachO.ParserConfig()
+                config.parse_dyld_exports = False
+                config.parse_dyld_bindings = False
+                config.parse_dyld_rebases = False
+
+                fat_binary = lief.MachO.parse(f, config)  # type: ignore
+
         if fat_binary is None or fat_binary.size == 0:
             raise RuntimeError(f"Failed to parse binary with LIEF: {binary_path}")
 
@@ -479,8 +485,13 @@ class AppleAppAnalyzer:
         strippable_symbols_size = self._check_strip_symbols_removal(binary_path, binary)
 
         if dwarf_binary_path:
+            dsym_config = lief.MachO.ParserConfig()
+            dsym_config.parse_dyld_exports = False
+            dsym_config.parse_dyld_bindings = False
+            dsym_config.parse_dyld_rebases = False
+
             with open(dwarf_binary_path, "rb") as f:
-                dwarf_fat_binary = lief.MachO.parse(f)  # type: ignore
+                dwarf_fat_binary = lief.MachO.parse(f, dsym_config)  # type: ignore
             if dwarf_fat_binary:
                 dwarf_binary = dwarf_fat_binary.at(0)
                 symbol_sizes = MachOSymbolSizes(dwarf_binary).get_symbol_sizes()


### PR DESCRIPTION
I've added configs to three parts of the code where we perform parsing. Upon testing, it appears that our required MachO parsing config is relatively simple for all three spots (and thus we are able to disable these options for our parsing needs). I tested with a substantially sized app which is pretty meaty and found a completely identical `apple-size-output.json` output. 

**I also found that each main machO parse (for the app I used to test) went from 19.5s to 4.1s (and for the dSYM parse, a very small improvement, but improvement nonetheless)**