### PR TITLE
[S4S Testing Only] Merge "Simplify arroyo strategy in order to implement overall timeout with less risk (#493)" again

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-import logging
-import multiprocessing
 import os
-import signal
 import time
 
 from dataclasses import dataclass
-from functools import partial
-from logging.handlers import QueueHandler, QueueListener
-from multiprocessing.pool import Pool
-from typing import Any, Callable, Mapping
+from typing import Any, Mapping
 
 from arroyo import Message, Topic, configure_metrics
 from arroyo.backends.kafka import KafkaConsumer as ArroyoKafkaConsumer
@@ -21,17 +15,12 @@ from arroyo.processing.processor import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyFactory
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.healthcheck import Healthcheck
-from arroyo.processing.strategies.run_task_with_multiprocessing import (
-    MultiprocessingPool,
-    RunTaskWithMultiprocessing,
-    parallel_worker_initializer,
-)
-from arroyo.types import Commit, FilteredPayload, Partition, TStrategyPayload
+from arroyo.processing.strategies.run_task import RunTask
+from arroyo.types import Commit, Partition
 from sentry_kafka_schemas import get_codec
 
 from launchpad.artifact_processor import ArtifactProcessor
 from launchpad.constants import HEALTHCHECK_MAX_AGE_SECONDS, PREPROD_ARTIFACT_EVENTS_TOPIC
-from launchpad.tracing import RequestLogFilter
 from launchpad.utils.arroyo_metrics import DatadogMetricsBackend
 from launchpad.utils.logging import get_logger
 
@@ -41,49 +30,14 @@ logger = get_logger(__name__)
 PREPROD_ARTIFACT_SCHEMA = get_codec(PREPROD_ARTIFACT_EVENTS_TOPIC)
 
 
-class LaunchpadMultiProcessingPool(MultiprocessingPool):
-    """Extended MultiprocessingPool with maxtasksperchild=1 to ensure clean worker state."""
-
-    def maybe_create_pool(self) -> None:
-        if self._MultiprocessingPool__pool is None:
-            self._MultiprocessingPool__metrics.increment("arroyo.strategies.run_task_with_multiprocessing.pool.create")
-            self._MultiprocessingPool__pool = Pool(
-                self._MultiprocessingPool__num_processes,
-                initializer=partial(parallel_worker_initializer, self._MultiprocessingPool__initializer),
-                context=multiprocessing.get_context("spawn"),
-                maxtasksperchild=1,  # why we have this subclass
-            )
-
-
-class LaunchpadRunTaskWithMultiprocessing(RunTaskWithMultiprocessing[TStrategyPayload, Any]):
-    """Tolerates child process exits from maxtasksperchild=1 by ignoring SIGCHLD."""
-
-    def __init__(
-        self,
-        function: Callable[[Message[TStrategyPayload]], Any],
-        next_step: ProcessingStrategy[FilteredPayload | Any],
-        max_batch_size: int,
-        max_batch_time: float,
-        pool: MultiprocessingPool,
-        input_block_size: int | None = None,
-        output_block_size: int | None = None,
-    ) -> None:
-        super().__init__(function, next_step, max_batch_size, max_batch_time, pool, input_block_size, output_block_size)
-        # Override SIGCHLD handler - child exits are expected with maxtasksperchild=1
-        signal.signal(
-            signal.SIGCHLD,
-            lambda signum, frame: logger.debug(f"Worker process exited normally (SIGCHLD {signum})"),
-        )
-
-
 def process_kafka_message_with_service(msg: Message[KafkaPayload]) -> Any:
-    """Process a Kafka message using the actual service logic in a worker process."""
+    """Process a Kafka message using the actual service logic."""
     try:
         decoded = PREPROD_ARTIFACT_SCHEMA.decode(msg.payload.value)
         ArtifactProcessor.process_message(decoded)
         return decoded  # type: ignore[no-any-return]
     except Exception as e:
-        logger.error(f"Failed to process message in worker: {e}", exc_info=True)
+        logger.error(f"Failed to process message: {e}", exc_info=True)
         raise
 
 
@@ -126,11 +80,7 @@ def create_kafka_consumer() -> LaunchpadKafkaConsumer:
     arroyo_consumer = ArroyoKafkaConsumer(consumer_config)
     healthcheck_path = config.healthcheck_file
 
-    strategy_factory = LaunchpadStrategyFactory(
-        concurrency=config.concurrency,
-        max_pending_futures=config.max_pending_futures,
-        healthcheck_file=healthcheck_path,
-    )
+    strategy_factory = LaunchpadStrategyFactory(healthcheck_file=healthcheck_path)
 
     topics = [Topic(topic) for topic in config.topics]
     topic = topics[0] if topics else Topic("default")
@@ -140,24 +90,21 @@ def create_kafka_consumer() -> LaunchpadKafkaConsumer:
         processor_factory=strategy_factory,
         join_timeout=config.join_timeout_seconds,  # Drop in-flight work during rebalance before Kafka times out
     )
-    return LaunchpadKafkaConsumer(processor, healthcheck_path, strategy_factory)
+    return LaunchpadKafkaConsumer(processor, healthcheck_path)
 
 
 class LaunchpadKafkaConsumer:
     processor: StreamProcessor[KafkaPayload]
     healthcheck_path: str | None
-    strategy_factory: LaunchpadStrategyFactory
     _running: bool
 
     def __init__(
         self,
         processor: StreamProcessor[KafkaPayload],
         healthcheck_path: str | None,
-        strategy_factory: LaunchpadStrategyFactory,
     ):
         self.processor = processor
         self.healthcheck_path = healthcheck_path
-        self.strategy_factory = strategy_factory
         self._running = False
 
     def run(self):
@@ -175,23 +122,10 @@ class LaunchpadKafkaConsumer:
             except FileNotFoundError:
                 pass
 
-            # Clean up multiprocessing pool
-            try:
-                self.strategy_factory.close()
-                logger.debug("Closed multiprocessing pool")
-            except Exception:
-                logger.exception("Error closing multiprocessing pool")
-
     def stop(self):
         """Signal shutdown to the processor."""
         logger.info(f"{self} stop commanded")
         self.processor.signal_shutdown()
-
-        # Kill all multiprocessing worker children (development only)
-        environment = os.getenv("LAUNCHPAD_ENV", "development").lower()
-        if environment == "development":
-            for child in multiprocessing.active_children():
-                child.terminate()
 
     def is_healthy(self) -> bool:
         try:
@@ -206,49 +140,8 @@ class LaunchpadKafkaConsumer:
 class LaunchpadStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     """Factory for creating the processing strategy chain."""
 
-    def __init__(
-        self,
-        concurrency: int,
-        max_pending_futures: int,
-        healthcheck_file: str | None = None,
-    ) -> None:
-        self._log_queue: multiprocessing.Queue[Any] = multiprocessing.Manager().Queue(-1)
-        self._queue_listener = self._setup_queue_listener()
-        self._queue_listener.start()
-
-        initializer_with_queue = partial(self._initialize_worker_logging, self._log_queue)
-
-        self._pool = LaunchpadMultiProcessingPool(
-            num_processes=concurrency,
-            initializer=initializer_with_queue,
-        )
-        self.concurrency = concurrency
-        self.max_pending_futures = max_pending_futures
+    def __init__(self, healthcheck_file: str | None = None) -> None:
         self.healthcheck_file = healthcheck_file
-
-    def _setup_queue_listener(self) -> QueueListener:
-        """Set up listener in main process to handle logs from workers."""
-        root_logger = logging.getLogger()
-        handlers = list(root_logger.handlers) if root_logger.handlers else []
-
-        return QueueListener(self._log_queue, *handlers, respect_handler_level=True)
-
-    @staticmethod
-    def _initialize_worker_logging(log_queue: multiprocessing.Queue[Any]) -> None:
-        """Initialize logging in worker process to send logs to queue.
-
-        With multiprocessing spawn context, subprocesses don't inherit
-        parent's stdout/stderr. We use a queue to send log records to
-        the main process which writes them to stdout for Docker/GCP.
-        """
-        root_logger = logging.getLogger()
-        root_logger.handlers.clear()
-
-        queue_handler = QueueHandler(log_queue)
-        queue_handler.addFilter(RequestLogFilter())
-
-        root_logger.addHandler(queue_handler)
-        root_logger.setLevel(logging.DEBUG)
 
     def create_with_partitions(
         self,
@@ -260,22 +153,9 @@ class LaunchpadStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         assert self.healthcheck_file
         next_step = Healthcheck(self.healthcheck_file, next_step)
 
-        strategy = LaunchpadRunTaskWithMultiprocessing(
-            process_kafka_message_with_service,
-            next_step=next_step,
-            max_batch_size=1,  # Process immediately, subject to be re-tuned
-            max_batch_time=1,  # Process after 1 second max, subject to be re-tuned
-            pool=self._pool,
-            input_block_size=None,
-            output_block_size=None,
-        )
+        strategy = RunTask(process_kafka_message_with_service, next_step=next_step)
 
         return strategy
-
-    def close(self) -> None:
-        """Clean up the multiprocessing pool and logging queue."""
-        self._pool.close()
-        self._queue_listener.stop()
 
 
 @dataclass
@@ -285,8 +165,6 @@ class KafkaConfig:
     bootstrap_servers: str
     group_id: str
     topics: list[str]
-    concurrency: int
-    max_pending_futures: int
     healthcheck_file: str | None
     auto_offset_reset: str
     arroyo_strict_offset_reset: bool | None
@@ -320,8 +198,6 @@ def get_kafka_config() -> KafkaConfig:
         bootstrap_servers=bootstrap_servers,
         group_id=group_id,
         topics=topics_env.split(","),
-        concurrency=int(os.getenv("KAFKA_CONCURRENCY", "2")),
-        max_pending_futures=int(os.getenv("KAFKA_MAX_PENDING_FUTURES", "100")),
         healthcheck_file=os.getenv("KAFKA_HEALTHCHECK_FILE"),
         auto_offset_reset=os.getenv("KAFKA_AUTO_OFFSET_RESET", "latest"),  # latest = skip old messages
         arroyo_strict_offset_reset=arroyo_strict_offset_reset,

--- a/tests/integration/test_kafka_service.py
+++ b/tests/integration/test_kafka_service.py
@@ -24,7 +24,6 @@ def kafka_env_vars():
         "KAFKA_BOOTSTRAP_SERVERS": os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
         "KAFKA_GROUP_ID": f"launchpad-test-{int(time.time())}",
         "KAFKA_TOPICS": PREPROD_ARTIFACT_EVENTS_TOPIC,
-        "KAFKA_CONCURRENCY": "1",
         "KAFKA_AUTO_OFFSET_RESET": "earliest",
         "LAUNCHPAD_ENV": "development",
         "SENTRY_BASE_URL": "http://test.sentry.io",
@@ -53,7 +52,6 @@ class TestKafkaConfigIntegration:
         assert config.bootstrap_servers == kafka_env_vars["KAFKA_BOOTSTRAP_SERVERS"]
         assert config.group_id == kafka_env_vars["KAFKA_GROUP_ID"]
         assert config.topics == [PREPROD_ARTIFACT_EVENTS_TOPIC]
-        assert config.concurrency == 1
         assert config.auto_offset_reset == "earliest"
 
     def test_kafka_config_missing_required_vars(self):
@@ -110,7 +108,6 @@ class TestKafkaConsumerIntegration:
         assert isinstance(consumer, LaunchpadKafkaConsumer)
         assert consumer.processor is not None
         assert consumer.healthcheck_path is not None
-        assert consumer.strategy_factory is not None
 
 
 @pytest.mark.integration


### PR DESCRIPTION
merges https://github.com/getsentry/launchpad/pull/493 again

Test runtask + a rebalance storm in s4s

I will merge this, pause all non s4s pipelines and then manually trigger a rebalance in s4s now with the arroyo logs emitting. This should help us understand why our healthcheck is erroneously causing us to continually shut down our consumers in a loop when an initial rebalance happens