### PR TITLE
perf(size): Bump timeout 12min->15min

### DIFF
--- a/src/launchpad/worker/tasks.py
+++ b/src/launchpad/worker/tasks.py
@@ -5,7 +5,7 @@ from .app import app
 
 logger = get_logger(__name__)
 
-default = app.taskregistry.create_namespace("default", processing_deadline_duration=60 * 12)
+default = app.taskregistry.create_namespace("default", processing_deadline_duration=60 * 15)
 
 
 @default.register(name="process_artifact")


### PR DESCRIPTION
Bump the default task processing deadline from 12 minutes to 15 minutes.

With the addition of image optimization analysis (#614), large apps with
thousands of images can take longer to process. The 12-minute deadline was
causing timeouts on these larger artifacts before analysis could complete.
The 15-minute ceiling gives the worker enough headroom to finish while still
bounding runaway tasks.