### PR TITLE
Include all arroyo processing logs again to debug prod rebalance storm causes

### DIFF
--- a/src/launchpad/utils/logging.py
+++ b/src/launchpad/utils/logging.py
@@ -141,8 +141,6 @@ def setup_logging(verbose: bool = False, quiet: bool = False) -> None:
 
     # Set levels for third-party libraries
     logging.getLogger("datadog.dogstatsd").setLevel(logging.ERROR)
-    logging.getLogger("arroyo.processing.processor").setLevel(logging.ERROR)
-    logging.getLogger("arroyo.processing.strategies.run_task_with_multiprocessing").setLevel(logging.ERROR)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
 


### PR DESCRIPTION
@fpacifici mentioned in an offline discussion that the arroyo logs should include detailed information when a consumer shuts down.

The logs are super super noisy so we actually omitted them, but given that we've faced two rebalance storms now trying to modify our arroyo strategy, lets include these logs again to aide in debugging