### PR TITLE
feat(size): Add platform discriminator field to insight models

### DIFF
--- a/src/launchpad/size/models/android.py
+++ b/src/launchpad/size/models/android.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from .common import BaseAnalysisResults, BaseAppInfo
@@ -14,6 +16,8 @@ from .insights import (
 
 class AndroidInsightResults(BaseModel):
     model_config = ConfigDict(frozen=True)
+
+    platform: Literal["android"] = "android"
 
     duplicate_files: DuplicateFilesInsightResult | None = Field(None, description="Duplicate files analysis")
     webp_optimization: WebPOptimizationInsightResult | None = Field(None, description="WebP optimization analysis")

--- a/src/launchpad/size/models/apple.py
+++ b/src/launchpad/size/models/apple.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import List, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -77,6 +77,8 @@ class AppleInsightResults(BaseModel):
     """Collection of all insight results."""
 
     model_config = ConfigDict(frozen=True)
+
+    platform: Literal["apple"] = "apple"
 
     duplicate_files: DuplicateFilesInsightResult | None = Field(None, description="Duplicate files analysis")
     large_images: LargeImageFileInsightResult | None = Field(None, description="Large image files analysis")


### PR DESCRIPTION
## Summary

- Add a `platform` field with `Literal` type to `AndroidInsightResults` and `AppleInsightResults` models
- This enables Pydantic discriminated union resolution in Sentry when parsing size analysis results

## Background

Sentry's size analysis comparison code parses insight results using a union type `AndroidInsightResults | AppleInsightResults`. Without a discriminator field, Pydantic uses left-to-right validation order, which causes iOS insights to be incorrectly parsed as `AndroidInsightResults`, silently dropping iOS-specific fields like `strip_binary` and `image_optimization`.

By adding an explicit `platform` field, Sentry can use `Field(discriminator="platform")` to correctly resolve the union type based on the platform value in the JSON.

## Changes

- `android.py`: Add `platform: Literal["android"] = "android"` to `AndroidInsightResults`
- `apple.py`: Add `platform: Literal["apple"] = "apple"` to `AppleInsightResults`

## Deployment Notes

This change is backwards compatible. The new field will be included in size analysis JSON output. Sentry will be updated to use this field as a discriminator, with a fallback for old data that doesn't include it.

Co-Authored-By: Claude <noreply@anthropic.com>