### PR TITLE
Set arroyo's max_pending_futures to 0

### DIFF
--- a/src/launchpad/kafka.py
+++ b/src/launchpad/kafka.py
@@ -366,7 +366,7 @@ def get_kafka_config() -> KafkaConfig:
         group_id=group_id,
         topics=topics_env.split(","),
         concurrency=int(os.getenv("KAFKA_CONCURRENCY", "1")),
-        max_pending_futures=int(os.getenv("KAFKA_MAX_PENDING_FUTURES", "100")),
+        max_pending_futures=int(os.getenv("KAFKA_MAX_PENDING_FUTURES", "0")),
         auto_offset_reset=os.getenv("KAFKA_AUTO_OFFSET_RESET", "latest"),  # latest = skip old messages
         arroyo_strict_offset_reset=arroyo_strict_offset_reset,
         security_protocol=os.environ.get("KAFKA_SECURITY_PROTOCOL", "plaintext"),


### PR DESCRIPTION
A simpler alternative to https://github.com/getsentry/launchpad/pull/512. Given how slow our average processing time is, we don't gain much performance benefit from the prefetching and this also solves the problem described in that PR.

The only downside of this approach is that if we set our consumer's concurrency > 1, arroyo may not use that extra concurrency because it wouldn't accept another pending future... so if we ever want to have concurrency > 1, we'll want to do the https://github.com/getsentry/launchpad/pull/512 approach, but we should be far away from needing to do that (and can just scale up the number of pods instead)