### PR TITLE
Remove size analysis retries from launchpad

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -26,10 +26,7 @@ from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import AndroidArtifact, AppleArtifact, Artifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.constants import (
-    MAX_RETRY_ATTEMPTS,
-    OPERATION_ERRORS,
     ArtifactType,
-    OperationName,
     PreprodFeature,
     ProcessingErrorCode,
     ProcessingErrorMessage,
@@ -218,10 +215,7 @@ class ArtifactProcessor:
     ) -> AppleAppInfo | BaseAppInfo:
         logger.info(f"Preprocessing for {artifact_id} (project: {project_id}, org: {organization_id})")
         try:
-            info = self._retry_operation(
-                lambda: analyzer.preprocess(cast(Any, artifact)),
-                OperationName.PREPROCESSING,
-            )
+            info = analyzer.preprocess(cast(Any, artifact))
             update_data = self._prepare_update_data(info, artifact, dequeued_at)
             self._sentry_client.update_artifact(
                 org=organization_id,
@@ -292,10 +286,7 @@ class ArtifactProcessor:
     ):
         logger.info(f"SIZE_ANALYSIS for {artifact_id} (project: {project_id}, org: {organization_id}) started")
         try:
-            results = self._retry_operation(
-                lambda: analyzer.analyze(cast(Any, artifact)),
-                OperationName.SIZE_ANALYSIS,
-            )
+            results = analyzer.analyze(cast(Any, artifact))
             self._upload_results(organization_id, project_id, artifact_id, results)
         except Exception as e:
             logger.exception(
@@ -311,30 +302,6 @@ class ArtifactProcessor:
             )
         else:
             logger.info(f"SIZE_ANALYSIS for {artifact_id} (project: {project_id}, org: {organization_id}) succeeded")
-
-    def _retry_operation(self, operation, operation_name: OperationName):
-        """Retry an operation up to MAX_RETRY_ATTEMPTS times."""
-        error_message = OPERATION_ERRORS[operation_name]
-        last_exception = None
-
-        for attempt in range(1, MAX_RETRY_ATTEMPTS + 1):
-            try:
-                logger.debug(f"Attempting {operation_name.value} (attempt {attempt}/{MAX_RETRY_ATTEMPTS})")
-                return operation()
-            except Exception as e:
-                last_exception = e
-                logger.warning(f"{operation_name.value} failed on attempt {attempt}/{MAX_RETRY_ATTEMPTS}: {e}")
-
-                if isinstance(e, (ValueError, NotImplementedError, FileNotFoundError)):
-                    logger.info(f"Non-retryable error for {operation_name.value}, not retrying")
-                    break
-
-                if attempt < MAX_RETRY_ATTEMPTS:
-                    logger.info(f"Retrying {operation_name.value} in a moment...")
-                    time.sleep(1)
-
-        logger.error(f"All {MAX_RETRY_ATTEMPTS} attempts failed for {operation_name.value}")
-        raise RuntimeError(f"{error_message.value}: {str(last_exception)}") from last_exception
 
     def _update_artifact_error_from_exception(
         self,

--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -32,18 +32,8 @@ class PreprodFeature(Enum):
     BUILD_DISTRIBUTION = "build_distribution"
 
 
-# Retry configuration
-MAX_RETRY_ATTEMPTS = 3
-
 # Health check threshold - consider unhealthy if file not touched in 60 seconds
 HEALTHCHECK_MAX_AGE_SECONDS = 60.0
-
-
-class OperationName(Enum):
-    """Enum for operation names used in retry logic."""
-
-    PREPROCESSING = "preprocessing"
-    SIZE_ANALYSIS = "size analysis"
 
 
 class ProcessingErrorMessage(Enum):
@@ -69,10 +59,3 @@ class ProcessingErrorMessage(Enum):
 
     # Unknown errors
     UNKNOWN_ERROR = "An unknown error occurred"
-
-
-# Operation to error message mapping
-OPERATION_ERRORS = {
-    OperationName.PREPROCESSING: ProcessingErrorMessage.PREPROCESSING_FAILED,
-    OperationName.SIZE_ANALYSIS: ProcessingErrorMessage.SIZE_ANALYSIS_FAILED,
-}

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -2,14 +2,10 @@
 
 from unittest.mock import Mock, patch
 
-import pytest
-
 from sentry_kafka_schemas.schema_types.preprod_artifact_events_v1 import PreprodArtifactEvents
 
 from launchpad.artifact_processor import ArtifactProcessor
 from launchpad.constants import (
-    MAX_RETRY_ATTEMPTS,
-    OperationName,
     PreprodFeature,
     ProcessingErrorCode,
     ProcessingErrorMessage,
@@ -27,70 +23,6 @@ class TestArtifactProcessorErrorHandling:
         mock_sentry_client = Mock(spec=SentryClient)
         mock_statsd = Mock()
         self.processor = ArtifactProcessor(mock_sentry_client, mock_statsd)
-
-    def test_retry_operation_success_on_first_attempt(self):
-        """Test that _retry_operation succeeds on first attempt."""
-        operation = Mock(return_value="success")
-
-        result = self.processor._retry_operation(
-            operation,
-            OperationName.PREPROCESSING,
-        )
-
-        assert result == "success"
-        assert operation.call_count == 1
-
-    def test_retry_operation_success_on_second_attempt(self):
-        """Test that _retry_operation succeeds on second attempt after one failure."""
-        operation = Mock()
-        operation.side_effect = [RuntimeError("Temporary failure"), "success"]
-
-        result = self.processor._retry_operation(
-            operation,
-            OperationName.PREPROCESSING,
-        )
-
-        assert result == "success"
-        assert operation.call_count == 2
-
-    def test_retry_operation_fails_after_max_attempts(self):
-        """Test that _retry_operation fails after MAX_RETRY_ATTEMPTS."""
-        operation = Mock()
-        operation.side_effect = RuntimeError("Persistent failure")
-
-        with pytest.raises(RuntimeError, match="Failed to extract basic app information"):
-            self.processor._retry_operation(
-                operation,
-                OperationName.PREPROCESSING,
-            )
-
-        assert operation.call_count == MAX_RETRY_ATTEMPTS
-
-    def test_retry_operation_non_retryable_error(self):
-        """Test that _retry_operation doesn't retry non-retryable errors."""
-        operation = Mock()
-        operation.side_effect = ValueError("Invalid input")
-
-        with pytest.raises(RuntimeError, match="Failed to perform size analysis"):
-            self.processor._retry_operation(
-                operation,
-                OperationName.SIZE_ANALYSIS,
-            )
-
-        assert operation.call_count == 1  # Should not retry
-
-    def test_retry_operation_maps_operation_to_correct_error_message(self):
-        """Test that _retry_operation correctly maps operation names to error messages."""
-        operation = Mock()
-        operation.side_effect = RuntimeError("Persistent failure")
-
-        # Test PREPROCESSING maps to PREPROCESSING_FAILED
-        with pytest.raises(RuntimeError, match="Failed to extract basic app information"):
-            self.processor._retry_operation(operation, OperationName.PREPROCESSING)
-
-        # Test SIZE_ANALYSIS maps to SIZE_ANALYSIS_FAILED
-        with pytest.raises(RuntimeError, match="Failed to perform size analysis"):
-            self.processor._retry_operation(operation, OperationName.SIZE_ANALYSIS)
 
     def test_update_artifact_error_success(self):
         """Test that _update_artifact_error successfully updates artifact with error."""


### PR DESCRIPTION
As we have discovered the consumer code is quite fragile.
This is partly due to the high complexity of the code (having to deal with
arroyo, threads, await, subprocesses, exception reporting, retries, etc).

While retries ought to help with fragility these retries (the global analysis ones) have not been helpful:
- The code they cover it either deterministic (e.g. size analysis, preprocessing)
- ...or has it's own embedded retries (e.g. Sentry client and the upload/download)
Over the past 30 days logs don't show any case where the retries here helped and in fact in the 10
occasions they occurred it was actually a deterministic failure that no amount of retrying would help:
- `preprocessing failed on attempt 2/3: 'str' object has no attribute 'isoformat'` x8
-  `size analysis failed on attempt 2/3: 'NoneType' object has no attribute 'symbol_info'` x2

Removing them will simplify the code base.
 