### PR TITLE
ref(gocd): Deploy image from multi-region registry

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -5,5 +5,5 @@ eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/get-cluster-credentials \
 && k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
-  --image="us-central1-docker.pkg.dev/sentryio/launchpad/image:${GO_REVISION_LAUNCHPAD_REPO}" \
+  --image="us-docker.pkg.dev/sentryio/launchpad-mr/image:${GO_REVISION_LAUNCHPAD_REPO}" \
   --container-name="launchpad"


### PR DESCRIPTION
Pull the launchpad deploy image from the multi-region `launchpad-mr` Artifact Registry repo (`us-docker.pkg.dev/sentryio/launchpad-mr/image`) instead of the single-region `us-central1` repo.

Images are already published to `launchpad-mr` by the cloudbuild pipeline (`cloudbuild.yaml`). This flips the deploy pin to pull from multi-region.

Companion ops PR updates the materialized-manifest fallback to match.

Agent transcript: https://claudescope.sentry.dev/share/82KA6VGkSekgITejrXEZnYW3bIJQBAgF-9bM5sTeOBU