### PR TITLE
Check first if a Swift symbol

### DIFF
--- a/src/launchpad/size/symbols/partitioner.py
+++ b/src/launchpad/size/symbols/partitioner.py
@@ -96,14 +96,14 @@ class SymbolInfo:
             compiler_generated_symbols: List[SymbolSize] = []
 
             for symbol in symbol_sizes:
-                if cls._is_compiler_generated(symbol.mangled_name):
-                    compiler_generated_symbols.append(symbol)
-                elif SwiftSymbolTypeAggregator.is_swift_symbol(symbol.mangled_name):
+                if SwiftSymbolTypeAggregator.is_swift_symbol(symbol.mangled_name):
                     swift_symbols.append(symbol)
                 elif ObjCSymbolTypeAggregator.is_objc_symbol(symbol.mangled_name):
                     objc_symbols.append(symbol)
                 elif CppSymbolTypeAggregator.is_cpp_symbol(symbol.mangled_name):
                     cpp_symbols.append(symbol)
+                elif cls._is_compiler_generated(symbol.mangled_name):
+                    compiler_generated_symbols.append(symbol)
                 else:
                     other_symbols.append(symbol)
 


### PR DESCRIPTION
Looking at some recent apps, a really quick performance win is simply reordering our symbol partitioning checks:
```
[19:11:50] DEBUG    Partitioned 1837495 symbols: Swift=1421843, ObjC=72876, C++=100133, Other=218463, Compiler-generated=24180 |
```
There are significantly more Swift symbols so we should always check that first.