### PR TITLE
feat(artifacts): Emit granular installable app error codes (EME-883)

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -334,13 +334,13 @@ class ArtifactProcessor:
             if not apple_info.is_code_signature_valid:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: invalid code signature")
                 self._update_distribution_error(
-                    organization_id, artifact_id, InstallableAppErrorCode.SKIPPED, "invalid_signature"
+                    organization_id, artifact_id, InstallableAppErrorCode.INVALID_CODE_SIGNATURE, ""
                 )
                 return
             if apple_info.is_simulator:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: simulator build")
                 self._update_distribution_error(
-                    organization_id, artifact_id, InstallableAppErrorCode.SKIPPED, "simulator"
+                    organization_id, artifact_id, InstallableAppErrorCode.SIMULATOR_BUILD, ""
                 )
                 return
             with tempfile.TemporaryDirectory() as temp_dir_str:
@@ -368,7 +368,7 @@ class ArtifactProcessor:
         else:
             logger.error(f"BUILD_DISTRIBUTION failed for {artifact_id}: unsupported artifact type")
             self._update_distribution_error(
-                organization_id, artifact_id, InstallableAppErrorCode.PROCESSING_ERROR, "unsupported artifact type"
+                organization_id, artifact_id, InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE, ""
             )
 
     def _do_size(

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -334,13 +334,19 @@ class ArtifactProcessor:
             if not apple_info.is_code_signature_valid:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: invalid code signature")
                 self._update_distribution_error(
-                    organization_id, artifact_id, InstallableAppErrorCode.INVALID_CODE_SIGNATURE, ""
+                    organization_id,
+                    artifact_id,
+                    InstallableAppErrorCode.INVALID_CODE_SIGNATURE,
+                    "The build's code signature could not be verified.",
                 )
                 return
             if apple_info.is_simulator:
                 logger.warning(f"BUILD_DISTRIBUTION skipped for {artifact_id}: simulator build")
                 self._update_distribution_error(
-                    organization_id, artifact_id, InstallableAppErrorCode.SIMULATOR_BUILD, ""
+                    organization_id,
+                    artifact_id,
+                    InstallableAppErrorCode.SIMULATOR_BUILD,
+                    "Simulator builds cannot be distributed.",
                 )
                 return
             with tempfile.TemporaryDirectory() as temp_dir_str:
@@ -368,7 +374,10 @@ class ArtifactProcessor:
         else:
             logger.error(f"BUILD_DISTRIBUTION failed for {artifact_id}: unsupported artifact type")
             self._update_distribution_error(
-                organization_id, artifact_id, InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE, ""
+                organization_id,
+                artifact_id,
+                InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE,
+                "This artifact type is not supported for distribution.",
             )
 
     def _do_size(

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -474,7 +474,6 @@ class ArtifactProcessor:
             "distribution.processing.error",
             tags=[
                 f"error_code:{error_code.value}",
-                f"error_message:{error_message}",
                 f"organization_id:{organization_id}",
             ],
         )

--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -3,6 +3,7 @@
 from enum import Enum
 
 
+# Must stay in sync with PreprodArtifact.ErrorCode in sentry.
 class ProcessingErrorCode(Enum):
     UNKNOWN = 0
     UPLOAD_TIMEOUT = 1
@@ -26,6 +27,9 @@ class PreprodFeature(Enum):
     BUILD_DISTRIBUTION = "build_distribution"
 
 
+# Must stay in sync with PreprodArtifact.InstallableAppErrorCode in sentry.
+# Adding a value here without adding it on the sentry side will make the
+# distribution PUT 400 on pydantic validation.
 class InstallableAppErrorCode(Enum):
     UNKNOWN = 0
     NO_QUOTA = 1

--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -3,10 +3,7 @@
 from enum import Enum
 
 
-# Error code constants (matching the Django model)
 class ProcessingErrorCode(Enum):
-    """Error codes for artifact processing (matching the Django model)."""
-
     UNKNOWN = 0
     UPLOAD_TIMEOUT = 1
     ARTIFACT_PROCESSING_TIMEOUT = 2
@@ -29,7 +26,6 @@ class PreprodFeature(Enum):
     BUILD_DISTRIBUTION = "build_distribution"
 
 
-# Matches InstallableApp.ErrorCode in sentry
 class InstallableAppErrorCode(Enum):
     UNKNOWN = 0
     NO_QUOTA = 1

--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -35,6 +35,11 @@ class InstallableAppErrorCode(Enum):
     NO_QUOTA = 1
     SKIPPED = 2
     PROCESSING_ERROR = 3
+    DISTRIBUTION_DISABLED = 4
+    DISTRIBUTION_FILTERED = 5
+    INVALID_CODE_SIGNATURE = 6
+    SIMULATOR_BUILD = 7
+    UNSUPPORTED_ARTIFACT_TYPE = 8
 
 
 # Health check threshold - consider unhealthy if file not touched in 60 seconds

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -163,7 +163,6 @@ class TestArtifactProcessorErrorHandling:
             "distribution.processing.error",
             tags=[
                 f"error_code:{InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE.value}",
-                "error_message:This artifact type is not supported for distribution.",
                 "organization_id:test-org-id",
             ],
         )
@@ -194,7 +193,6 @@ class TestArtifactProcessorErrorHandling:
             "distribution.processing.error",
             tags=[
                 f"error_code:{InstallableAppErrorCode.INVALID_CODE_SIGNATURE.value}",
-                "error_message:The build's code signature could not be verified.",
                 "organization_id:test-org-id",
             ],
         )
@@ -226,7 +224,6 @@ class TestArtifactProcessorErrorHandling:
             "distribution.processing.error",
             tags=[
                 f"error_code:{InstallableAppErrorCode.SIMULATOR_BUILD.value}",
-                "error_message:Simulator builds cannot be distributed.",
                 "organization_id:test-org-id",
             ],
         )

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -155,15 +155,15 @@ class TestArtifactProcessorErrorHandling:
             org="test-org-id",
             artifact_id="test-artifact-id",
             data={
-                "error_code": InstallableAppErrorCode.PROCESSING_ERROR.value,
-                "error_message": "unsupported artifact type",
+                "error_code": InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE.value,
+                "error_message": "",
             },
         )
         mock_statsd.increment.assert_called_once_with(
             "distribution.processing.error",
             tags=[
-                f"error_code:{InstallableAppErrorCode.PROCESSING_ERROR.value}",
-                "error_message:unsupported artifact type",
+                f"error_code:{InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE.value}",
+                "error_message:",
                 "organization_id:test-org-id",
             ],
         )
@@ -186,15 +186,15 @@ class TestArtifactProcessorErrorHandling:
             org="test-org-id",
             artifact_id="test-artifact-id",
             data={
-                "error_code": InstallableAppErrorCode.SKIPPED.value,
-                "error_message": "invalid_signature",
+                "error_code": InstallableAppErrorCode.INVALID_CODE_SIGNATURE.value,
+                "error_message": "",
             },
         )
         mock_statsd.increment.assert_called_once_with(
             "distribution.processing.error",
             tags=[
-                f"error_code:{InstallableAppErrorCode.SKIPPED.value}",
-                "error_message:invalid_signature",
+                f"error_code:{InstallableAppErrorCode.INVALID_CODE_SIGNATURE.value}",
+                "error_message:",
                 "organization_id:test-org-id",
             ],
         )
@@ -218,15 +218,15 @@ class TestArtifactProcessorErrorHandling:
             org="test-org-id",
             artifact_id="test-artifact-id",
             data={
-                "error_code": InstallableAppErrorCode.SKIPPED.value,
-                "error_message": "simulator",
+                "error_code": InstallableAppErrorCode.SIMULATOR_BUILD.value,
+                "error_message": "",
             },
         )
         mock_statsd.increment.assert_called_once_with(
             "distribution.processing.error",
             tags=[
-                f"error_code:{InstallableAppErrorCode.SKIPPED.value}",
-                "error_message:simulator",
+                f"error_code:{InstallableAppErrorCode.SIMULATOR_BUILD.value}",
+                "error_message:",
                 "organization_id:test-org-id",
             ],
         )

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -156,14 +156,14 @@ class TestArtifactProcessorErrorHandling:
             artifact_id="test-artifact-id",
             data={
                 "error_code": InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE.value,
-                "error_message": "",
+                "error_message": "This artifact type is not supported for distribution.",
             },
         )
         mock_statsd.increment.assert_called_once_with(
             "distribution.processing.error",
             tags=[
                 f"error_code:{InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE.value}",
-                "error_message:",
+                "error_message:This artifact type is not supported for distribution.",
                 "organization_id:test-org-id",
             ],
         )
@@ -187,14 +187,14 @@ class TestArtifactProcessorErrorHandling:
             artifact_id="test-artifact-id",
             data={
                 "error_code": InstallableAppErrorCode.INVALID_CODE_SIGNATURE.value,
-                "error_message": "",
+                "error_message": "The build's code signature could not be verified.",
             },
         )
         mock_statsd.increment.assert_called_once_with(
             "distribution.processing.error",
             tags=[
                 f"error_code:{InstallableAppErrorCode.INVALID_CODE_SIGNATURE.value}",
-                "error_message:",
+                "error_message:The build's code signature could not be verified.",
                 "organization_id:test-org-id",
             ],
         )
@@ -219,14 +219,14 @@ class TestArtifactProcessorErrorHandling:
             artifact_id="test-artifact-id",
             data={
                 "error_code": InstallableAppErrorCode.SIMULATOR_BUILD.value,
-                "error_message": "",
+                "error_message": "Simulator builds cannot be distributed.",
             },
         )
         mock_statsd.increment.assert_called_once_with(
             "distribution.processing.error",
             tags=[
                 f"error_code:{InstallableAppErrorCode.SIMULATOR_BUILD.value}",
-                "error_message:",
+                "error_message:Simulator builds cannot be distributed.",
                 "organization_id:test-org-id",
             ],
         )


### PR DESCRIPTION
Mirror the new granular `InstallableAppErrorCode` values added in [getsentry/sentry#113440](https://github.com/getsentry/sentry/pull/113440), and emit them directly from `_do_distribution` instead of packing the reason into the free-form `error_message` string.

Before, when distribution was skipped for one of these reasons we sent `error_code=SKIPPED` (or `PROCESSING_ERROR`) plus a short-code string in `error_message` and the Sentry frontend had to pattern-match on those strings. After Sentry gained dedicated enum values for each case, launchpad emits the specific code paired with a human-readable sentence that the Sentry install page renders verbatim as the description:

| Case                        | Before                                        | After                                                                           |
| --------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------- |
| iOS signature invalid       | `SKIPPED` + `"invalid_signature"`             | `INVALID_CODE_SIGNATURE` + `"The build's code signature could not be verified."` |
| iOS simulator build         | `SKIPPED` + `"simulator"`                     | `SIMULATOR_BUILD` + `"Simulator builds cannot be distributed."`                 |
| Unrecognised artifact type  | `PROCESSING_ERROR` + `"unsupported artifact type"` | `UNSUPPORTED_ARTIFACT_TYPE` + `"This artifact type is not supported for distribution."` |

## Cleanup

- Drop the `error_message` tag from the `distribution.processing.error` statsd metric. `error_code` is the pivot dimension; `error_message` is 1:1 with the code today and interpolating a variable into it later would silently explode metric cardinality. The log line and PUT body still carry the message.
- Correct the class-name references in the enum sync comments (`InstallableApp.ErrorCode` → `PreprodArtifact.InstallableAppErrorCode`) and spell out why the invariant matters — drift will 400 on Sentry's pydantic validation.

Refs EME-883