### PR TITLE
Speed up dex mapping lookups

### DIFF
--- a/src/launchpad/cli.py
+++ b/src/launchpad/cli.py
@@ -8,7 +8,7 @@ import click
 from . import __version__
 from .distribution.cli import distribution_command
 from .service import run_service
-from .size.cli import app_icon_command, size_command
+from .size.cli import app_icon_command, profile_dex_parsing_command, size_command
 from .utils.console import console
 from .utils.logging import setup_logging
 
@@ -85,6 +85,7 @@ def serve(host: str, port: int, mode: str | None, verbose: bool) -> None:
 cli.add_command(size_command)
 cli.add_command(app_icon_command)
 cli.add_command(distribution_command)
+cli.add_command(profile_dex_parsing_command)
 
 
 def main() -> None:

--- a/src/launchpad/parsers/android/dex/dex_mapping.py
+++ b/src/launchpad/parsers/android/dex/dex_mapping.py
@@ -21,6 +21,8 @@ class DexMappingClass:
 class DexMapping:
     def __init__(self, bytes: bytes) -> None:
         self._classes: dict[str, DexMappingClass] = {}
+        self._classes_by_deobfuscated: dict[str, DexMappingClass] = {}
+        self._classes_by_deobfuscated_fqn: dict[str, DexMappingClass] = {}
 
         classes: list[DexMappingClass] = []
         current_class: DexMappingClass | None = None
@@ -42,6 +44,9 @@ class DexMapping:
 
         for clazz in classes:
             self._classes[clazz.obfuscated_fqn] = clazz
+            self._classes_by_deobfuscated[clazz.deobfuscated_signature] = clazz
+            self._classes_by_deobfuscated_fqn[clazz.deobfuscated_fqn] = clazz
+        return None
 
     @staticmethod
     def _parse_comment(line: str, pending_file_name: str | None) -> str | None:
@@ -178,10 +183,7 @@ class DexMapping:
         return self._classes.get(obfuscated_class_name)
 
     def lookup_deobfuscated_signature(self, deobfuscated_class_signature: str) -> DexMappingClass | None:
-        for clazz in self._classes.values():
-            if clazz.deobfuscated_signature == deobfuscated_class_signature:
-                return clazz
-        return None
+        return self._classes_by_deobfuscated.get(deobfuscated_class_signature)
 
     def deobfuscate_method(self, class_name: str, obfuscated_method_name: str) -> str | None:
         """Deobfuscate a method name for a given class.
@@ -195,19 +197,16 @@ class DexMapping:
         """
         # First try to find the class by obfuscated name
         clazz = self.lookup_obfuscated_class(class_name)
-        if clazz is None:
-            # Try to find by deobfuscated signature
-            clazz = self.lookup_deobfuscated_signature(class_name)
-            if clazz is None:
-                # Try to match by deobfuscated FQN
-                for c in self._classes.values():
-                    if c.deobfuscated_fqn == class_name:
-                        clazz = c
-                        break
-                if clazz is None:
-                    return None
 
-        if clazz.methods is None:
+        # Try to find by deobfuscated signature
+        if clazz is None:
+            clazz = self.lookup_deobfuscated_signature(class_name)
+
+        # Try to match by deobfuscated FQN
+        if clazz is None:
+            clazz = self._classes_by_deobfuscated_fqn.get(class_name)
+
+        if clazz is None or clazz.methods is None:
             return None
 
         return clazz.methods.get(obfuscated_method_name)
@@ -224,19 +223,16 @@ class DexMapping:
         """
         # First try to find the class by obfuscated name
         clazz = self.lookup_obfuscated_class(class_name)
-        if clazz is None:
-            # Try to find by deobfuscated signature
-            clazz = self.lookup_deobfuscated_signature(class_name)
-            if clazz is None:
-                # Try to match by deobfuscated FQN
-                for c in self._classes.values():
-                    if c.deobfuscated_fqn == class_name:
-                        clazz = c
-                        break
-                if clazz is None:
-                    return None
 
-        if clazz.fields is None:
+        # Try to find by deobfuscated signature
+        if clazz is None:
+            clazz = self.lookup_deobfuscated_signature(class_name)
+
+        # Try to match by deobfuscated FQN
+        if clazz is None:
+            clazz = self._classes_by_deobfuscated_fqn.get(class_name)
+
+        if clazz is None or clazz.fields is None:
             return None
 
         return clazz.fields.get(obfuscated_field_name)

--- a/src/launchpad/size/cli.py
+++ b/src/launchpad/size/cli.py
@@ -6,6 +6,8 @@ import click
 from rich.table import Table
 
 from launchpad.artifacts.artifact_factory import ArtifactFactory
+from launchpad.parsers.android.dex.dex_file_parser import DexFileParser
+from launchpad.parsers.android.dex.dex_mapping import DexMapping
 from launchpad.size.models.android import AndroidAnalysisResults
 from launchpad.size.models.apple import AppleAnalysisResults
 from launchpad.size.models.common import BaseAnalysisResults, FileAnalysis
@@ -139,6 +141,20 @@ def app_icon_command(
     else:
         console.print("No app icon found")
         raise click.Abort()
+
+
+@click.command(name="profile-dex-parsing")
+@click.argument("input_path", type=click.Path(exists=True, path_type=Path), metavar="DEX_PATH")
+@click.argument("mapping_path", required=False, type=click.Path(exists=True, path_type=Path), metavar="MAPPING_PATH")
+def profile_dex_parsing_command(input_path: Path, mapping_path: Path | None = None):
+    mapping = None
+    if mapping_path:
+        with open(mapping_path, "rb") as f:
+            mapping = DexMapping(f.read())
+    with open(input_path, "rb") as f:
+        parser = DexFileParser(f.read(), mapping)
+
+    parser.get_class_definitions()
 
 
 def _print_results_as_table(results: BaseAnalysisResults) -> None:


### PR DESCRIPTION
Before, no mapping:
```
$ time python -m launchpad profile-dex-parsing ~/Desktop/from_aab_classes.dex

________________________________________________________
Executed in    2.36 secs    fish           external
   usr time    2.16 secs    0.09 millis    2.16 secs
   sys time    0.11 secs    4.22 millis    0.11 secs
```

Before, with mapping:
```
$ time python -m launchpad profile-dex-parsing ~/Desktop/from_aab_classes.dex ~/Desktop/from_aab_proguard.map

________________________________________________________
Executed in   91.80 secs    fish           external
   usr time   91.20 secs    0.07 millis   91.20 secs
   sys time    0.44 secs    1.48 millis    0.44 secs
```

After, with mapping:
```
$ time python -m launchpad profile-dex-parsing ~/Desktop/from_aab_classes.dex ~/Desktop/from_aab_proguard.map

________________________________________________________
Executed in    5.03 secs    fish           external
   usr time    4.73 secs    0.11 millis    4.73 secs
   sys time    0.20 secs    4.30 millis    0.19 secs
```

Also add `launchpad profile-dex-parsing classes.dex proguard.map`
subcommand for testing just Dex parsing:
```
python -m cProfile -o my_profile -m launchpad profile-dex-parsing classes.dex proguard.map
```
