### PR TITLE
ref: Remove unused HEALTHCHECK_MAX_AGE_SECONDS constant

### DIFF
--- a/src/launchpad/constants.py
+++ b/src/launchpad/constants.py
@@ -42,10 +42,6 @@ class InstallableAppErrorCode(Enum):
     UNSUPPORTED_ARTIFACT_TYPE = 8
 
 
-# Health check threshold - consider unhealthy if file not touched in 60 seconds
-HEALTHCHECK_MAX_AGE_SECONDS = 60.0
-
-
 class ProcessingErrorMessage(Enum):
     """Fixed set of error messages for artifact processing."""
 


### PR DESCRIPTION
## Summary

`HEALTHCHECK_MAX_AGE_SECONDS` is a leftover from the Kafka-era file-touch healthcheck. It has been unreferenced anywhere in the codebase since the HTTP server was removed during the TaskBroker migration.

The worker's health check is now handled by TaskBroker via the `health_check_file_path` mechanism (`/tmp/health`), so this constant serves no purpose.

## Context

Companion cleanup to the ops-repo removal of launchpad's dead HTTP ingress (getsentry/ops#21502). This is the launchpad-side dead-config counterpart.

## Verification

- `grep` confirms the only occurrence was the definition itself.
- `make check` passes (lint, format, types, deps).