### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/workflows/sentry_dogfood.yml
+++ b/.github/workflows/sentry_dogfood.yml
@@ -21,7 +21,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Sentry CLI
-        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.4.1" sh
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
+        with:
+          version: "3.4.1"
 
       - name: Unzip iOS app
         run: |


### PR DESCRIPTION
## Summary
- The "Install Sentry CLI" step in `sentry_dogfood.yml` used `curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.4.1" sh`, piping a remote install script directly into a shell.
- Replaced it with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.
- Same pinned version (`3.4.1`) preserved via the action's `version` input.

## Test plan
- [x] Validated `sentry_dogfood.yml` parses correctly
- [ ] Verify the job still installs sentry-cli 3.4.1 and uploads the iOS app correctly on this PR

Fixes VULN-2195

🤖 Generated with [Claude Code](https://claude.com/claude-code)