### PR TITLE
Kill analysis subprocess if join timeout is triggered implying task should be killed

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -111,21 +111,21 @@ def process_kafka_message_with_service(
             return None  # type: ignore[return-value]
 
         if process.exitcode != 0:
-            # Check if we killed it during rebalance (regardless of exit code)
-            pid = process.pid  # type: ignore[assignment]
-            with registry_lock:
-                was_killed_by_rebalance = pid in factory._killed_during_rebalance
-                if was_killed_by_rebalance:
+            # Check if we killed it during rebalance - if so, don't commit offset
+            pid = process.pid
+            if pid is not None:
+                with registry_lock:
+                    was_killed_by_rebalance = pid in factory._killed_during_rebalance
                     factory._killed_during_rebalance.discard(pid)
 
-            if was_killed_by_rebalance:
-                logger.warning(
-                    "Process killed during rebalance, message will be reprocessed",
-                    extra={"artifact_id": artifact_id},
-                )
-                raise TimeoutError("Subprocess killed during rebalance")
+                if was_killed_by_rebalance:
+                    logger.warning(
+                        "Process killed during rebalance, message will be reprocessed",
+                        extra={"artifact_id": artifact_id},
+                    )
+                    raise TimeoutError("Subprocess killed during rebalance")
 
-            # All other non-zero exit codes are failures - skip message
+            # All other failures - skip message
             logger.error(
                 "Process exited with non-zero code",
                 extra={"exit_code": process.exitcode, "artifact_id": artifact_id},


### PR DESCRIPTION
An unexpected side effect of moving the analysis to a subprocess was that when the kafka partition is signaled to be revoked, we would normally give the task 10s and then kill it... but in arroyo [we wait ](https://github.com/getsentry/arroyo/blob/517e4b4fb9bd59909c3bb7d4484947f0581ea87a/arroyo/processing/strategies/run_task_in_threads.py#L155) until all the threads are completed before moving on...

so it seems like this is what is happening in prod currently:
```
1. Rebalance triggered (t=0s)
2. Arroyo calls `RunTaskInThreads.close()` & `RunTaskInThreads.join(timeout=10)`
3. join() loops through futures with timeout (t=0-10s)
4. join() calls self.__executor.shutdown() (t=~10s)
   └─ ⚠️ BLOCKS waiting for ALL threads to complete
5. Threads are still blocked on process.join(timeout=720)
   └─ Subprocesses still running, up to 12 minutes remaining
6. Subprocess finally finishes after 6 minutes (t=~370s)
7. All threads finally exit
8. executor.shutdown() finally returns
9. join() completes and returns
```

and the JOIN taking super long causes kafka to think our consumer is dead and kills it.

Instead, if we can kill the subprocess, it should look like this:
```
1. Rebalance triggered (t=0s)
2. Arroyo calls ShutdownAwareStrategy.close()
3. wrapper.close() calls factory.kill_active_processes() (t=0s)
4. wrapper.close() calls inner.close() (RunTaskInThreads.close()) (t=~5s)
5. RunTaskInThreads.join() loops through pending futures (t=~5s)
   ├─ Tries future.result(remaining) for each message
   ├─ Threads see their subprocesses are dead
   └─ Threads exit their finally blocks quickly
6. RunTaskInThreads.join() calls executor.shutdown() (t=~6s)
   └─ Threads already exited, returns immediately
7. RunTaskInThreads.join() returns (t=~6s)
8. join() completes and returns (t=~6s)
```