### PR TITLE
perf(docker): Reduce image size by ~800 MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && \
     curl \
     git \
     build-essential \
-    openjdk-17-jdk \
+    openjdk-17-jre-headless \
     unzip \
     zip \
     file \
@@ -66,7 +66,11 @@ WORKDIR /app
 
 # Copy requirements and install Python dependencies
 COPY requirements.txt requirements-dev.txt ./
-RUN pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+RUN if [ "$TEST_BUILD" = "true" ]; then \
+    pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt; \
+    else \
+    pip install --no-cache-dir -r requirements.txt; \
+    fi
 
 # Copy source code, tests, and scripts
 COPY src/ ./src/
@@ -98,7 +102,8 @@ RUN if [ "$TEST_BUILD" = "true" ]; then \
 
 RUN pip install -e .
 
-RUN python scripts/deps --install --local-architecture=x86_64 --local-system=linux
+RUN python scripts/deps --install --local-architecture=x86_64 --local-system=linux && \
+    rm -rf /app/.devenv
 
 # Change ownership to app user
 RUN chown -R app:app /app


### PR DESCRIPTION
Three low-risk changes to reduce the Docker image size (~3.19 GB → ~2.4 GB):

1. **Switch `openjdk-17-jdk` to `openjdk-17-jre-headless`** (~250 MB) — only `java` and `keytool` are needed at runtime, both included in JRE-headless
2. **Skip dev dependencies in production builds** (~150-200 MB) — `requirements-dev.txt` (pytest, ruff, memray, bandit, etc.) is now only installed when `TEST_BUILD=true`, which `docker-compose.e2e.yml` already sets
3. **Clean up `.devenv/` after `scripts/deps --install`** (~400 MB) — runtime binaries are copied to `/usr/local/bin/` by `--install`, but the downloads and extractions in `.devenv/` were left behind in the image

This is the first step toward getting the image under 500 MB for self-hosted (GH-610). Further reductions (multi-stage build to remove build-essential, `.dockerignore`, unused pip packages) can follow.

Fixes #610