### PR TITLE
Check all items for category breakdown calculation

### DIFF
--- a/src/launchpad/size/treemap/treemap_builder.py
+++ b/src/launchpad/size/treemap/treemap_builder.py
@@ -286,7 +286,7 @@ class TreemapBuilder:
     def _calculate_category_breakdown(self, file_analysis: FileAnalysis) -> Dict[str, Dict[str, int]]:
         """Calculate size breakdown by category."""
         breakdown: Dict[str, Dict[str, int]] = defaultdict(lambda: {"size": 0})
-        for file_info in file_analysis.files:
+        for file_info in file_analysis.items:
             treemap_type = file_info.treemap_type.value
             size = to_nearest_block_size(file_info.size, self.filesystem_block_size)
             breakdown[treemap_type]["size"] += size


### PR DESCRIPTION
Close https://linear.app/getsentry/issue/EME-646/component-breakdown-percentages-dont-match

The category breakdown logic needs to include all items, not just files. Directories have their own size (metadata) and get treemap_type=TreemapType.FILES, but they're excluded from category_breakdown because the function only iterates files, not directories.

After making this change, I re-ran analysis on 3 different builds and the category values all match up precisely now
