### PR TITLE
fix(parser): Handle cpu_type as int when LIEF returns unknown CPU types

### DIFF
--- a/src/launchpad/parsers/apple/macho_parser.py
+++ b/src/launchpad/parsers/apple/macho_parser.py
@@ -21,6 +21,26 @@ from .swift_protocol_parser import SwiftProtocolParser
 
 logger = get_logger(__name__)
 
+# Mach-O CPU type constants
+CPU_TYPE_NAMES: Dict[int, str] = {
+    0x0000000C: "ARM",
+    0x0100000C: "ARM64",
+    0x0200000C: "ARM64_32",  # watchOS
+    0x00000007: "X86",
+    0x01000007: "X86_64",
+}
+
+
+def get_cpu_type_name(cpu_type: lief.MachO.Header.CPU_TYPE | int) -> str:
+    """Get architecture name from cpu_type, handling both enum and int cases.
+
+    LIEF sometimes returns cpu_type as an int instead of an enum when it doesn't
+    recognize the CPU type (e.g., ARM64_32 for watchOS).
+    """
+    if isinstance(cpu_type, lief.MachO.Header.CPU_TYPE):
+        return cpu_type.name
+    return CPU_TYPE_NAMES.get(cpu_type, f"UNKNOWN_{cpu_type}")
+
 
 class MachOParser:
     """Parser for Mach-O binaries using LIEF."""
@@ -78,14 +98,8 @@ class MachOParser:
     @sentry_sdk.trace
     def _cpu_type_to_string(self, cpu_type: int) -> str | None:
         """Convert LIEF CPU type to string representation."""
-        # Common CPU types from Mach-O
-        cpu_types = {
-            0x0000000C: "arm",  # ARM
-            0x0100000C: "arm64",  # ARM64
-            0x00000007: "x86",  # i386
-            0x01000007: "x86_64",  # x86_64
-        }
-        return cpu_types.get(cpu_type)
+        result = CPU_TYPE_NAMES.get(cpu_type)
+        return result.lower() if result else None
 
     @sentry_sdk.trace
     def get_section_bytes_at_offset(self, section_name: str, offset: int, size: int) -> bytes | None:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -19,7 +19,7 @@ from cryptography import x509
 from launchpad.artifacts.apple.zipped_xcarchive import BinaryInfo, ZippedXCArchive
 from launchpad.artifacts.artifact import AppleArtifact
 from launchpad.parsers.apple.dwarf_relocations_parser import DwarfRelocationsParser
-from launchpad.parsers.apple.macho_parser import MachOParser
+from launchpad.parsers.apple.macho_parser import MachOParser, get_cpu_type_name
 from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.hermes.reporter import HermesReport
 from launchpad.size.hermes.utils import make_hermes_reports
@@ -486,7 +486,7 @@ class AppleAppAnalyzer:
         architecture_slices: List[ArchitectureSlice] = []
 
         for slice_binary in fat_binary:
-            arch_name = slice_binary.header.cpu_type.name
+            arch_name = get_cpu_type_name(slice_binary.header.cpu_type)
             slice_parser = MachOParser(slice_binary)
             architecture_slices.append(
                 ArchitectureSlice(
@@ -517,7 +517,7 @@ class AppleAppAnalyzer:
                 # Build a map of architecture name -> dSYM slice index
                 dsym_arch_map: Dict[str, int] = {}
                 for i, dsym_slice in enumerate(dwarf_fat_binary):
-                    dsym_arch_name = dsym_slice.header.cpu_type.name
+                    dsym_arch_name = get_cpu_type_name(dsym_slice.header.cpu_type)
                     dsym_arch_map[dsym_arch_name] = i
 
                 # Symbolicate each architecture slice


### PR DESCRIPTION
When parsing fat Mach-O binaries, LIEF returns `cpu_type` as an int instead of
its `CPU_TYPE` enum when it doesn't recognize the CPU type. This happens with
ARM64_32 architecture used in watchOS apps, causing an `AttributeError` when
accessing `.name` on the int value.

This adds a `get_cpu_type_name()` helper function that handles both cases:
- When LIEF returns an enum, it extracts the `.name` attribute
- When LIEF returns an int, it looks up the architecture name from a constants map
- Falls back to `UNKNOWN_{value}` for truly unknown CPU types

Also consolidates the duplicate CPU type mapping that existed in `_cpu_type_to_string()`.