### PR TITLE
perf: fix Android AAB cleanup and mapping cache

### DIFF
--- a/src/launchpad/artifacts/android/aab.py
+++ b/src/launchpad/artifacts/android/aab.py
@@ -149,7 +149,8 @@ class AAB(AndroidArtifact):
         dex_mapping_file = dex_mapping_files[0]
         with open(dex_mapping_file, "rb") as f:
             dex_mapping_buffer = f.read()
-        return DexMapping(dex_mapping_buffer)
+        self._dex_mapping = DexMapping(dex_mapping_buffer)
+        return self._dex_mapping
 
     @sentry_sdk.trace
     def get_app_icon(self) -> bytes | None:

--- a/src/launchpad/artifacts/android/aab.py
+++ b/src/launchpad/artifacts/android/aab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 import tempfile
 
+from functools import partial
 from pathlib import Path
 from typing import Callable
 
@@ -101,7 +102,7 @@ class AAB(AndroidArtifact):
                         APK(
                             new_apk_path,
                             self.get_dex_mapping(),
-                            cleanup=lambda: shutil.rmtree(tmp_dir),
+                            cleanup=partial(shutil.rmtree, tmp_dir),
                         )
                     )
 

--- a/tests/unit/artifacts/android/test_aab.py
+++ b/tests/unit/artifacts/android/test_aab.py
@@ -42,3 +42,9 @@ class TestAAB:
         with patch.object(test_aab, "get_manifest", return_value=malicious_manifest):
             with pytest.raises(UnsafePathError):
                 test_aab.get_app_icon()
+
+    def test_get_dex_mapping_caches_mapping(self, test_aab: AAB) -> None:
+        dex_mapping = test_aab.get_dex_mapping()
+
+        assert dex_mapping is not None
+        assert test_aab.get_dex_mapping() is dex_mapping


### PR DESCRIPTION
The `AAB` class contained a `_dex_mapping` field that was presumably intended to cache the results of computing the dex mapping. However, since it was never written to, when there were multiple APKs, the mapping would be re-computed for each one. This appears to in some cases waste a lot of time (e.g. see [this](https://sentry.sentry.io/explore/traces/trace/0ef18e37cd8d4dac88cc6c5c714cb6e2/?fov=1%2C438944.9997558594&mode=samples&node=span-9c4e14f4dc103ceb&project=4509667577233409&query=span.description%3A%EF%80%8DStartsWith%EF%80%8Dlaunchpad.size.analyzers.android.&sort=-timestamp&source=traces&statsPeriod=2h&tab=waterfall&targetId=a8b2d269611aa74a&timestamp=1786098081) case where we spent ~30s computing the mapping once, then did it 5 more times).

Also fixed an independent closure capture bug with APK cleanup logic.
