### PR TITLE
fix(artifacts): Report distribution errors for unsupported and skipped builds (EME-422)

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -370,7 +370,7 @@ class ArtifactProcessor:
                     error_code=InstallableAppErrorCode.PROCESSING_ERROR.value,
                     error_message="unsupported artifact type",
                 )
-            except SentryClientError:
+            except Exception:
                 logger.exception(f"Failed to update distribution error for artifact {artifact_id}")
 
     def _do_size(
@@ -468,7 +468,7 @@ class ArtifactProcessor:
                 error_code=InstallableAppErrorCode.SKIPPED.value,
                 error_message=skip_reason,
             )
-        except SentryClientError:
+        except Exception:
             logger.exception(f"Failed to update distribution skip for artifact {artifact_id}")
 
     def _update_size_error_from_exception(

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -330,13 +330,32 @@ class ArtifactProcessor:
         logger.info(f"BUILD_DISTRIBUTION for {artifact_id} (project: {project_id}, org: {organization_id})")
         if isinstance(artifact, ZippedXCArchive):
             apple_info = cast(AppleAppInfo, info)
-            if apple_info.is_code_signature_valid and not apple_info.is_simulator:
-                with tempfile.TemporaryDirectory() as temp_dir_str:
-                    temp_dir = Path(temp_dir_str)
-                    ipa_path = temp_dir / "App.ipa"
-                    artifact.generate_ipa(ipa_path)
-                    with open(ipa_path, "rb") as f:
-                        self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
+            if not apple_info.is_code_signature_valid:
+                logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: invalid code signature")
+                self._update_artifact_error(
+                    organization_id,
+                    project_id,
+                    artifact_id,
+                    ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                    ProcessingErrorMessage.INVALID_CODE_SIGNATURE,
+                )
+                return
+            if apple_info.is_simulator:
+                logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: simulator build")
+                self._update_artifact_error(
+                    organization_id,
+                    project_id,
+                    artifact_id,
+                    ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                    ProcessingErrorMessage.SIMULATOR_BUILD,
+                )
+                return
+            with tempfile.TemporaryDirectory() as temp_dir_str:
+                temp_dir = Path(temp_dir_str)
+                ipa_path = temp_dir / "App.ipa"
+                artifact.generate_ipa(ipa_path)
+                with open(ipa_path, "rb") as f:
+                    self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
         elif isinstance(artifact, (AAB, ZippedAAB)):
             with tempfile.TemporaryDirectory() as temp_dir_str:
                 temp_dir = Path(temp_dir_str)

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -354,9 +354,14 @@ class ArtifactProcessor:
             with apk.raw_file() as f:
                 self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
         else:
-            # TODO(EME-422): Should call _update_artifact_error here once we
-            # support setting errors just for build.
             logger.error(f"BUILD_DISTRIBUTION failed for {artifact_id} (project: {project_id}, org: {organization_id})")
+            self._update_artifact_error(
+                organization_id,
+                project_id,
+                artifact_id,
+                ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
+                ProcessingErrorMessage.UNSUPPORTED_ARTIFACT_TYPE,
+            )
 
     def _do_size(
         self,

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -331,20 +331,13 @@ class ArtifactProcessor:
         logger.info(f"BUILD_DISTRIBUTION for {artifact_id} (project: {project_id}, org: {organization_id})")
         if isinstance(artifact, ZippedXCArchive):
             apple_info = cast(AppleAppInfo, info)
-            if not apple_info.is_code_signature_valid:
-                logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: invalid code signature")
-                self._update_distribution_skip(organization_id, project_id, artifact_id, "invalid_signature")
-                return
-            if apple_info.is_simulator:
-                logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: simulator build")
-                self._update_distribution_skip(organization_id, project_id, artifact_id, "simulator")
-                return
-            with tempfile.TemporaryDirectory() as temp_dir_str:
-                temp_dir = Path(temp_dir_str)
-                ipa_path = temp_dir / "App.ipa"
-                artifact.generate_ipa(ipa_path)
-                with open(ipa_path, "rb") as f:
-                    self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
+            if apple_info.is_code_signature_valid and not apple_info.is_simulator:
+                with tempfile.TemporaryDirectory() as temp_dir_str:
+                    temp_dir = Path(temp_dir_str)
+                    ipa_path = temp_dir / "App.ipa"
+                    artifact.generate_ipa(ipa_path)
+                    with open(ipa_path, "rb") as f:
+                        self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
         elif isinstance(artifact, (AAB, ZippedAAB)):
             with tempfile.TemporaryDirectory() as temp_dir_str:
                 temp_dir = Path(temp_dir_str)
@@ -452,24 +445,6 @@ class ArtifactProcessor:
             logger.exception(f"Failed to update artifact with error {message}")
         else:
             logger.info(f"Successfully updated artifact {artifact_id} with error information")
-
-    def _update_distribution_skip(
-        self,
-        organization_id: str,
-        project_id: str,
-        artifact_id: str,
-        skip_reason: str,
-    ) -> None:
-        """Report distribution skip via the dedicated distribution endpoint."""
-        try:
-            self._sentry_client.update_distribution_error(
-                org=organization_id,
-                artifact_id=artifact_id,
-                error_code=InstallableAppErrorCode.SKIPPED.value,
-                error_message=skip_reason,
-            )
-        except Exception:
-            logger.exception(f"Failed to update distribution skip for artifact {artifact_id}")
 
     def _update_size_error_from_exception(
         self,

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -333,11 +333,15 @@ class ArtifactProcessor:
             apple_info = cast(AppleAppInfo, info)
             if not apple_info.is_code_signature_valid:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: invalid code signature")
-                self._report_distribution_skip(organization_id, artifact_id, "invalid_signature")
+                self._update_distribution_error(
+                    organization_id, artifact_id, InstallableAppErrorCode.SKIPPED, "invalid_signature"
+                )
                 return
             if apple_info.is_simulator:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: simulator build")
-                self._report_distribution_skip(organization_id, artifact_id, "simulator")
+                self._update_distribution_error(
+                    organization_id, artifact_id, InstallableAppErrorCode.SKIPPED, "simulator"
+                )
                 return
             with tempfile.TemporaryDirectory() as temp_dir_str:
                 temp_dir = Path(temp_dir_str)
@@ -363,15 +367,9 @@ class ArtifactProcessor:
                 self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
         else:
             logger.error(f"BUILD_DISTRIBUTION failed for {artifact_id}: unsupported artifact type")
-            try:
-                self._sentry_client.update_distribution_error(
-                    org=organization_id,
-                    artifact_id=artifact_id,
-                    error_code=InstallableAppErrorCode.PROCESSING_ERROR.value,
-                    error_message="unsupported artifact type",
-                )
-            except Exception:
-                logger.exception(f"Failed to update distribution error for artifact {artifact_id}")
+            self._update_distribution_error(
+                organization_id, artifact_id, InstallableAppErrorCode.PROCESSING_ERROR, "unsupported artifact type"
+            )
 
     def _do_size(
         self,
@@ -453,22 +451,38 @@ class ArtifactProcessor:
         else:
             logger.info(f"Successfully updated artifact {artifact_id} with error information")
 
-    def _report_distribution_skip(
+    def _update_distribution_error(
         self,
         organization_id: str,
         artifact_id: str,
-        skip_reason: str,
+        error_code: InstallableAppErrorCode,
+        error_message: str,
     ) -> None:
-        """Report distribution skip via the dedicated distribution endpoint."""
+        """Update distribution with error/skip information."""
+        logger.info(f"Updating distribution for {artifact_id} with error code {error_code.value}")
+
+        self._statsd.increment(
+            "distribution.processing.error",
+            tags=[
+                f"error_code:{error_code.value}",
+                f"error_message:{error_message}",
+                f"organization_id:{organization_id}",
+            ],
+        )
+
         try:
-            self._sentry_client.update_distribution_error(
+            self._sentry_client.update_distribution(
                 org=organization_id,
                 artifact_id=artifact_id,
-                error_code=InstallableAppErrorCode.SKIPPED.value,
-                error_message=skip_reason,
+                data={
+                    "error_code": error_code.value,
+                    "error_message": error_message,
+                },
             )
-        except Exception:
-            logger.exception(f"Failed to report distribution skip for artifact {artifact_id}")
+        except SentryClientError:
+            logger.exception(f"Failed to update distribution error for artifact {artifact_id}")
+        else:
+            logger.info(f"Successfully updated distribution for {artifact_id} with error information")
 
     def _update_size_error_from_exception(
         self,

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -363,7 +363,15 @@ class ArtifactProcessor:
                 self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
         else:
             logger.error(f"BUILD_DISTRIBUTION failed for {artifact_id}: unsupported artifact type")
-            self._update_distribution_skip(organization_id, project_id, artifact_id, "unsupported")
+            try:
+                self._sentry_client.update_distribution_error(
+                    org=organization_id,
+                    artifact_id=artifact_id,
+                    error_code=InstallableAppErrorCode.PROCESSING_ERROR.value,
+                    error_message="unsupported artifact type",
+                )
+            except SentryClientError:
+                logger.exception(f"Failed to update distribution error for artifact {artifact_id}")
 
     def _do_size(
         self,

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -331,13 +331,20 @@ class ArtifactProcessor:
         logger.info(f"BUILD_DISTRIBUTION for {artifact_id} (project: {project_id}, org: {organization_id})")
         if isinstance(artifact, ZippedXCArchive):
             apple_info = cast(AppleAppInfo, info)
-            if apple_info.is_code_signature_valid and not apple_info.is_simulator:
-                with tempfile.TemporaryDirectory() as temp_dir_str:
-                    temp_dir = Path(temp_dir_str)
-                    ipa_path = temp_dir / "App.ipa"
-                    artifact.generate_ipa(ipa_path)
-                    with open(ipa_path, "rb") as f:
-                        self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
+            if not apple_info.is_code_signature_valid:
+                logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: invalid code signature")
+                self._report_distribution_skip(organization_id, artifact_id, "invalid_signature")
+                return
+            if apple_info.is_simulator:
+                logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: simulator build")
+                self._report_distribution_skip(organization_id, artifact_id, "simulator")
+                return
+            with tempfile.TemporaryDirectory() as temp_dir_str:
+                temp_dir = Path(temp_dir_str)
+                ipa_path = temp_dir / "App.ipa"
+                artifact.generate_ipa(ipa_path)
+                with open(ipa_path, "rb") as f:
+                    self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
         elif isinstance(artifact, (AAB, ZippedAAB)):
             with tempfile.TemporaryDirectory() as temp_dir_str:
                 temp_dir = Path(temp_dir_str)
@@ -445,6 +452,23 @@ class ArtifactProcessor:
             logger.exception(f"Failed to update artifact with error {message}")
         else:
             logger.info(f"Successfully updated artifact {artifact_id} with error information")
+
+    def _report_distribution_skip(
+        self,
+        organization_id: str,
+        artifact_id: str,
+        skip_reason: str,
+    ) -> None:
+        """Report distribution skip via the dedicated distribution endpoint."""
+        try:
+            self._sentry_client.update_distribution_error(
+                org=organization_id,
+                artifact_id=artifact_id,
+                error_code=InstallableAppErrorCode.SKIPPED.value,
+                error_message=skip_reason,
+            )
+        except Exception:
+            logger.exception(f"Failed to report distribution skip for artifact {artifact_id}")
 
     def _update_size_error_from_exception(
         self,

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -33,6 +33,7 @@ from launchpad.artifacts.artifact import AndroidArtifact, AppleArtifact, Artifac
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.constants import (
     ArtifactType,
+    DistributionState,
     PreprodFeature,
     ProcessingErrorCode,
     ProcessingErrorMessage,
@@ -332,23 +333,11 @@ class ArtifactProcessor:
             apple_info = cast(AppleAppInfo, info)
             if not apple_info.is_code_signature_valid:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: invalid code signature")
-                self._update_artifact_error(
-                    organization_id,
-                    project_id,
-                    artifact_id,
-                    ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
-                    ProcessingErrorMessage.INVALID_CODE_SIGNATURE,
-                )
+                self._update_distribution_skip(organization_id, project_id, artifact_id, "invalid_signature")
                 return
             if apple_info.is_simulator:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: simulator build")
-                self._update_artifact_error(
-                    organization_id,
-                    project_id,
-                    artifact_id,
-                    ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
-                    ProcessingErrorMessage.SIMULATOR_BUILD,
-                )
+                self._update_distribution_skip(organization_id, project_id, artifact_id, "simulator")
                 return
             with tempfile.TemporaryDirectory() as temp_dir_str:
                 temp_dir = Path(temp_dir_str)
@@ -373,14 +362,8 @@ class ArtifactProcessor:
             with apk.raw_file() as f:
                 self._sentry_client.upload_installable_app(organization_id, project_id, artifact_id, f)
         else:
-            logger.error(f"BUILD_DISTRIBUTION failed for {artifact_id} (project: {project_id}, org: {organization_id})")
-            self._update_artifact_error(
-                organization_id,
-                project_id,
-                artifact_id,
-                ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR,
-                ProcessingErrorMessage.UNSUPPORTED_ARTIFACT_TYPE,
-            )
+            logger.error(f"BUILD_DISTRIBUTION failed for {artifact_id}: unsupported artifact type")
+            self._update_distribution_skip(organization_id, project_id, artifact_id, "unsupported")
 
     def _do_size(
         self,
@@ -461,6 +444,27 @@ class ArtifactProcessor:
             logger.exception(f"Failed to update artifact with error {message}")
         else:
             logger.info(f"Successfully updated artifact {artifact_id} with error information")
+
+    def _update_distribution_skip(
+        self,
+        organization_id: str,
+        project_id: str,
+        artifact_id: str,
+        skip_reason: str,
+    ) -> None:
+        """Update artifact with distribution skip state."""
+        try:
+            self._sentry_client.update_artifact(
+                org=organization_id,
+                project=project_id,
+                artifact_id=artifact_id,
+                data={
+                    "distribution_state": DistributionState.NOT_RAN.value,
+                    "distribution_skip_reason": skip_reason,
+                },
+            )
+        except SentryClientError:
+            logger.exception(f"Failed to update distribution skip for artifact {artifact_id}")
 
     def _update_size_error_from_exception(
         self,

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -33,7 +33,7 @@ from launchpad.artifacts.artifact import AndroidArtifact, AppleArtifact, Artifac
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.constants import (
     ArtifactType,
-    DistributionState,
+    InstallableAppErrorCode,
     PreprodFeature,
     ProcessingErrorCode,
     ProcessingErrorMessage,
@@ -452,16 +452,13 @@ class ArtifactProcessor:
         artifact_id: str,
         skip_reason: str,
     ) -> None:
-        """Update artifact with distribution skip state."""
+        """Report distribution skip via the dedicated distribution endpoint."""
         try:
-            self._sentry_client.update_artifact(
+            self._sentry_client.update_distribution_error(
                 org=organization_id,
-                project=project_id,
                 artifact_id=artifact_id,
-                data={
-                    "distribution_state": DistributionState.NOT_RAN.value,
-                    "distribution_skip_reason": skip_reason,
-                },
+                error_code=InstallableAppErrorCode.SKIPPED.value,
+                error_message=skip_reason,
             )
         except SentryClientError:
             logger.exception(f"Failed to update distribution skip for artifact {artifact_id}")

--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -29,11 +29,12 @@ class PreprodFeature(Enum):
     BUILD_DISTRIBUTION = "build_distribution"
 
 
-# Matches PreprodArtifact.DistributionState in sentry
-class DistributionState(Enum):
-    PENDING = 0
-    COMPLETED = 1
-    NOT_RAN = 2
+# Matches InstallableApp.ErrorCode in sentry
+class InstallableAppErrorCode(Enum):
+    UNKNOWN = 0
+    NO_QUOTA = 1
+    SKIPPED = 2
+    PROCESSING_ERROR = 3
 
 
 # Health check threshold - consider unhealthy if file not touched in 60 seconds

--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -46,6 +46,8 @@ class ProcessingErrorMessage(Enum):
     SIZE_ANALYSIS_FAILED = "Failed to perform size analysis"
     ARTIFACT_PARSING_FAILED = "Failed to parse artifact file"
     UNSUPPORTED_ARTIFACT_TYPE = "Unsupported artifact type"
+    INVALID_CODE_SIGNATURE = "Cannot distribute app with invalid code signature"
+    SIMULATOR_BUILD = "Cannot distribute simulator builds"
 
     # System-related errors
     TEMP_FILE_CREATION_FAILED = "Failed to create temporary file"

--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -29,6 +29,13 @@ class PreprodFeature(Enum):
     BUILD_DISTRIBUTION = "build_distribution"
 
 
+# Matches PreprodArtifact.DistributionState in sentry
+class DistributionState(Enum):
+    PENDING = 0
+    COMPLETED = 1
+    NOT_RAN = 2
+
+
 # Health check threshold - consider unhealthy if file not touched in 60 seconds
 HEALTHCHECK_MAX_AGE_SECONDS = 60.0
 
@@ -46,8 +53,6 @@ class ProcessingErrorMessage(Enum):
     SIZE_ANALYSIS_FAILED = "Failed to perform size analysis"
     ARTIFACT_PARSING_FAILED = "Failed to parse artifact file"
     UNSUPPORTED_ARTIFACT_TYPE = "Unsupported artifact type"
-    INVALID_CODE_SIGNATURE = "Cannot distribute app with invalid code signature"
-    SIMULATOR_BUILD = "Cannot distribute simulator builds"
 
     # System-related errors
     TEMP_FILE_CREATION_FAILED = "Failed to create temporary file"

--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -134,8 +134,9 @@ class RetentionResponse(BaseModel):
     build_distribution: int
 
 
-class EmptyResponse(BaseModel):
-    model_config = ConfigDict(extra="allow")
+class DistributionResponse(BaseModel):
+    model_config = ConfigDict(strict=True, alias_generator=to_camel)
+    artifact_id: str
 
 
 def create_retry_session(max_retries: int = 3) -> requests.Session:
@@ -256,10 +257,10 @@ class SentryClient:
         endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/update/"
         return self._make_json_request("PUT", endpoint, UpdateResponse, data=data)
 
-    def update_distribution(self, org: str, artifact_id: str, data: Dict[str, Any]) -> EmptyResponse:
+    def update_distribution(self, org: str, artifact_id: str, data: Dict[str, Any]) -> DistributionResponse:
         """Update preprod artifact distribution."""
         endpoint = f"/api/0/organizations/{org}/preprodartifacts/{artifact_id}/distribution/"
-        return self._make_json_request("PUT", endpoint, EmptyResponse, data=data)
+        return self._make_json_request("PUT", endpoint, DistributionResponse, data=data)
 
     def upload_size_analysis_file(
         self,

--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -134,6 +134,10 @@ class RetentionResponse(BaseModel):
     build_distribution: int
 
 
+class EmptyResponse(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
 def create_retry_session(max_retries: int = 3) -> requests.Session:
     """Create a requests session with retry configuration."""
     session = requests.Session()
@@ -252,10 +256,10 @@ class SentryClient:
         endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/update/"
         return self._make_json_request("PUT", endpoint, UpdateResponse, data=data)
 
-    def update_distribution(self, org: str, artifact_id: str, data: Dict[str, Any]) -> None:
+    def update_distribution(self, org: str, artifact_id: str, data: Dict[str, Any]) -> EmptyResponse:
         """Update preprod artifact distribution."""
         endpoint = f"/api/0/organizations/{org}/preprodartifacts/{artifact_id}/distribution/"
-        self._make_json_request("PUT", endpoint, data=data)
+        return self._make_json_request("PUT", endpoint, EmptyResponse, data=data)
 
     def upload_size_analysis_file(
         self,
@@ -371,10 +375,10 @@ class SentryClient:
         self,
         method: str,
         endpoint: str,
-        model: ResponseModel | None = None,
+        model: ResponseModel,
         data: Dict[str, Any] | None = None,
         timeout: int = 30,
-    ) -> ResponseModel | None:
+    ) -> ResponseModel:
         """Make a JSON request with standard error handling."""
         url = self._build_url(endpoint)
         body = json.dumps(data).encode("utf-8") if data else b""
@@ -389,8 +393,6 @@ class SentryClient:
         )
 
         if response.status_code == 200:
-            if model is None:
-                return None
             try:
                 j = response.json()
                 return model.model_validate(j)

--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -252,23 +252,10 @@ class SentryClient:
         endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/update/"
         return self._make_json_request("PUT", endpoint, UpdateResponse, data=data)
 
-    def update_distribution_error(self, org: str, artifact_id: str, error_code: int, error_message: str) -> None:
-        """Report distribution error via the dedicated distribution endpoint."""
+    def update_distribution(self, org: str, artifact_id: str, data: Dict[str, Any]) -> None:
+        """Update preprod artifact distribution."""
         endpoint = f"/api/0/organizations/{org}/preprodartifacts/{artifact_id}/distribution/"
-        url = self._build_url(endpoint)
-        body = json.dumps({"error_code": error_code, "error_message": error_message}).encode("utf-8")
-
-        logger.debug(f"PUT {url}")
-        response = self.session.request(
-            method="PUT",
-            url=url,
-            data=body,
-            auth=self.auth,
-            timeout=30,
-        )
-
-        if response.status_code != 200:
-            raise SentryClientError(response=response)
+        self._make_json_request("PUT", endpoint, data=data)
 
     def upload_size_analysis_file(
         self,
@@ -384,10 +371,10 @@ class SentryClient:
         self,
         method: str,
         endpoint: str,
-        model: ResponseModel,
+        model: ResponseModel | None = None,
         data: Dict[str, Any] | None = None,
         timeout: int = 30,
-    ) -> ResponseModel:
+    ) -> ResponseModel | None:
         """Make a JSON request with standard error handling."""
         url = self._build_url(endpoint)
         body = json.dumps(data).encode("utf-8") if data else b""
@@ -402,6 +389,8 @@ class SentryClient:
         )
 
         if response.status_code == 200:
+            if model is None:
+                return None
             try:
                 j = response.json()
                 return model.model_validate(j)

--- a/src/launchpad/sentry_client.py
+++ b/src/launchpad/sentry_client.py
@@ -252,6 +252,24 @@ class SentryClient:
         endpoint = f"/api/0/internal/{org}/{project}/files/preprodartifacts/{artifact_id}/update/"
         return self._make_json_request("PUT", endpoint, UpdateResponse, data=data)
 
+    def update_distribution_error(self, org: str, artifact_id: str, error_code: int, error_message: str) -> None:
+        """Report distribution error via the dedicated distribution endpoint."""
+        endpoint = f"/api/0/organizations/{org}/preprodartifacts/{artifact_id}/distribution/"
+        url = self._build_url(endpoint)
+        body = json.dumps({"error_code": error_code, "error_message": error_message}).encode("utf-8")
+
+        logger.debug(f"PUT {url}")
+        response = self.session.request(
+            method="PUT",
+            url=url,
+            data=body,
+            auth=self.auth,
+            timeout=30,
+        )
+
+        if response.status_code != 200:
+            raise SentryClientError(response=response)
+
     def upload_size_analysis_file(
         self,
         org: str,

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -6,7 +6,7 @@ from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import Artifact
 from launchpad.constants import (
-    DistributionState,
+    InstallableAppErrorCode,
     ProcessingErrorCode,
     ProcessingErrorMessage,
 )
@@ -139,7 +139,7 @@ class TestArtifactProcessorErrorHandling:
 
     def test_do_distribution_unknown_artifact_type_skips(self):
         mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_artifact.return_value = None
+        mock_sentry_client.update_distribution_error.return_value = None
         self.processor._sentry_client = mock_sentry_client
 
         unknown_artifact = Mock(spec=Artifact)
@@ -149,19 +149,16 @@ class TestArtifactProcessorErrorHandling:
             "test-org-id", "test-project-id", "test-artifact-id", unknown_artifact, mock_info
         )
 
-        mock_sentry_client.update_artifact.assert_called_once_with(
+        mock_sentry_client.update_distribution_error.assert_called_once_with(
             org="test-org-id",
-            project="test-project-id",
             artifact_id="test-artifact-id",
-            data={
-                "distribution_state": DistributionState.NOT_RAN.value,
-                "distribution_skip_reason": "unsupported",
-            },
+            error_code=InstallableAppErrorCode.SKIPPED.value,
+            error_message="unsupported",
         )
 
     def test_do_distribution_invalid_code_signature_skips(self):
         mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_artifact.return_value = None
+        mock_sentry_client.update_distribution_error.return_value = None
         self.processor._sentry_client = mock_sentry_client
 
         artifact = Mock(spec=ZippedXCArchive)
@@ -171,20 +168,17 @@ class TestArtifactProcessorErrorHandling:
 
         self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
 
-        mock_sentry_client.update_artifact.assert_called_once_with(
+        mock_sentry_client.update_distribution_error.assert_called_once_with(
             org="test-org-id",
-            project="test-project-id",
             artifact_id="test-artifact-id",
-            data={
-                "distribution_state": DistributionState.NOT_RAN.value,
-                "distribution_skip_reason": "invalid_signature",
-            },
+            error_code=InstallableAppErrorCode.SKIPPED.value,
+            error_message="invalid_signature",
         )
         mock_sentry_client.upload_installable_app.assert_not_called()
 
     def test_do_distribution_simulator_build_skips(self):
         mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_artifact.return_value = None
+        mock_sentry_client.update_distribution_error.return_value = None
         self.processor._sentry_client = mock_sentry_client
 
         artifact = Mock(spec=ZippedXCArchive)
@@ -194,14 +188,11 @@ class TestArtifactProcessorErrorHandling:
 
         self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
 
-        mock_sentry_client.update_artifact.assert_called_once_with(
+        mock_sentry_client.update_distribution_error.assert_called_once_with(
             org="test-org-id",
-            project="test-project-id",
             artifact_id="test-artifact-id",
-            data={
-                "distribution_state": DistributionState.NOT_RAN.value,
-                "distribution_skip_reason": "simulator",
-            },
+            error_code=InstallableAppErrorCode.SKIPPED.value,
+            error_message="simulator",
         )
         mock_sentry_client.upload_installable_app.assert_not_called()
 

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 from objectstore_client import Client as ObjectstoreClient
 
 from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig
-from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import Artifact
 from launchpad.constants import (
     InstallableAppErrorCode,
@@ -155,46 +154,6 @@ class TestArtifactProcessorErrorHandling:
             error_code=InstallableAppErrorCode.PROCESSING_ERROR.value,
             error_message="unsupported artifact type",
         )
-
-    def test_do_distribution_invalid_code_signature_skips(self):
-        mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_distribution_error.return_value = None
-        self.processor._sentry_client = mock_sentry_client
-
-        artifact = Mock(spec=ZippedXCArchive)
-        mock_info = Mock()
-        mock_info.is_code_signature_valid = False
-        mock_info.is_simulator = False
-
-        self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
-
-        mock_sentry_client.update_distribution_error.assert_called_once_with(
-            org="test-org-id",
-            artifact_id="test-artifact-id",
-            error_code=InstallableAppErrorCode.SKIPPED.value,
-            error_message="invalid_signature",
-        )
-        mock_sentry_client.upload_installable_app.assert_not_called()
-
-    def test_do_distribution_simulator_build_skips(self):
-        mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_distribution_error.return_value = None
-        self.processor._sentry_client = mock_sentry_client
-
-        artifact = Mock(spec=ZippedXCArchive)
-        mock_info = Mock()
-        mock_info.is_code_signature_valid = True
-        mock_info.is_simulator = True
-
-        self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
-
-        mock_sentry_client.update_distribution_error.assert_called_once_with(
-            org="test-org-id",
-            artifact_id="test-artifact-id",
-            error_code=InstallableAppErrorCode.SKIPPED.value,
-            error_message="simulator",
-        )
-        mock_sentry_client.upload_installable_app.assert_not_called()
 
 
 class TestArtifactProcessorMessageHandling:

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 from objectstore_client import Client as ObjectstoreClient
 
 from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig
+from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import Artifact
 from launchpad.constants import (
     InstallableAppErrorCode,
@@ -154,6 +155,46 @@ class TestArtifactProcessorErrorHandling:
             error_code=InstallableAppErrorCode.PROCESSING_ERROR.value,
             error_message="unsupported artifact type",
         )
+
+    def test_do_distribution_invalid_code_signature_reports_skip(self):
+        mock_sentry_client = Mock(spec=SentryClient)
+        mock_sentry_client.update_distribution_error.return_value = None
+        self.processor._sentry_client = mock_sentry_client
+
+        artifact = Mock(spec=ZippedXCArchive)
+        mock_info = Mock()
+        mock_info.is_code_signature_valid = False
+        mock_info.is_simulator = False
+
+        self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
+
+        mock_sentry_client.update_distribution_error.assert_called_once_with(
+            org="test-org-id",
+            artifact_id="test-artifact-id",
+            error_code=InstallableAppErrorCode.SKIPPED.value,
+            error_message="invalid_signature",
+        )
+        mock_sentry_client.upload_installable_app.assert_not_called()
+
+    def test_do_distribution_simulator_build_reports_skip(self):
+        mock_sentry_client = Mock(spec=SentryClient)
+        mock_sentry_client.update_distribution_error.return_value = None
+        self.processor._sentry_client = mock_sentry_client
+
+        artifact = Mock(spec=ZippedXCArchive)
+        mock_info = Mock()
+        mock_info.is_code_signature_valid = True
+        mock_info.is_simulator = True
+
+        self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
+
+        mock_sentry_client.update_distribution_error.assert_called_once_with(
+            org="test-org-id",
+            artifact_id="test-artifact-id",
+            error_code=InstallableAppErrorCode.SKIPPED.value,
+            error_message="simulator",
+        )
+        mock_sentry_client.upload_installable_app.assert_not_called()
 
 
 class TestArtifactProcessorMessageHandling:

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -137,7 +137,7 @@ class TestArtifactProcessorErrorHandling:
         assert ProcessingErrorMessage.SIZE_ANALYSIS_FAILED.value == "Failed to perform size analysis"
         assert ProcessingErrorMessage.UNKNOWN_ERROR.value == "An unknown error occurred"
 
-    def test_do_distribution_unknown_artifact_type_skips(self):
+    def test_do_distribution_unknown_artifact_type_reports_error(self):
         mock_sentry_client = Mock(spec=SentryClient)
         mock_sentry_client.update_distribution_error.return_value = None
         self.processor._sentry_client = mock_sentry_client
@@ -152,8 +152,8 @@ class TestArtifactProcessorErrorHandling:
         mock_sentry_client.update_distribution_error.assert_called_once_with(
             org="test-org-id",
             artifact_id="test-artifact-id",
-            error_code=InstallableAppErrorCode.SKIPPED.value,
-            error_message="unsupported",
+            error_code=InstallableAppErrorCode.PROCESSING_ERROR.value,
+            error_message="unsupported artifact type",
         )
 
     def test_do_distribution_invalid_code_signature_skips(self):

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 from objectstore_client import Client as ObjectstoreClient
 
 from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig
+from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import Artifact
 from launchpad.constants import (
     ProcessingErrorCode,
@@ -157,6 +158,52 @@ class TestArtifactProcessorErrorHandling:
                 "error_message": ProcessingErrorMessage.UNSUPPORTED_ARTIFACT_TYPE.value,
             },
         )
+
+    def test_do_distribution_invalid_code_signature_reports_error(self):
+        mock_sentry_client = Mock(spec=SentryClient)
+        mock_sentry_client.update_artifact.return_value = None
+        self.processor._sentry_client = mock_sentry_client
+
+        artifact = Mock(spec=ZippedXCArchive)
+        mock_info = Mock()
+        mock_info.is_code_signature_valid = False
+        mock_info.is_simulator = False
+
+        self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
+
+        mock_sentry_client.update_artifact.assert_called_once_with(
+            org="test-org-id",
+            project="test-project-id",
+            artifact_id="test-artifact-id",
+            data={
+                "error_code": ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR.value,
+                "error_message": ProcessingErrorMessage.INVALID_CODE_SIGNATURE.value,
+            },
+        )
+        mock_sentry_client.upload_installable_app.assert_not_called()
+
+    def test_do_distribution_simulator_build_reports_error(self):
+        mock_sentry_client = Mock(spec=SentryClient)
+        mock_sentry_client.update_artifact.return_value = None
+        self.processor._sentry_client = mock_sentry_client
+
+        artifact = Mock(spec=ZippedXCArchive)
+        mock_info = Mock()
+        mock_info.is_code_signature_valid = True
+        mock_info.is_simulator = True
+
+        self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
+
+        mock_sentry_client.update_artifact.assert_called_once_with(
+            org="test-org-id",
+            project="test-project-id",
+            artifact_id="test-artifact-id",
+            data={
+                "error_code": ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR.value,
+                "error_message": ProcessingErrorMessage.SIMULATOR_BUILD.value,
+            },
+        )
+        mock_sentry_client.upload_installable_app.assert_not_called()
 
 
 class TestArtifactProcessorMessageHandling:

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 from objectstore_client import Client as ObjectstoreClient
 
 from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig
+from launchpad.artifacts.artifact import Artifact
 from launchpad.constants import (
     ProcessingErrorCode,
     ProcessingErrorMessage,
@@ -133,6 +134,29 @@ class TestArtifactProcessorErrorHandling:
         assert ProcessingErrorMessage.PREPROCESSING_FAILED.value == "Failed to extract basic app information"
         assert ProcessingErrorMessage.SIZE_ANALYSIS_FAILED.value == "Failed to perform size analysis"
         assert ProcessingErrorMessage.UNKNOWN_ERROR.value == "An unknown error occurred"
+
+    def test_do_distribution_unknown_artifact_type_reports_error(self):
+        """Test that _do_distribution reports an error for unknown artifact types."""
+        mock_sentry_client = Mock(spec=SentryClient)
+        mock_sentry_client.update_artifact.return_value = None
+        self.processor._sentry_client = mock_sentry_client
+
+        unknown_artifact = Mock(spec=Artifact)
+        mock_info = Mock()
+
+        self.processor._do_distribution(
+            "test-org-id", "test-project-id", "test-artifact-id", unknown_artifact, mock_info
+        )
+
+        mock_sentry_client.update_artifact.assert_called_once_with(
+            org="test-org-id",
+            project="test-project-id",
+            artifact_id="test-artifact-id",
+            data={
+                "error_code": ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR.value,
+                "error_message": ProcessingErrorMessage.UNSUPPORTED_ARTIFACT_TYPE.value,
+            },
+        )
 
 
 class TestArtifactProcessorMessageHandling:

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -6,6 +6,7 @@ from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import Artifact
 from launchpad.constants import (
+    DistributionState,
     ProcessingErrorCode,
     ProcessingErrorMessage,
 )
@@ -136,8 +137,7 @@ class TestArtifactProcessorErrorHandling:
         assert ProcessingErrorMessage.SIZE_ANALYSIS_FAILED.value == "Failed to perform size analysis"
         assert ProcessingErrorMessage.UNKNOWN_ERROR.value == "An unknown error occurred"
 
-    def test_do_distribution_unknown_artifact_type_reports_error(self):
-        """Test that _do_distribution reports an error for unknown artifact types."""
+    def test_do_distribution_unknown_artifact_type_skips(self):
         mock_sentry_client = Mock(spec=SentryClient)
         mock_sentry_client.update_artifact.return_value = None
         self.processor._sentry_client = mock_sentry_client
@@ -154,12 +154,12 @@ class TestArtifactProcessorErrorHandling:
             project="test-project-id",
             artifact_id="test-artifact-id",
             data={
-                "error_code": ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR.value,
-                "error_message": ProcessingErrorMessage.UNSUPPORTED_ARTIFACT_TYPE.value,
+                "distribution_state": DistributionState.NOT_RAN.value,
+                "distribution_skip_reason": "unsupported",
             },
         )
 
-    def test_do_distribution_invalid_code_signature_reports_error(self):
+    def test_do_distribution_invalid_code_signature_skips(self):
         mock_sentry_client = Mock(spec=SentryClient)
         mock_sentry_client.update_artifact.return_value = None
         self.processor._sentry_client = mock_sentry_client
@@ -176,13 +176,13 @@ class TestArtifactProcessorErrorHandling:
             project="test-project-id",
             artifact_id="test-artifact-id",
             data={
-                "error_code": ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR.value,
-                "error_message": ProcessingErrorMessage.INVALID_CODE_SIGNATURE.value,
+                "distribution_state": DistributionState.NOT_RAN.value,
+                "distribution_skip_reason": "invalid_signature",
             },
         )
         mock_sentry_client.upload_installable_app.assert_not_called()
 
-    def test_do_distribution_simulator_build_reports_error(self):
+    def test_do_distribution_simulator_build_skips(self):
         mock_sentry_client = Mock(spec=SentryClient)
         mock_sentry_client.update_artifact.return_value = None
         self.processor._sentry_client = mock_sentry_client
@@ -199,8 +199,8 @@ class TestArtifactProcessorErrorHandling:
             project="test-project-id",
             artifact_id="test-artifact-id",
             data={
-                "error_code": ProcessingErrorCode.ARTIFACT_PROCESSING_ERROR.value,
-                "error_message": ProcessingErrorMessage.SIMULATOR_BUILD.value,
+                "distribution_state": DistributionState.NOT_RAN.value,
+                "distribution_skip_reason": "simulator",
             },
         )
         mock_sentry_client.upload_installable_app.assert_not_called()

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -139,8 +139,10 @@ class TestArtifactProcessorErrorHandling:
 
     def test_do_distribution_unknown_artifact_type_reports_error(self):
         mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_distribution_error.return_value = None
+        mock_sentry_client.update_distribution.return_value = None
+        mock_statsd = Mock()
         self.processor._sentry_client = mock_sentry_client
+        self.processor._statsd = mock_statsd
 
         unknown_artifact = Mock(spec=Artifact)
         mock_info = Mock()
@@ -149,17 +151,29 @@ class TestArtifactProcessorErrorHandling:
             "test-org-id", "test-project-id", "test-artifact-id", unknown_artifact, mock_info
         )
 
-        mock_sentry_client.update_distribution_error.assert_called_once_with(
+        mock_sentry_client.update_distribution.assert_called_once_with(
             org="test-org-id",
             artifact_id="test-artifact-id",
-            error_code=InstallableAppErrorCode.PROCESSING_ERROR.value,
-            error_message="unsupported artifact type",
+            data={
+                "error_code": InstallableAppErrorCode.PROCESSING_ERROR.value,
+                "error_message": "unsupported artifact type",
+            },
+        )
+        mock_statsd.increment.assert_called_once_with(
+            "distribution.processing.error",
+            tags=[
+                f"error_code:{InstallableAppErrorCode.PROCESSING_ERROR.value}",
+                "error_message:unsupported artifact type",
+                "organization_id:test-org-id",
+            ],
         )
 
     def test_do_distribution_invalid_code_signature_reports_skip(self):
         mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_distribution_error.return_value = None
+        mock_sentry_client.update_distribution.return_value = None
+        mock_statsd = Mock()
         self.processor._sentry_client = mock_sentry_client
+        self.processor._statsd = mock_statsd
 
         artifact = Mock(spec=ZippedXCArchive)
         mock_info = Mock()
@@ -168,18 +182,30 @@ class TestArtifactProcessorErrorHandling:
 
         self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
 
-        mock_sentry_client.update_distribution_error.assert_called_once_with(
+        mock_sentry_client.update_distribution.assert_called_once_with(
             org="test-org-id",
             artifact_id="test-artifact-id",
-            error_code=InstallableAppErrorCode.SKIPPED.value,
-            error_message="invalid_signature",
+            data={
+                "error_code": InstallableAppErrorCode.SKIPPED.value,
+                "error_message": "invalid_signature",
+            },
+        )
+        mock_statsd.increment.assert_called_once_with(
+            "distribution.processing.error",
+            tags=[
+                f"error_code:{InstallableAppErrorCode.SKIPPED.value}",
+                "error_message:invalid_signature",
+                "organization_id:test-org-id",
+            ],
         )
         mock_sentry_client.upload_installable_app.assert_not_called()
 
     def test_do_distribution_simulator_build_reports_skip(self):
         mock_sentry_client = Mock(spec=SentryClient)
-        mock_sentry_client.update_distribution_error.return_value = None
+        mock_sentry_client.update_distribution.return_value = None
+        mock_statsd = Mock()
         self.processor._sentry_client = mock_sentry_client
+        self.processor._statsd = mock_statsd
 
         artifact = Mock(spec=ZippedXCArchive)
         mock_info = Mock()
@@ -188,11 +214,21 @@ class TestArtifactProcessorErrorHandling:
 
         self.processor._do_distribution("test-org-id", "test-project-id", "test-artifact-id", artifact, mock_info)
 
-        mock_sentry_client.update_distribution_error.assert_called_once_with(
+        mock_sentry_client.update_distribution.assert_called_once_with(
             org="test-org-id",
             artifact_id="test-artifact-id",
-            error_code=InstallableAppErrorCode.SKIPPED.value,
-            error_message="simulator",
+            data={
+                "error_code": InstallableAppErrorCode.SKIPPED.value,
+                "error_message": "simulator",
+            },
+        )
+        mock_statsd.increment.assert_called_once_with(
+            "distribution.processing.error",
+            tags=[
+                f"error_code:{InstallableAppErrorCode.SKIPPED.value}",
+                "error_message:simulator",
+                "organization_id:test-org-id",
+            ],
         )
         mock_sentry_client.upload_installable_app.assert_not_called()
 


### PR DESCRIPTION
## Summary

When Sentry requests `BUILD_DISTRIBUTION`, Launchpad now reports back via
the distribution endpoint in all cases where it can't fulfill the request:

- **Unknown artifact types**: Reports `PROCESSING_ERROR` via `update_distribution_error`
- **Invalid code signature (iOS)**: Reports `SKIPPED` with reason `invalid_signature`
- **Simulator builds (iOS)**: Reports `SKIPPED` with reason `simulator`

Previously, these cases either silently did nothing or only logged an error,
leaving the artifact stuck in a "processing" state in Sentry with no timeout
to recover.

Fixes EME-422

🤖 Generated with [Claude Code](https://claude.com/claude-code)