### PR TITLE
perf(docker): Add dockerignore file to improve start up speed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.devenv/
+output/
+.venv/
+venv/
+.git/
+__pycache__/
+*.pyc
+*.egg-info/
+.pytest_cache/
+.ty_cache/
+.DS_Store


### PR DESCRIPTION
Add `.dockerignore` to exclude large directories (`.devenv/`, `output/`, `.venv/`, `.git/`, `__pycache__/`) from the Docker build context.

None of these are referenced by any `COPY` instruction in the Dockerfile — they just get sent to the daemon and discarded. This cuts ~4.8 GB from the build context, making builds start significantly faster.

No change to the final image.

Refs #610