### PR TITLE
feat(worker): Add explicit logging and error reporting for processing timeouts

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -147,7 +147,7 @@ class ArtifactProcessor:
                 logger.error(
                     f"Processing timed out for artifact {artifact_id} (project: {project_id}, org: {organization_id}) after {duration:.2f}s"
                 )
-                artifact_processor._update_size_error(
+                artifact_processor._update_artifact_error(
                     organization_id,
                     project_id,
                     artifact_id,

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -20,6 +20,7 @@ from objectstore_client import (
     Usecase,
 )
 from objectstore_client.metadata import TimeToLive
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from launchpad.api.update_api_models import AndroidAppInfo as AndroidAppInfoModel
 from launchpad.api.update_api_models import AppleAppInfo as AppleAppInfoModel
@@ -139,6 +140,21 @@ class ArtifactProcessor:
             logger.info(f"Processing artifact {artifact_id} (project: {project_id}, org: {organization_id})")
             try:
                 artifact_type = artifact_processor.process_artifact(organization_id, project_id, artifact_id)
+            except ProcessingDeadlineExceeded:
+                statsd.increment("artifact.processing.failed")
+                statsd.increment("artifact.processing.timeout")
+                duration = time.time() - start_time
+                logger.error(
+                    f"Processing timed out for artifact {artifact_id} (project: {project_id}, org: {organization_id}) after {duration:.2f}s"
+                )
+                artifact_processor._update_size_error(
+                    organization_id,
+                    project_id,
+                    artifact_id,
+                    ProcessingErrorCode.ARTIFACT_PROCESSING_TIMEOUT,
+                    ProcessingErrorMessage.PROCESSING_TIMEOUT,
+                )
+                raise
             except Exception:
                 statsd.increment("artifact.processing.failed")
                 duration = time.time() - start_time


### PR DESCRIPTION
`ProcessingDeadlineExceeded` extends `BaseException`, not `Exception`, so the
existing `except Exception` handler in `process_message` never caught timeouts.
When a build hit the 12-minute processing deadline, launchpad produced zero
logs and never reported the failure back to Sentry — the artifact stayed in
`PROCESSING` state until the hourly `detect_expired_preprod_artifacts` cron
picked it up (up to ~90 minutes later in the worst case).

This adds an explicit `except ProcessingDeadlineExceeded` handler that:
- Logs an error with artifact/project/org IDs and duration
- Emits `artifact.processing.failed` and `artifact.processing.timeout` metrics
- Reports the timeout to Sentry immediately via `_update_size_error` with
  `ARTIFACT_PROCESSING_TIMEOUT`, so the artifact is marked failed right away
- Re-raises so taskbroker's handler still runs (Sentry SDK capture + task
  marked as FAILURE)