### PR TITLE
chore(tasks) Use a shared taskbroker container

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -5,6 +5,13 @@ x-sentry-service-config:
   dependencies:
     launchpad:
       description: Service that powers preprod artifact analysis
+    taskbroker:
+      description: Taskbroker gRPC server
+      remote:
+        repo_name: taskbroker
+        branch: main
+        repo_link: https://github.com/getsentry/taskbroker.git
+        mode: containerized
   modes:
     default: []
     containerized: [launchpad]


### PR DESCRIPTION
Align with sentry + seer usage of taskbroker as a shared local development service. I tested this locally with

```
devservices up taskbroker
make worker
```

The worker was able to connect to the taskbroker that was running.

Refs STREAM-874