### PR TITLE
chore(tasks) Remove metrics prefix from taskworker runtime

### DIFF
--- a/src/launchpad/worker/app.py
+++ b/src/launchpad/worker/app.py
@@ -34,7 +34,6 @@ def create_metrics() -> MetricsBackend:
         processing_pool="launchpad",
         statsd_host=host,
         statsd_port=port,
-        enable_prefixed_metrics=True,
     )
 
 


### PR DESCRIPTION
Stop emitting `launchpad.taskworker.*` metrics, and only emit `taskworker.*` metrics.

I've gone through the emerge dashboards and updated any metrics that are changing.

Refs STREAM-1173