### PR TITLE
ref: record and collect some DEX processing stats

### DIFF
--- a/src/launchpad/artifacts/android/apk.py
+++ b/src/launchpad/artifacts/android/apk.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Callable, Iterator
@@ -15,7 +17,7 @@ from launchpad.parsers.android.icon.binary_xml_drawable_parser import (
 from launchpad.utils.android.apksigner import Apksigner
 
 from ...parsers.android.dex.dex_file_parser import DexFileParser
-from ...parsers.android.dex.types import ClassDefinition
+from ...parsers.android.dex.types import ClassDefinition, DexStats
 from ...utils.logging import get_logger
 from ..artifact import AndroidArtifact
 from ..providers.exceptions import UnsafePathError
@@ -99,16 +101,46 @@ class APK(AndroidArtifact):
 
         self._class_definitions = []
         dex_files = list(self._extract_dir.rglob("classes*.dex"))
+        dex_stats = DexStats()
         for dex_file in dex_files:
             try:
+                read_started_at = time.perf_counter()
                 with open(dex_file, "rb") as f:
                     dex_buffer = f.read()
-                dex_file_parser = DexFileParser(dex_buffer, self._dex_mapping)
+                dex_stats.read_duration_ms += (time.perf_counter() - read_started_at) * 1000
+
+                parser_started_at = time.perf_counter()
+                dex_file_parser = DexFileParser(
+                    dex_buffer,
+                    self._dex_mapping,
+                    stats=dex_stats,
+                )
                 class_definitions = dex_file_parser.get_class_definitions()
+                dex_stats.parser_duration_ms += (time.perf_counter() - parser_started_at) * 1000
                 self._class_definitions.extend(class_definitions)
             except (OSError, IOError) as e:
                 logger.error(f"Failed to read DEX file {dex_file}: {e}")
                 continue
+
+        if (span := sentry_sdk.get_current_span()) is not None:
+            span.set_data("dex_stats.file_count", dex_stats.file_count)
+            span.set_data("dex_stats.total_bytes", dex_stats.total_bytes)
+            span.set_data("dex_stats.read_duration_ms", dex_stats.read_duration_ms)
+            span.set_data("dex_stats.parser.duration_ms", dex_stats.parser_duration_ms)
+            span.set_data("dex_stats.parser.method_duration_ms", dex_stats.parser_method_duration_ms)
+            span.set_data("dex_stats.parser.field_duration_ms", dex_stats.parser_field_duration_ms)
+            span.set_data("dex_stats.parser.class_count", dex_stats.parser_class_count)
+            span.set_data("dex_stats.parser.method_count", dex_stats.parser_method_count)
+            span.set_data("dex_stats.parser.field_count", dex_stats.parser_field_count)
+            span.set_data(
+                "dex_stats.parser.method_annotation_scan_steps",
+                dex_stats.parser_method_annotation_scan_steps,
+            )
+            span.set_data(
+                "dex_stats.parser.field_annotation_scan_steps",
+                dex_stats.parser_field_annotation_scan_steps,
+            )
+            span.set_data("dex_stats.parser.mapping_present", dex_stats.parser_mapping_present)
 
         return self._class_definitions
 

--- a/src/launchpad/parsers/android/dex/dex_class_parser.py
+++ b/src/launchpad/parsers/android/dex/dex_class_parser.py
@@ -1,3 +1,5 @@
+import time
+
 from launchpad.parsers.android.dex.dex_base_utils import DexBaseUtils
 from launchpad.parsers.android.dex.dex_field_parser import DexFieldParser
 from launchpad.parsers.android.dex.dex_mapping import DexMapping
@@ -9,6 +11,7 @@ from launchpad.parsers.android.dex.types import (
     AnnotationsDirectory,
     ClassDefinition,
     DexFileHeader,
+    DexStats,
     Field,
     Method,
 )
@@ -22,10 +25,12 @@ class DexClassParser:
         buffer_wrapper: BufferWrapper,
         offset: int,
         dex_mapping: DexMapping | None = None,
+        stats: DexStats | None = None,
     ):
         self._header = header
         self._buffer_wrapper = buffer_wrapper
         self._offset = offset
+        self._stats = stats if stats is not None else DexStats()
         self._dex_mapping = dex_mapping
 
         # Cachable for later reuse
@@ -118,11 +123,15 @@ class DexClassParser:
         # Static values overhead
         size += self._get_static_values_overhead_size()
 
+        method_started_at = time.perf_counter()
         for method in self.get_methods():
             size += method.size
+        self._stats.parser_method_duration_ms += (time.perf_counter() - method_started_at) * 1000
 
+        field_started_at = time.perf_counter()
         for field in self.get_fields():
             size += field.size
+        self._stats.parser_field_duration_ms += (time.perf_counter() - field_started_at) * 1000
 
         return size
 
@@ -224,6 +233,7 @@ class DexClassParser:
             annotations = []
             if annotations_directory is not None:
                 for method_annotation in annotations_directory.method_annotations:
+                    self._stats.parser_method_annotation_scan_steps += 1
                     if method_annotation.method_index == method_index:
                         annotations = DexBaseUtils.get_annotation_set(
                             self._buffer_wrapper,
@@ -301,6 +311,7 @@ class DexClassParser:
             annotations = []
             if annotations_directory is not None:
                 for method_annotation in annotations_directory.method_annotations:
+                    self._stats.parser_method_annotation_scan_steps += 1
                     if method_annotation.method_index == method_index:
                         annotations = DexBaseUtils.get_annotation_set(
                             self._buffer_wrapper,
@@ -387,6 +398,7 @@ class DexClassParser:
             annotations = []
             if annotations_directory is not None:
                 for field_annotation in annotations_directory.field_annotations:
+                    self._stats.parser_field_annotation_scan_steps += 1
                     if field_annotation.field_index == field_index:
                         annotations = DexBaseUtils.get_annotation_set(
                             self._buffer_wrapper,
@@ -462,6 +474,7 @@ class DexClassParser:
             annotations = []
             if annotations_directory is not None:
                 for field_annotation in annotations_directory.field_annotations:
+                    self._stats.parser_field_annotation_scan_steps += 1
                     if field_annotation.field_index == field_index:
                         annotations = DexBaseUtils.get_annotation_set(
                             self._buffer_wrapper,

--- a/src/launchpad/parsers/android/dex/dex_file_parser.py
+++ b/src/launchpad/parsers/android/dex/dex_file_parser.py
@@ -5,6 +5,7 @@ from launchpad.parsers.android.dex.dex_class_parser import DexClassParser
 from launchpad.parsers.android.dex.dex_mapping import DexMapping
 from launchpad.parsers.android.dex.types import (
     ClassDefinition,
+    DexStats,
 )
 from launchpad.parsers.buffer_wrapper import BufferWrapper
 from launchpad.utils import logging
@@ -14,10 +15,19 @@ logger = logging.get_logger(__name__)
 
 # https://source.android.com/docs/core/runtime/dex-format
 class DexFileParser:
-    def __init__(self, buffer: bytes, dex_mapping: DexMapping | None = None):
+    def __init__(
+        self,
+        buffer: bytes,
+        dex_mapping: DexMapping | None = None,
+        stats: DexStats | None = None,
+    ):
         self._buffer_wrapper = BufferWrapper(buffer)
         self._header = DexBaseUtils.get_header(self._buffer_wrapper)
         self._dex_mapping = dex_mapping
+        self._stats = stats if stats is not None else DexStats()
+        self._stats.file_count += 1
+        self._stats.total_bytes += len(buffer)
+        self._stats.parser_mapping_present = self._stats.parser_mapping_present or dex_mapping is not None
 
     def get_class_definitions(self) -> list[ClassDefinition]:
         class_defs: list[ClassDefinition] = []
@@ -29,8 +39,13 @@ class DexFileParser:
                 buffer_wrapper=self._buffer_wrapper,
                 offset=offset,
                 dex_mapping=self._dex_mapping,
+                stats=self._stats,
             )
 
-            class_defs.append(class_parser.parse())
+            class_definition = class_parser.parse()
+            self._stats.parser_class_count += 1
+            self._stats.parser_method_count += len(class_definition.methods)
+            self._stats.parser_field_count += len(class_definition.fields)
+            class_defs.append(class_definition)
 
         return class_defs

--- a/src/launchpad/parsers/android/dex/types.py
+++ b/src/launchpad/parsers/android/dex/types.py
@@ -21,6 +21,22 @@ class DexFileHeader:
 
 
 @dataclass
+class DexStats:
+    file_count: int = 0
+    total_bytes: int = 0
+    read_duration_ms: float = 0.0
+    parser_duration_ms: float = 0.0
+    parser_method_duration_ms: float = 0.0
+    parser_field_duration_ms: float = 0.0
+    parser_class_count: int = 0
+    parser_method_count: int = 0
+    parser_field_count: int = 0
+    parser_method_annotation_scan_steps: int = 0
+    parser_field_annotation_scan_steps: int = 0
+    parser_mapping_present: bool = False
+
+
+@dataclass
 class Prototype:
     shorty_descriptor: str
     return_type: str


### PR DESCRIPTION
Gather some additional telemetry for DEX processing to help investigate why some jobs take multiple minutes to compute class definitions. Current speculative theory is that we have superlinear scaling when searching through method/field annotation lists, which may become problematic for large apps.