### PR TITLE
ref(worker): Rename artifact_id tag to preprod_artifact_id

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -133,7 +133,7 @@ class ArtifactProcessor:
             scope = stack.enter_context(sentry_sdk.new_scope())
             scope.set_tag("launchpad.project_id", project_id)
             scope.set_tag("launchpad.organization_id", organization_id)
-            scope.set_tag("launchpad.artifact_id", artifact_id)
+            scope.set_tag("launchpad.preprod_artifact_id", artifact_id)
             stack.enter_context(scope.start_transaction(op="subprocess", name="launchpad.process_message"))
             statsd.increment("artifact.processing.started")
             logger.info(f"Processing artifact {artifact_id} (project: {project_id}, org: {organization_id})")


### PR DESCRIPTION
Rename the Sentry tag from `launchpad.artifact_id` to `launchpad.preprod_artifact_id` to distinguish preprod artifacts from other artifact types in observability data.

This makes the tag name more precise, avoiding ambiguity as we add support for additional artifact types that also have artifact IDs.