### PR TITLE
[ios performance] Temporarily use lief fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
---find-links https://github.com/getsentry/LIEF/releases/expanded_assets/1.0.0
-
 aiohttp>=3.12.15
 asn1crypto>=1.5.0
 build>=1.3.0
@@ -9,7 +7,11 @@ cryptography>=45.0.7
 datadog==0.52.1
 google-api-core==2.25.1
 google-api-python-client==2.181.0
-lief==1.0.0.dev0
+
+# LIEF - use pre-built wheels from our fork
+lief @ https://github.com/getsentry/LIEF/releases/download/1.0.0/lief-1.0.0.dev0-cp312-cp312-manylinux2014_aarch64.whl ; sys_platform == 'linux' and platform_machine == 'aarch64'
+lief @ https://github.com/getsentry/LIEF/releases/download/1.0.0/lief-1.0.0.dev0-cp313-cp313-macosx_11_0_arm64.whl ; sys_platform == 'darwin' and platform_machine == 'arm64'
+lief @ https://github.com/getsentry/LIEF/releases/download/1.0.0/lief-1.0.0.dev0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl ; sys_platform == 'linux' and platform_machine == 'x86_64'
 lzfse>=0.4.2
 pillow>=11.3.0
 pillow_heif>=1.1.0


### PR DESCRIPTION
Just use it without the wheels for now. Adds an extra 30s or so to the docker image build, but should be fine for this temporary usage.

We can add wheels to our forked release if we notice much more of a difference

verified works locally