### PR TITLE
fix(tasks) Add rpc_secret to taskworker

### DIFF
--- a/src/launchpad/worker/app.py
+++ b/src/launchpad/worker/app.py
@@ -1,4 +1,3 @@
-import json
 import os
 import platform
 import resource

--- a/src/launchpad/worker/app.py
+++ b/src/launchpad/worker/app.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import resource
@@ -101,8 +102,14 @@ app = TaskbrokerApp(
     router_class=CustomRouter(),
     metrics_class=TaskworkerMetricsBackend(),
 )
+
+rpc_secret: str | None = None
+env_secret = os.getenv("LAUNCHPAD_GRPC_SHARED_SECRET")
+if env_secret:
+    rpc_secret = json.dumps([env_secret])
+
 app.set_config({
-    "rpc_secret": os.getenv("TASKWORKER_SHARED_SECRET"),
+    "rpc_secret": rpc_secret,
 })
 
 app.set_modules(["launchpad.worker.tasks"])

--- a/src/launchpad/worker/app.py
+++ b/src/launchpad/worker/app.py
@@ -101,5 +101,8 @@ app = TaskbrokerApp(
     router_class=CustomRouter(),
     metrics_class=TaskworkerMetricsBackend(),
 )
+app.set_config({
+    "rpc_secret": os.getenv("TASKWORKER_SHARED_SECRET"),
+})
 
 app.set_modules(["launchpad.worker.tasks"])

--- a/src/launchpad/worker/app.py
+++ b/src/launchpad/worker/app.py
@@ -108,8 +108,10 @@ env_secret = os.getenv("LAUNCHPAD_GRPC_SHARED_SECRET")
 if env_secret:
     rpc_secret = json.dumps([env_secret])
 
-app.set_config({
-    "rpc_secret": rpc_secret,
-})
+app.set_config(
+    {
+        "rpc_secret": rpc_secret,
+    }
+)
 
 app.set_modules(["launchpad.worker.tasks"])

--- a/src/launchpad/worker/app.py
+++ b/src/launchpad/worker/app.py
@@ -103,14 +103,9 @@ app = TaskbrokerApp(
     metrics_class=TaskworkerMetricsBackend(),
 )
 
-rpc_secret: str | None = None
-env_secret = os.getenv("LAUNCHPAD_GRPC_SHARED_SECRET")
-if env_secret:
-    rpc_secret = json.dumps([env_secret])
-
 app.set_config(
     {
-        "rpc_secret": rpc_secret,
+        "rpc_secret": os.getenv("TASKWORKER_SHARED_SECRET", None),
     }
 )
 


### PR DESCRIPTION
In production we need an RPC secret to sign requests to taskbroker. Instead of using the existing shared secret between launchpad and sentry, we should use a different key.