### PR TITLE
fix(workflows): Drop injectable args, let sentry-cli auto-detect VCS

### DIFF
--- a/.github/workflows/sentry_dogfood.yml
+++ b/.github/workflows/sentry_dogfood.yml
@@ -21,10 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Sentry CLI
-        run: |
-          curl -L -o sentry-cli https://github.com/getsentry/sentry-cli/releases/download/3.4.1/sentry-cli-Darwin-universal
-          chmod +x sentry-cli
-          sudo mv sentry-cli /usr/local/bin/
+        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.4.1" sh
 
       - name: Unzip iOS app
         run: |

--- a/.github/workflows/sentry_dogfood.yml
+++ b/.github/workflows/sentry_dogfood.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Sentry CLI
         run: |
-          curl -L -o sentry-cli https://github.com/getsentry/sentry-cli/releases/download/2.53.0-alpha/sentry-cli-Darwin-universal
+          curl -L -o sentry-cli https://github.com/getsentry/sentry-cli/releases/download/3.4.1/sentry-cli-Darwin-universal
           chmod +x sentry-cli
           sudo mv sentry-cli /usr/local/bin/
 

--- a/.github/workflows/sentry_dogfood.yml
+++ b/.github/workflows/sentry_dogfood.yml
@@ -33,73 +33,21 @@ jobs:
           mv "$EXTRACTED_PATH" ./HackerNews.xcarchive
 
       - name: Upload iOS app to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            sentry-cli \
-             --log-level=debug \
-             --auth-token ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }} \
-             build \
-             upload \
-             ./HackerNews.xcarchive \
-             --org sentry \
-             --project launchpad-test-ios \
-             --head-sha ${{ github.event.pull_request.head.sha }} \
-             --base-sha ${{ github.event.pull_request.base.sha }} \
-             --vcs-provider github \
-             --head-repo-name ${{ github.repository }} \
-             --base-repo-name ${{ github.repository }} \
-             --head-ref ${{ github.head_ref }} \
-             --base-ref ${{ github.base_ref }} \
-             --pr-number ${{ github.event.number }} \
-             --build-configuration Release
-          else
-            sentry-cli \
-             --log-level=debug \
-             --auth-token ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }} \
-             build \
-             upload \
-             ./HackerNews.xcarchive \
-             --org sentry \
-             --project launchpad-test-ios \
-             --head-sha ${{ github.sha }} \
-             --vcs-provider github \
-             --head-repo-name ${{ github.repository }} \
-             --head-ref ${{ github.ref_name }} \
-             --build-configuration Release
-          fi
+          sentry-cli --log-level=debug build upload \
+            ./HackerNews.xcarchive \
+            --org sentry \
+            --project launchpad-test-ios \
+            --build-configuration Release
 
       - name: Upload Android app to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            sentry-cli \
-             --log-level=debug \
-             --auth-token ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }} \
-             build \
-             upload \
-             ./tests/_fixtures/android/hn.aab \
-             --org sentry \
-             --project launchpad-test-android \
-             --head-sha ${{ github.event.pull_request.head.sha }} \
-             --base-sha ${{ github.event.pull_request.base.sha }} \
-             --vcs-provider github \
-             --head-repo-name ${{ github.repository }} \
-             --base-repo-name ${{ github.repository }} \
-             --head-ref ${{ github.head_ref }} \
-             --base-ref ${{ github.base_ref }} \
-             --pr-number ${{ github.event.number }} \
-             --build-configuration Release
-          else
-            sentry-cli \
-             --log-level=debug \
-             --auth-token ${{ secrets.SENTRY_SENTRY_AUTH_TOKEN }} \
-             build \
-             upload \
-             ./tests/_fixtures/android/hn.aab \
-             --org sentry \
-             --project launchpad-test-android \
-             --head-sha ${{ github.sha }} \
-             --vcs-provider github \
-             --head-repo-name ${{ github.repository }} \
-             --head-ref ${{ github.ref_name }} \
-             --build-configuration Release
-          fi
+          sentry-cli --log-level=debug build upload \
+            ./tests/_fixtures/android/hn.aab \
+            --org sentry \
+            --project launchpad-test-android \
+            --build-configuration Release


### PR DESCRIPTION
## Summary

Alternate fix to #607 for the script injection vulnerability in the Sentry Dogfood workflow.

Rather than moving every `${{ github.* }}` interpolation into an `env:` block, this PR removes the arguments entirely. `sentry-cli`'s `collect_git_metadata` auto-detects all of them when running in CI.

This eliminates the injection vector by construction — there is no untrusted input in any `run:` block — and collapses the workflow from ~95 lines of conditional branching to ~14 lines of straight-line invocation.

## Related

- Original fix: #607
- Linear: [VULN-1590](https://linear.app/getsentry/issue/VULN-1590)

🤖 Generated with [Claude Code](https://claude.com/claude-code)