### PR TITLE
Add extra check for cms signature before parsing

### DIFF
--- a/src/launchpad/parsers/apple/code_signature_parser.py
+++ b/src/launchpad/parsers/apple/code_signature_parser.py
@@ -581,10 +581,19 @@ class CodeSignatureParser:
 
             logger.debug(f"Signature magic: 0x{magic:08x}, length: {signature_length}")
 
+            # Check if there's actual signature data (not just the header)
+            if signature_length <= 8:
+                logger.debug("Signature slot present but empty (length <= 8)")
+                return None
+
             # Extract the signature content (skip the 8-byte header)
             sig_start = sig_offset + 8
             sig_end = sig_offset + signature_length
             signature_content = bytes(content[sig_start:sig_end])
+
+            if len(signature_content) == 0:
+                logger.debug("No signature content to parse")
+                return None
 
             # Parse the CMS signature
             try:


### PR DESCRIPTION
Should address this error we were seeing

```
Failed to parse CMS signature
Traceback (most recent call last):
  File "/app/src/launchpad/parsers/apple/code_signature_parser.py", line 591, in _parse_signature
    signature = cms.ContentInfo.load(signature_content)  # type: ignore[attr-defined]
  File "/usr/local/lib/python3.13/site-packages/asn1crypto/core.py", line 230, in load
    value, _ = _parse_build(encoded_data, spec=spec, spec_params=kwargs, strict=strict)
               ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/asn1crypto/core.py", line 5672, in _parse_build
    info, new_pointer = _parse(encoded_data, encoded_len, pointer)
                        ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/asn1crypto/parser.py", line 173, in _parse
    raise ValueError(_INSUFFICIENT_DATA_MESSAGE % (1, data_len - pointer))
ValueError: Insufficient data - 1 bytes requested but only 0 available
```