### PR TITLE
fix(demangle): Log cwl-demangle timeouts at warning, not error

### DIFF
--- a/src/launchpad/utils/apple/cwl_demangle.py
+++ b/src/launchpad/utils/apple/cwl_demangle.py
@@ -168,9 +168,7 @@ class CwlDemangler:
                 )
             except subprocess.TimeoutExpired:
                 elapsed = time.time() - start_time
-                logger.exception(
-                    "cwl-demangle subprocess timed out", extra={"chunk_idx": chunk_idx, "elapsed": elapsed}
-                )
+                logger.warning("cwl-demangle subprocess timed out", extra={"chunk_idx": chunk_idx, "elapsed": elapsed})
                 return {}
             except subprocess.CalledProcessError:
                 elapsed = time.time() - start_time


### PR DESCRIPTION
Downgrade the tolerated `cwl-demangle` `TimeoutExpired` log from `logger.exception` (ERROR) to `logger.warning` so these expected, non-fatal timeouts stop being captured as Sentry errors (LAUNCHPAD-6G, 16k+ occurrences).