### PR TITLE
Revert "Temporarily bump kafka healthcheck max age to 5 minutes (#485)"

### DIFF
--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -35,8 +35,8 @@ class PreprodFeature(Enum):
 # Retry configuration
 MAX_RETRY_ATTEMPTS = 3
 
-# Health check threshold - consider unhealthy if file not touched in 5 minutes
-HEALTHCHECK_MAX_AGE_SECONDS = 300.0
+# Health check threshold - consider unhealthy if file not touched in 60 seconds
+HEALTHCHECK_MAX_AGE_SECONDS = 60.0
 
 
 class OperationName(Enum):


### PR DESCRIPTION
This reverts commit 0a0f43c5a9c30c4848747f66ffc315b8f85dfb10.

Wasn't useful in solving an outage I was trying to mitigate, so reverting