### PR TITLE
perf(size): Adjust image optimization timeout to 4min + prioritize largest images first

### DIFF
--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -47,7 +47,7 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
     TARGET_JPEG_QUALITY = 85
     TARGET_HEIC_QUALITY = 85
     _MAX_WORKERS = 4
-    _TIMEOUT_SECONDS = 300
+    _TIMEOUT_SECONDS = 240
 
     @abstractmethod
     def _find_images(self, input: InsightsInput) -> List[FileInfo]:
@@ -73,6 +73,7 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
         files = self._find_images(input)
         if not files:
             return None
+        files.sort(key=lambda f: f.size, reverse=True)
 
         results: List[OptimizableImageFile] = []
         timed_out = False


### PR DESCRIPTION
## Summary

- Reduce image optimization timeout from 5min to 4min to better fit within the overall analysis time budget
- Sort images by size (largest first) before processing, so the highest-impact optimizations are analyzed first if the timeout is reached

This ensures that when the insight times out, we've already captured the biggest potential savings rather than spending time on small images that may never surface meaningful recommendations.