### PR TITLE
docs: Remove stale Kafka/serve references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,17 +34,14 @@ launchpad size path/to/app.apk                                 # Android
 launchpad size app.xcarchive.zip --skip-swift-metadata --skip-symbols  # faster
 
 # Service development
-devservices up                 # Start Kafka infrastructure
-make serve                     # Start Launchpad server (Kafka mode: HTTP + Kafka consumer)
-make worker                    # Start Launchpad worker (TaskWorker mode: no HTTP server)
+make worker                    # Start Launchpad worker (TaskWorker mode)
 ```
 
 ## Architecture
 
 ### Core Components
-- **CLI** (`src/launchpad/cli.py`): Main entry point, uses Click. Two service commands: `serve` (Kafka mode) and `worker` (TaskWorker mode)
-- **Service** (`src/launchpad/service.py`): Kafka consumer + HTTP server for production (`launchpad serve`)
-- **Worker** (`src/launchpad/worker/`): TaskWorker mode — receives tasks via TaskBroker RPC, no HTTP server (`launchpad worker`)
+- **CLI** (`src/launchpad/cli.py`): Main entry point, uses Click
+- **Worker** (`src/launchpad/worker/`): TaskWorker — receives tasks via TaskBroker RPC (`launchpad worker`)
 - **Analyzers** (`src/launchpad/size/analyzers/`): Platform-specific analysis engines (AppleAppAnalyzer, AndroidAnalyzer)
 - **Parsers** (`src/launchpad/parsers/`): Binary parsing - Mach-O via LIEF, custom DEX parsers
 - **Insights** (`src/launchpad/size/insights/`): Optimization recommendations (image compression, symbol stripping, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,9 @@ make worker                    # Start Launchpad worker (TaskWorker mode)
 
 ### Key Data Models
 - `AppleAnalysisResults` / `AndroidAnalysisResults`: Platform analysis output
-- `BinaryComponent`: Individual binary analysis with symbols and sections
+- `AppComponent`: Individual app component with size and type info
 - `TreemapElement`: Hierarchical size data for visualization
-- `InsightResult`: Optimization recommendation with potential savings
+- `BaseInsightResult`: Optimization recommendation with potential savings
 
 ## Code Style
 
@@ -83,8 +83,8 @@ A feature is not complete until:
 
 ## Adding New Insights
 
-1. Create class in `insights/apple/` or `insights/android/`
-2. Inherit from `Insight` base class
-3. Implement `analyze()` returning `InsightResult`
+1. Create class in `insights/apple/`, `insights/android/`, or `insights/common/`
+2. Implement the `Insight` protocol
+3. Implement `analyze()` returning a subclass of `BaseInsightResult`
 4. Register in platform analyzer's insight list
 5. Add integration tests

--- a/README.md
+++ b/README.md
@@ -18,42 +18,9 @@ devenv sync
 
 If you don't have devenv installed, [follow these instructions](https://github.com/getsentry/devenv#install).
 
-### Using devservices
+### Running the worker
 
-[devservices](https://github.com/getsentry/devservices) manages the dependencies used by Launchpad:
-
-```bash
-# Start dependency containers (e.g. Kafka)
-devservices up
-
-# Begin listening for messages (Kafka mode)
-make serve
-
-# Or run the TaskWorker instead
-make worker
-
-# Stop containers
-devservices down
-```
-
-## Usage
-
-Launchpad can run in two operational modes:
-
-- **Kafka mode** (`launchpad serve`): HTTP server + Kafka consumer. This is the existing production mode that runs alongside the [Sentry monolith](https://github.com/getsentry/sentry).
-- **TaskWorker mode** (`launchpad worker`): TaskWorker only, no HTTP server. This is a lighter-weight mode that receives work via the TaskBroker RPC interface instead of Kafka.
-
-### Running in Kafka mode
-
-```bash
-devservices up
-make serve
-# or: launchpad serve --dev
-```
-
-### Running in TaskWorker mode
-
-Requires `LAUNCHPAD_WORKER_RPC_HOST` and `LAUNCHPAD_WORKER_CONCURRENCY` environment variables (already configured in `.envrc`).
+Launchpad runs as a TaskWorker that receives work via the TaskBroker RPC interface. Requires `LAUNCHPAD_WORKER_RPC_HOST` and `LAUNCHPAD_WORKER_CONCURRENCY` environment variables (already configured in `.envrc`).
 
 The TaskBroker handles task distribution and dispatches work to the worker via RPC. A single worker instance processes tasks in parallel — `LAUNCHPAD_WORKER_CONCURRENCY` controls how many child processes run simultaneously (e.g., 16 means up to 16 artifacts processed in parallel).
 
@@ -121,14 +88,9 @@ devservices up --mode ingest
 devservices serve --workers
 ```
 
-Next run `launchpad` in another terminal using either mode:
+Next run `launchpad` in another terminal:
 
 ```bash
-# Kafka mode (HTTP server + Kafka consumer)
-devservices up
-make serve
-
-# TaskWorker mode (TaskWorker only, no HTTP server)
 make worker
 ```
 
@@ -154,9 +116,6 @@ make test-unit
 
 # Integration tests only
 make test-integration
-
-# Integration test with devservices
-make test-service-integration
 ```
 
 ### Code Quality


### PR DESCRIPTION
## Summary
- Remove references to `make serve`, `launchpad serve`, and Kafka mode from README and CLAUDE.md
- Remove reference to `make test-service-integration` which no longer exists
- Simplify documentation to reflect that Launchpad now only runs as a TaskWorker

🤖 Generated with [Claude Code](https://claude.com/claude-code)