### PR TITLE
chore(devenv): Escapes percent signs to fix `devenv sync`

### DIFF
--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -6,13 +6,13 @@ editable =
   .
 
 [python3.14.5]
-darwin_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%2B20260510-x86_64-apple-darwin-install_only.tar.gz
+darwin_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%%2B20260510-x86_64-apple-darwin-install_only.tar.gz
 darwin_x86_64_sha256 = 3f9e5535449001be140b9421b9c0b9b46478f182d9569f2a4e3efe74ae14f5ed
-darwin_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%2B20260510-aarch64-apple-darwin-install_only.tar.gz
+darwin_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%%2B20260510-aarch64-apple-darwin-install_only.tar.gz
 darwin_arm64_sha256 = 53ab0f338f508356a5e169316972c3a2cf3553fef3f20ff18512e253342d29db
-linux_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%2B20260510-x86_64-unknown-linux-gnu-install_only.tar.gz
+linux_x86_64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%%2B20260510-x86_64-unknown-linux-gnu-install_only.tar.gz
 linux_x86_64_sha256 = b3916b829fb0bc9efe93e800e6738a629ee4ade4aad798378d9326f4a0bac2db
-linux_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%2B20260510-aarch64-unknown-linux-gnu-install_only.tar.gz
+linux_arm64 = https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5%%2B20260510-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = aa63daf3aff8360baf6888c24fb5dde155f0895f3d83eb9ddf172ba5c6c17c33
 
 [uv]


### PR DESCRIPTION
boom