### PR TITLE
Fix handled error when icon couldn't be parsed

### DIFF
--- a/src/launchpad/artifacts/android/manifest/proto_xml.py
+++ b/src/launchpad/artifacts/android/manifest/proto_xml.py
@@ -356,11 +356,11 @@ class ProtoXmlUtils:
         if not value:
             logger.debug("could not find string value for attribute matching filter, trying to parse compiled value")
 
-            if not attribute.compiled_item:
+            compiled_item = getattr(attribute, "compiled_item", None)
+            if not compiled_item:
                 logger.debug("could not find compiledItem for attribute matching filter")
                 return None
 
-            compiled_item = attribute.compiled_item
             if compiled_item.HasField("str"):
                 return str(compiled_item.str.value)
             elif compiled_item.HasField("ref"):

--- a/src/launchpad/parsers/android/icon/icon_parser.py
+++ b/src/launchpad/parsers/android/icon/icon_parser.py
@@ -141,8 +141,8 @@ class IconParser:
 
     def _render_vector_drawable(self, root_element: XmlNode) -> bytes | None:
         # Extract vector attributes
-        width = self._get_attr_value(root_element.attributes, "width", required=True)
-        height = self._get_attr_value(root_element.attributes, "height", required=True)
+        width = self._get_attr_value(root_element.attributes, "width")
+        height = self._get_attr_value(root_element.attributes, "height")
         viewport_width = self._get_attr_value(root_element.attributes, "viewportWidth")
         viewport_height = self._get_attr_value(root_element.attributes, "viewportHeight")
         tint = self._get_attr_value(root_element.attributes, "tint")


### PR DESCRIPTION
Should remove some logspam from Gcloud with an uncaught error: https://sentry.sentry.io/issues/7184227780/?alert_rule_id=16138328&alert_type=issue&notification_uuid=e1be3162-5997-44f0-83dc-0e09ee49ee40&project=4509667577233409

Repro'd with an AAB that was failing loudly (this exception was still caught, just error logged) and now it runs as expected and safely handles the case that previously threw the exception without logging an error.