### PR TITLE
ref: add more spans to investigate long processing times

### DIFF
--- a/src/launchpad/artifacts/android/aab.py
+++ b/src/launchpad/artifacts/android/aab.py
@@ -86,25 +86,30 @@ class AAB(AndroidArtifact):
         apks_dir = create_temp_directory("apks-")
         try:
             bundletool = Bundletool()
-            bundletool.build_apks(bundle_path=self.path, output_dir=apks_dir, device_spec=device_spec)
+            with sentry_sdk.start_span(op="aab", description="aab.build_primary_apks"):
+                bundletool.build_apks(bundle_path=self.path, output_dir=apks_dir, device_spec=device_spec)
 
             apks = []
             for apk_path in apks_dir.glob("*.apk"):
                 tmp_dir = Path(tempfile.mkdtemp())
                 new_apk_path = tmp_dir / apk_path.name
-                shutil.copyfile(apk_path, new_apk_path)
-                apks.append(
-                    APK(
-                        new_apk_path,
-                        self.get_dex_mapping(),
-                        cleanup=lambda: shutil.rmtree(tmp_dir),
+                with sentry_sdk.start_span(op="file.copy", description="aab.copy_primary_apk") as span:
+                    span.set_data("apk.size", apk_path.stat().st_size)
+                    shutil.copyfile(apk_path, new_apk_path)
+                with sentry_sdk.start_span(op="aab", description="aab.initialize_primary_apk"):
+                    apks.append(
+                        APK(
+                            new_apk_path,
+                            self.get_dex_mapping(),
+                            cleanup=lambda: shutil.rmtree(tmp_dir),
+                        )
                     )
-                )
 
             self._primary_apks = apks
             return apks
         finally:
-            cleanup_directory(apks_dir)
+            with sentry_sdk.start_span(op="file.cleanup", description="aab.cleanup_primary_apks"):
+                cleanup_directory(apks_dir)
 
     @sentry_sdk.trace
     def get_universal_apk(self, apk_dir: Path, device_spec: DeviceSpec = DeviceSpec()) -> APK:

--- a/src/launchpad/artifacts/android/apk.py
+++ b/src/launchpad/artifacts/android/apk.py
@@ -38,7 +38,8 @@ class APK(AndroidArtifact):
         super().__init__(path, cleanup=cleanup)
         self._dex_mapping = dex_mapping
         self._zip_provider = ZipProvider(path)
-        self._extract_dir = self._zip_provider.extract_to_temp_directory()
+        with sentry_sdk.start_span(op="file.extract", description="apk.extract"):
+            self._extract_dir = self._zip_provider.extract_to_temp_directory()
         self._manifest: AndroidManifest | None = None
         self._resource_table: BinaryResourceTable | None = None
         self._class_definitions: list[ClassDefinition] | None = None

--- a/src/launchpad/size/analyzers/android.py
+++ b/src/launchpad/size/analyzers/android.py
@@ -4,6 +4,8 @@ import time
 
 from datetime import datetime, timezone
 
+import sentry_sdk
+
 from launchpad.artifacts.android.aab import AAB
 from launchpad.artifacts.android.apk import APK
 from launchpad.artifacts.android.zipped_aab import ZippedAAB
@@ -66,36 +68,45 @@ class AndroidAnalyzer:
 
         return self.app_info
 
+    @sentry_sdk.trace
     def analyze(self, artifact: AndroidArtifact) -> AndroidAnalysisResults:
         start_time = time.time()
         # Use preprocessed app info if available, otherwise extract it
         if not self.app_info:
-            self.app_info = self.preprocess(artifact)
+            with sentry_sdk.start_span(op="analyze", description="android.analyze.preprocess"):
+                self.app_info = self.preprocess(artifact)
 
         app_info = self.app_info
 
         apks: list[APK] = []
         # Split AAB into APKs, or use the APK directly
-        if isinstance(artifact, AAB):
-            apks = artifact.get_primary_apks()
-        elif isinstance(artifact, ZippedAAB):
-            apks = artifact.get_primary_apks()
-        elif isinstance(artifact, ZippedAPK):
-            apks.append(artifact.get_primary_apk())
-        elif isinstance(artifact, APK):
-            apks.append(artifact)
-        else:
-            raise ValueError(f"Unsupported artifact type: {type(artifact)}")
+        with sentry_sdk.start_span(op="analyze", description="android.analyze.get_primary_apks") as span:
+            span.set_data("artifact.type", type(artifact).__name__)
+            if isinstance(artifact, AAB):
+                apks = artifact.get_primary_apks()
+            elif isinstance(artifact, ZippedAAB):
+                apks = artifact.get_primary_apks()
+            elif isinstance(artifact, ZippedAPK):
+                apks.append(artifact.get_primary_apk())
+            elif isinstance(artifact, APK):
+                apks.append(artifact)
+            else:
+                raise ValueError(f"Unsupported artifact type: {type(artifact)}")
+            span.set_data("apk.count", len(apks))
 
         logger.debug("Found %d APKs", len(apks))
 
-        file_analysis = self._get_file_analysis(apks)
-        class_definitions = self._get_class_definitions(apks)
-        hermes_reports = self._get_hermes_reports(apks)
+        with sentry_sdk.start_span(op="analyze", description="android.analyze.file_analysis"):
+            file_analysis = self._get_file_analysis(apks)
+        with sentry_sdk.start_span(op="analyze", description="android.analyze.class_definitions"):
+            class_definitions = self._get_class_definitions(apks)
+        with sentry_sdk.start_span(op="analyze", description="android.analyze.hermes_reports"):
+            hermes_reports = self._get_hermes_reports(apks)
 
         # Calculate download and install sizes
         logger.debug("Calculating APK download and install sizes")
-        download_size, install_size = self._calculate_apk_sizes(apks)
+        with sentry_sdk.start_span(op="analyze", description="android.analyze.apk_sizes"):
+            download_size, install_size = self._calculate_apk_sizes(apks)
 
         # Generate insights BEFORE treemap so we can tag nodes with flagged insights
         insights: AndroidInsightResults | None = None
@@ -131,7 +142,8 @@ class AndroidAnalyzer:
         )
 
         logger.debug("Building file treemap")
-        treemap = treemap_builder.build_file_treemap(file_analysis)
+        with sentry_sdk.start_span(op="analyze", description="android.analyze.treemap"):
+            treemap = treemap_builder.build_file_treemap(file_analysis)
 
         analysis_duration = time.time() - start_time
         return AndroidAnalysisResults(


### PR DESCRIPTION
I'd like to understand why some jobs seem to take a surprisingly long time to process (e.g. have seen some where it's like 6 mins to process an apk, 2 mins to generate the dex mapping). This adds some more spans downstream of `analyze` to try and help explain that. The clankers were pretty eager about adding them... happy to cut down on some of them if this seems like too much.