### PR TITLE
perf(size): Parallelize Apple binary analysis across processes

### DIFF
--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -342,7 +342,7 @@ class ZippedXCArchive(AppleArtifact):
         watch_paths = self._discover_watch_binaries(app_bundle_path)
         all_binary_paths.extend(watch_paths)
 
-        # Phase 2: Parse and cache all binaries
+        # Phase 2: Extract UUIDs from all binaries
         self._extract_all_binary_uuids(all_binary_paths)
 
         # Phase 3: Build BinaryInfo objects using cached data
@@ -548,7 +548,7 @@ class ZippedXCArchive(AppleArtifact):
                 self._binary_uuid_cache[binary_path] = extracted_uuid
 
             except Exception:
-                logger.exception(f"Failed to parse and cache binary {binary_path}")
+                logger.exception(f"Failed to extract UUID from binary {binary_path}")
                 continue
 
     def _extract_binary_uuid(self, binary_path: Path) -> str | None:

--- a/src/launchpad/artifacts/apple/zipped_xcarchive.py
+++ b/src/launchpad/artifacts/apple/zipped_xcarchive.py
@@ -73,7 +73,6 @@ class ZippedXCArchive(AppleArtifact):
         self._provisioning_profile: dict[str, Any] | None = None
         self._dsym_info: dict[str, DsymInfo] | None = None
         self._binary_uuid_cache: dict[Path, str] = {}
-        self._lief_cache: dict[Path, lief.MachO.FatBinary] = {}
 
     def get_extract_dir(self) -> SafeDirectory:
         return self._extract_dir
@@ -344,7 +343,7 @@ class ZippedXCArchive(AppleArtifact):
         all_binary_paths.extend(watch_paths)
 
         # Phase 2: Parse and cache all binaries
-        self._parse_and_cache_all_binaries(all_binary_paths)
+        self._extract_all_binary_uuids(all_binary_paths)
 
         # Phase 3: Build BinaryInfo objects using cached data
         binaries: List[BinaryInfo] = []
@@ -366,10 +365,6 @@ class ZippedXCArchive(AppleArtifact):
         )
 
         return binaries
-
-    def get_lief_cache(self) -> dict[Path, lief.MachO.FatBinary]:
-        """Get the LIEF cache of pre-parsed binaries"""
-        return self._lief_cache
 
     @sentry_sdk.trace
     def get_asset_catalog_details(self, relative_path: Path) -> List[AssetCatalogElement]:
@@ -516,11 +511,7 @@ class ZippedXCArchive(AppleArtifact):
             scale=scale,
         )
 
-    def _parse_and_cache_all_binaries(self, binary_paths: List[Path]) -> None:
-        """Parse all binaries once, extracting UUIDs and caching LIEF objects for those with dSYMs."""
-        if self._dsym_info is None:
-            self._find_dsym_files()
-
+    def _extract_all_binary_uuids(self, binary_paths: List[Path]) -> None:
         config = lief.MachO.ParserConfig()
         config.parse_dyld_exports = False
         config.parse_dyld_bindings = False
@@ -555,12 +546,6 @@ class ZippedXCArchive(AppleArtifact):
                     continue
 
                 self._binary_uuid_cache[binary_path] = extracted_uuid
-
-                if extracted_uuid in self._dsym_info:
-                    self._lief_cache[binary_path] = fat_binary
-                    logger.debug(f"Cached LIEF object for {binary_path.name} (has dSYM)")
-                else:
-                    logger.debug(f"Skipped LIEF cache for {binary_path.name} (no dSYM)")
 
             except Exception:
                 logger.exception(f"Failed to parse and cache binary {binary_path}")

--- a/src/launchpad/artifacts/artifact.py
+++ b/src/launchpad/artifacts/artifact.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import Any, Callable
 
-import lief
-
 from launchpad.parsers.android.dex.dex_mapping import DexMapping
 
 from .android.manifest.manifest import AndroidManifest
@@ -51,10 +49,6 @@ class AppleArtifact(Artifact):
     def get_plist(self) -> dict[str, Any]:
         """Get the plist from the artifact."""
         raise NotImplementedError("Not implemented")
-
-    def get_lief_cache(self) -> dict[Path, lief.MachO.FatBinary]:
-        """Get the LIEF cache of pre-parsed binaries"""
-        return {}
 
     def generate_ipa(self, output_path: Path):
         raise NotImplementedError("Not implemented")

--- a/src/launchpad/sentry_sdk_init.py
+++ b/src/launchpad/sentry_sdk_init.py
@@ -20,9 +20,9 @@ from launchpad.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def initialize_sentry_sdk() -> None:
+def initialize_sentry_sdk(config: SentryConfig | None = None) -> None:
     """Initialize Sentry SDK with launchpad-specific configuration."""
-    config = get_sentry_config()
+    config = config or get_sentry_config()
 
     if config.environment.lower() in ("test", "development"):
         logger.debug(f"In {config.environment} environment, skipping Sentry SDK initialization")

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -67,8 +67,6 @@ logger = get_logger(__name__)
 
 
 def _binary_worker_init() -> None:
-    # Each binary already runs in its own worker; keep per-binary demangling serial so
-    # the outer pool doesn't multiply into dozens of concurrent cwl-demangle subprocesses.
     os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
 
 
@@ -78,7 +76,6 @@ def _force_kill_pool(executor: ProcessPoolExecutor) -> None:
             proc.kill()
         except Exception:
             pass
-    # Best-effort cleanup: never raise, or we'd mask the exception being re-raised at the call site.
     try:
         executor.shutdown(wait=False, cancel_futures=True)
     except Exception:
@@ -86,8 +83,6 @@ def _force_kill_pool(executor: ProcessPoolExecutor) -> None:
 
 
 def _run_and_time(analyze: Any, binary_info: BinaryInfo) -> Tuple[Any, float]:
-    # Time each binary inside the worker that runs it, so per-binary duration survives even
-    # though the parent emits the completed logs in a batch after all results return.
     start = time.monotonic()
     return analyze(binary_info), time.monotonic() - start
 
@@ -190,8 +185,6 @@ class AppleAppAnalyzer:
 
             if workers > 1:
                 logger.debug(f"Analyzing binaries in parallel with {workers} processes")
-                # Workers re-parse from disk (lief_cache=None), so the parent's cached LIEF
-                # trees are dead weight; drop them so they don't stay resident all run.
                 artifact.get_lief_cache().clear()
                 analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path, lief_cache=None)
                 executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
@@ -494,8 +487,6 @@ class AppleAppAnalyzer:
                 configured = 0
             if configured >= 1:
                 return min(configured, num_binaries)
-        # Match the worker pod's whole-core CPU request; os.cpu_count() reads node cores
-        # (no CPU limit set), which would oversubscribe. Override via the env var above.
         return min(4, num_binaries)
 
     def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import ctypes
 import gc
 import os
+import signal
+import sys
 import tempfile
 import time
 
+from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -62,6 +67,28 @@ from ..models.apple import (
 )
 
 logger = get_logger(__name__)
+
+
+def _binary_worker_init() -> None:
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
+        libc.prctl.restype = ctypes.c_int
+        PR_SET_PDEATHSIG = 1
+        libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
+    except Exception:
+        logger.debug("Could not set PR_SET_PDEATHSIG for binary worker", exc_info=True)
+
+
+def _force_kill_pool(executor: ProcessPoolExecutor) -> None:
+    for proc in list(getattr(executor, "_processes", {}).values()):
+        try:
+            proc.kill()
+        except Exception:
+            pass
+    executor.shutdown(wait=False, cancel_futures=True)
 
 
 class AppleAppAnalyzer:
@@ -155,37 +182,33 @@ class AppleAppAnalyzer:
             binaries = artifact.get_all_binary_paths()
             logger.debug(f"Found {len(binaries)} binaries to analyze")
 
-            lief_cache = artifact.get_lief_cache()
+            extract_dir = artifact.get_extract_dir()
+            workers = self._binary_analysis_worker_count(len(binaries))
             for binary_info in binaries:
-                logger.info(
-                    "size.apple.binary_analysis_started",
-                    extra={
-                        "event": "size.binary_analysis_started",
-                        "binary_name": binary_info.name,
-                        "binary_path": str(binary_info.path.relative_to(app_bundle_path)),
-                        "has_dsym": binary_info.dsym_path is not None,
-                    },
-                )
-                if binary_info.dsym_path:
-                    logger.debug(
-                        f"Found dSYM file for {binary_info.name} at {binary_info.dsym_path.relative_to(artifact.get_extract_dir())}"
-                    )
-                binary = self._analyze_binary(binary_info, app_bundle_path, lief_cache)
+                self._log_binary_started(binary_info, app_bundle_path, extract_dir)
+
+            if workers > 1:
+                logger.debug(f"Analyzing binaries in parallel with {workers} processes")
+                analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path, lief_cache=None)
+                executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
+                try:
+                    results = list(executor.map(analyze, binaries))
+                    executor.shutdown(wait=True)
+                except BaseException:
+                    _force_kill_pool(executor)
+                    raise
+            else:
+                lief_cache = artifact.get_lief_cache()
+                results = []
+                for binary_info in binaries:
+                    results.append(self._analyze_binary(binary_info, app_bundle_path, lief_cache))
+                    gc.collect()
+
+            for binary_info, binary in zip(binaries, results):
                 if binary is not None:
                     binary_analysis.append(binary)
                     binary_analysis_map[str(binary_info.path.relative_to(app_bundle_path))] = binary
-
-                logger.info(
-                    "size.apple.binary_analysis_completed",
-                    extra={
-                        "event": "size.binary_analysis_completed",
-                        "binary_name": binary_info.name,
-                        "symbol_count": (len(binary.symbol_info.symbol_sizes) if binary.symbol_info else 0),
-                        "swift_types_count": (len(binary.symbol_info.swift_type_groups) if binary.symbol_info else 0),
-                        "objc_types_count": (len(binary.symbol_info.objc_type_groups) if binary.symbol_info else 0),
-                    },
-                )
-                gc.collect()
+                    self._log_binary_completed(binary_info, binary)
 
             hermes_reports = make_hermes_reports(app_bundle_path)
 
@@ -453,6 +476,44 @@ class AppleAppAnalyzer:
                 extra={"insight": insight_name, "elapsed_s": round(time.monotonic() - started, 3)},
             )
             return result
+
+    def _binary_analysis_worker_count(self, num_binaries: int) -> int:
+        if num_binaries <= 1:
+            return 1
+        override = os.getenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS")
+        if override:
+            try:
+                configured = int(override)
+            except ValueError:
+                configured = 0
+            if configured >= 1:
+                return min(configured, num_binaries)
+        return min(8, os.cpu_count() or 1, num_binaries)
+
+    def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:
+        logger.info(
+            "size.apple.binary_analysis_started",
+            extra={
+                "event": "size.binary_analysis_started",
+                "binary_name": binary_info.name,
+                "binary_path": str(binary_info.path.relative_to(app_bundle_path)),
+                "has_dsym": binary_info.dsym_path is not None,
+            },
+        )
+        if binary_info.dsym_path:
+            logger.debug(f"Found dSYM file for {binary_info.name} at {binary_info.dsym_path.relative_to(extract_dir)}")
+
+    def _log_binary_completed(self, binary_info: BinaryInfo, binary: MachOBinaryAnalysis) -> None:
+        logger.info(
+            "size.apple.binary_analysis_completed",
+            extra={
+                "event": "size.binary_analysis_completed",
+                "binary_name": binary_info.name,
+                "symbol_count": (len(binary.symbol_info.symbol_sizes) if binary.symbol_info else 0),
+                "swift_types_count": (len(binary.symbol_info.swift_type_groups) if binary.symbol_info else 0),
+                "objc_types_count": (len(binary.symbol_info.objc_type_groups) if binary.symbol_info else 0),
+            },
+        )
 
     @sentry_sdk.trace
     def _analyze_binary(

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import os
 import tempfile
 import time
@@ -170,15 +171,22 @@ class AppleAppAnalyzer:
             for binary_info in binaries:
                 self._log_binary_started(binary_info, app_bundle_path, extract_dir)
 
-            logger.debug(f"Analyzing binaries with {workers} processes")
             analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path)
-            executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
-            try:
-                results = list(executor.map(partial(_run_and_time, analyze), binaries))
-                executor.shutdown(wait=True)
-            except BaseException:
-                executor.kill_workers()
-                raise
+            if workers > 0:
+                logger.debug(f"Analyzing binaries with {workers} processes")
+                executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
+                try:
+                    results = list(executor.map(partial(_run_and_time, analyze), binaries))
+                    executor.shutdown(wait=True)
+                except BaseException:
+                    executor.kill_workers()
+                    raise
+            else:
+                logger.debug("Analyzing binaries in-process")
+                results = []
+                for binary_info in binaries:
+                    results.append(_run_and_time(analyze, binary_info))
+                    gc.collect()
 
             for binary_info, (binary, elapsed) in zip(binaries, results):
                 if binary is not None:
@@ -458,7 +466,7 @@ class AppleAppAnalyzer:
             configured = int(os.getenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "4"))
         except ValueError:
             configured = 4
-        return max(1, min(configured, num_binaries))
+        return min(configured, num_binaries)
 
     def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:
         logger.info(

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -465,17 +465,11 @@ class AppleAppAnalyzer:
             return result
 
     def _binary_analysis_worker_count(self, num_binaries: int) -> int:
-        if num_binaries <= 1:
-            return 1
-        override = os.getenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS")
-        if override:
-            try:
-                configured = int(override)
-            except ValueError:
-                configured = 0
-            if configured >= 1:
-                return min(configured, num_binaries)
-        return min(4, num_binaries)
+        try:
+            configured = int(os.getenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "4"))
+        except ValueError:
+            configured = 4
+        return max(1, min(configured, num_binaries))
 
     def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:
         logger.info(

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -70,18 +70,6 @@ def _binary_worker_init() -> None:
     os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
 
 
-def _force_kill_pool(executor: ProcessPoolExecutor) -> None:
-    for proc in list(getattr(executor, "_processes", {}).values()):
-        try:
-            proc.kill()
-        except Exception:
-            pass
-    try:
-        executor.shutdown(wait=False, cancel_futures=True)
-    except Exception:
-        logger.debug("executor.shutdown during force-kill raised", exc_info=True)
-
-
 def _run_and_time(analyze: Any, binary_info: BinaryInfo) -> Tuple[Any, float]:
     start = time.monotonic()
     return analyze(binary_info), time.monotonic() - start
@@ -192,7 +180,7 @@ class AppleAppAnalyzer:
                     results = list(executor.map(partial(_run_and_time, analyze), binaries))
                     executor.shutdown(wait=True)
                 except BaseException:
-                    _force_kill_pool(executor)
+                    executor.kill_workers()
                     raise
             else:
                 lief_cache = artifact.get_lief_cache()

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -78,7 +78,11 @@ def _force_kill_pool(executor: ProcessPoolExecutor) -> None:
             proc.kill()
         except Exception:
             pass
-    executor.shutdown(wait=False, cancel_futures=True)
+    # Best-effort cleanup: never raise, or we'd mask the exception being re-raised at the call site.
+    try:
+        executor.shutdown(wait=False, cancel_futures=True)
+    except Exception:
+        logger.debug("executor.shutdown during force-kill raised", exc_info=True)
 
 
 class AppleAppAnalyzer:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import gc
+import logging
+import multiprocessing
 import os
 import tempfile
+import threading
 import time
 
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from functools import partial
+from logging.handlers import QueueHandler
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -45,6 +49,7 @@ from launchpad.size.treemap.treemap_builder import TreemapBuilder
 from launchpad.size.utils.apple_bundle_size import calculate_bundle_sizes
 from launchpad.size.utils.file_analysis import analyze_apple_files
 from launchpad.size.utils.insight_path_map import build_insight_path_map
+from launchpad.tracing import current_request_id
 from launchpad.utils.apple.apple_strip import AppleStrip
 from launchpad.utils.apple.code_signature_validator import CodeSignatureValidator
 from launchpad.utils.file_utils import get_file_size, to_nearest_block_size
@@ -66,13 +71,36 @@ from ..models.apple import (
 logger = get_logger(__name__)
 
 
-def _binary_worker_init() -> None:
+def _binary_worker_init(log_queue: multiprocessing.Queue[logging.LogRecord | None], log_level: int) -> None:
     os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
+    root = logging.getLogger()
+    root.handlers = [QueueHandler(log_queue)]
+    root.setLevel(log_level)
 
 
-def _run_and_time(analyze: Any, binary_info: BinaryInfo) -> Tuple[Any, float]:
-    start = time.monotonic()
-    return analyze(binary_info), time.monotonic() - start
+class _WorkerLogRelay:
+    def __init__(self) -> None:
+        self.queue: multiprocessing.Queue[logging.LogRecord | None] = multiprocessing.Queue()
+        self.level = logging.getLogger().getEffectiveLevel()
+        self._request_id = current_request_id()
+        self._thread = threading.Thread(target=self._drain, name="binary-analysis-log-relay", daemon=True)
+
+    def __enter__(self) -> _WorkerLogRelay:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.queue.put(None)
+        self._thread.join(timeout=2)
+
+    def _drain(self) -> None:
+        try:
+            while (record := self.queue.get()) is not None:
+                if self._request_id is not None:
+                    record.request_id = self._request_id
+                logging.getLogger(record.name).handle(record)
+        except Exception:
+            logger.debug("Worker log relay stopped", exc_info=True)
 
 
 class AppleAppAnalyzer:
@@ -166,33 +194,37 @@ class AppleAppAnalyzer:
             binaries = artifact.get_all_binary_paths()
             logger.debug(f"Found {len(binaries)} binaries to analyze")
 
-            extract_dir = artifact.get_extract_dir()
             workers = self._binary_analysis_worker_count(len(binaries))
-            for binary_info in binaries:
-                self._log_binary_started(binary_info, app_bundle_path, extract_dir)
-
-            analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path)
+            analyze = partial(
+                self._analyze_binary_logged,
+                app_bundle_path=app_bundle_path,
+                extract_dir=artifact.get_extract_dir(),
+            )
             if workers > 0:
                 logger.debug(f"Analyzing binaries with {workers} processes")
-                executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
-                try:
-                    results = list(executor.map(partial(_run_and_time, analyze), binaries))
-                    executor.shutdown(wait=True)
-                except BaseException:
-                    executor.kill_workers()
-                    raise
+                with _WorkerLogRelay() as relay:
+                    executor = ProcessPoolExecutor(
+                        max_workers=workers,
+                        initializer=_binary_worker_init,
+                        initargs=(relay.queue, relay.level),
+                    )
+                    try:
+                        results = list(executor.map(analyze, binaries))
+                        executor.shutdown(wait=True)
+                    except BaseException:
+                        executor.kill_workers()
+                        raise
             else:
                 logger.debug("Analyzing binaries in-process")
                 results = []
                 for binary_info in binaries:
-                    results.append(_run_and_time(analyze, binary_info))
+                    results.append(analyze(binary_info))
                     gc.collect()
 
-            for binary_info, (binary, elapsed) in zip(binaries, results):
+            for binary_info, binary in zip(binaries, results):
                 if binary is not None:
                     binary_analysis.append(binary)
                     binary_analysis_map[str(binary_info.path.relative_to(app_bundle_path))] = binary
-                    self._log_binary_completed(binary_info, binary, elapsed)
 
             hermes_reports = make_hermes_reports(app_bundle_path)
 
@@ -467,6 +499,16 @@ class AppleAppAnalyzer:
         except ValueError:
             configured = 4
         return min(configured, num_binaries)
+
+    def _analyze_binary_logged(
+        self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path
+    ) -> MachOBinaryAnalysis | None:
+        self._log_binary_started(binary_info, app_bundle_path, extract_dir)
+        start = time.monotonic()
+        binary = self._analyze_binary(binary_info, app_bundle_path)
+        if binary is not None:
+            self._log_binary_completed(binary_info, binary, time.monotonic() - start)
+        return binary
 
     def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:
         logger.info(

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -12,7 +12,7 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Tuple
 
 import lief
 import sentry_sdk
@@ -22,6 +22,7 @@ from sentry_sdk.utils import qualname_from_function
 
 from launchpad.artifacts.apple.zipped_xcarchive import BinaryInfo, ZippedXCArchive
 from launchpad.artifacts.artifact import AppleArtifact
+from launchpad.artifacts.providers.safe_directory import SafeDirectory
 from launchpad.parsers.apple.dwarf_relocations_parser import DwarfRelocationsParser
 from launchpad.parsers.apple.macho_parser import MachOParser, get_cpu_type_name
 from launchpad.sentry_sdk_init import SentryConfig, get_sentry_config, initialize_sentry_sdk
@@ -69,6 +70,8 @@ from ..models.apple import (
 
 logger = get_logger(__name__)
 
+_DEFAULT_BINARY_ANALYSIS_WORKERS = 4
+
 
 class _WorkerContext(NamedTuple):
     verbose: bool
@@ -78,12 +81,11 @@ class _WorkerContext(NamedTuple):
 
     @classmethod
     def capture(cls) -> _WorkerContext:
-        sentry_active = sentry_sdk.get_client().is_active() and os.getenv("LAUNCHPAD_ENV") is not None
         headers = {"sentry-trace": sentry_sdk.get_traceparent(), "baggage": sentry_sdk.get_baggage()}
         return cls(
             verbose=logging.getLogger().getEffectiveLevel() <= logging.DEBUG,
             request_id=current_request_id(),
-            sentry_config=get_sentry_config() if sentry_active else None,
+            sentry_config=get_sentry_config() if sentry_sdk.get_client().is_active() else None,
             trace_headers={k: v for k, v in headers.items() if v},
         )
 
@@ -98,7 +100,7 @@ def _binary_worker_init(context: _WorkerContext) -> None:
         sentry_sdk.continue_trace(context.trace_headers)
 
 
-def _analyze_and_flush(analyze: Any, binary_info: BinaryInfo) -> _TimedBinary:
+def _analyze_and_flush(analyze: Callable[[BinaryInfo], _TimedBinary], binary_info: BinaryInfo) -> _TimedBinary:
     try:
         return analyze(binary_info)
     finally:
@@ -223,10 +225,7 @@ class AppleAppAnalyzer:
                     raise
             else:
                 logger.debug("Analyzing binaries in-process")
-                results = []
-                for binary_info in binaries:
-                    results.append(analyze(binary_info))
-                    gc.collect()
+                results = [analyze(binary_info) for binary_info in binaries]
 
             for binary_info, timed in zip(binaries, results):
                 if workers > 0:
@@ -504,22 +503,24 @@ class AppleAppAnalyzer:
 
     def _binary_analysis_worker_count(self, num_binaries: int) -> int:
         try:
-            configured = int(os.getenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "4"))
+            configured = int(os.getenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", _DEFAULT_BINARY_ANALYSIS_WORKERS))
         except ValueError:
-            configured = 4
+            configured = _DEFAULT_BINARY_ANALYSIS_WORKERS
         return min(configured, num_binaries)
 
-    def _analyze_binary_logged(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> _TimedBinary:
+    def _analyze_binary_logged(
+        self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: SafeDirectory
+    ) -> _TimedBinary:
         self._log_binary_started(binary_info, app_bundle_path, extract_dir)
         started_at = time.time()
         start = time.monotonic()
         binary = self._analyze_binary(binary_info, app_bundle_path)
         elapsed_s = time.monotonic() - start
+        gc.collect()
         if binary is not None:
             self._log_binary_completed(binary_info, binary, elapsed_s)
         return _TimedBinary(binary, started_at, started_at + elapsed_s)
 
-    # Pool workers have no Sentry client, so rebuild the span @sentry_sdk.trace would have made.
     def _record_binary_span(self, binary_info: BinaryInfo, timed: _TimedBinary) -> None:
         span = sentry_sdk.start_span(
             op="function",
@@ -529,7 +530,7 @@ class AppleAppAnalyzer:
         span.set_data("binary_name", binary_info.name)
         span.finish(end_timestamp=timed.finished_at)
 
-    def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:
+    def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: SafeDirectory) -> None:
         logger.info(
             "size.apple.binary_analysis_started",
             extra={

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -104,21 +104,29 @@ class _WorkerLogRelay:
     def __exit__(self, *exc: object) -> None:
         self._stop.set()
         self._thread.join(timeout=2)
+        if self._thread.is_alive():
+            logger.warning("Worker log relay did not stop; a worker was likely killed mid-write")
 
     def _drain(self) -> None:
-        try:
-            while True:
-                try:
-                    record = self.queue.get(timeout=0.1)
-                except queue.Empty:
-                    if self._stop.is_set():
-                        return
+        while True:
+            try:
+                record = self.queue.get(timeout=0.1)
+            except queue.Empty:
+                if self._stop.is_set():
+                    return
+                continue
+            except Exception:
+                logger.warning("Dropped an undecodable worker log record", exc_info=True)
+                continue
+            try:
+                target = logging.getLogger(record.name)
+                if not target.isEnabledFor(record.levelno):
                     continue
                 if self._request_id is not None:
                     record.request_id = self._request_id
-                logging.getLogger(record.name).handle(record)
-        except Exception:
-            logger.debug("Worker log relay stopped", exc_info=True)
+                target.handle(record)
+            except Exception:
+                logger.warning("Failed to relay a worker log record", exc_info=True)
 
 
 class AppleAppAnalyzer:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import gc
 import os
 import tempfile
 import time
@@ -171,23 +170,15 @@ class AppleAppAnalyzer:
             for binary_info in binaries:
                 self._log_binary_started(binary_info, app_bundle_path, extract_dir)
 
-            if workers > 1:
-                logger.debug(f"Analyzing binaries in parallel with {workers} processes")
-                analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path)
-                executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
-                try:
-                    results = list(executor.map(partial(_run_and_time, analyze), binaries))
-                    executor.shutdown(wait=True)
-                except BaseException:
-                    executor.kill_workers()
-                    raise
-            else:
-                results = []
-                for binary_info in binaries:
-                    start = time.monotonic()
-                    result = self._analyze_binary(binary_info, app_bundle_path)
-                    results.append((result, time.monotonic() - start))
-                    gc.collect()
+            logger.debug(f"Analyzing binaries with {workers} processes")
+            analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path)
+            executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
+            try:
+                results = list(executor.map(partial(_run_and_time, analyze), binaries))
+                executor.shutdown(wait=True)
+            except BaseException:
+                executor.kill_workers()
+                raise
 
             for binary_info, (binary, elapsed) in zip(binaries, results):
                 if binary is not None:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import ctypes
 import gc
 import os
-import signal
-import sys
 import tempfile
 import time
 
@@ -73,18 +70,6 @@ def _binary_worker_init() -> None:
     # Each binary already runs in its own worker; keep per-binary demangling serial so
     # the outer pool doesn't multiply into dozens of concurrent cwl-demangle subprocesses.
     os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
-    if not sys.platform.startswith("linux"):
-        return
-    try:
-        libc = ctypes.CDLL(None, use_errno=True)
-        libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
-        libc.prctl.restype = ctypes.c_int
-        # Have the kernel SIGKILL this worker if the parent dies, so a worker wedged
-        # in a non-returning LIEF call can't orphan when parent-side cleanup never runs.
-        PR_SET_PDEATHSIG = 1
-        libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
-    except Exception:
-        logger.debug("Could not set PR_SET_PDEATHSIG for binary worker", exc_info=True)
 
 
 def _force_kill_pool(executor: ProcessPoolExecutor) -> None:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -6,6 +6,7 @@ import gc
 import logging
 import multiprocessing
 import os
+import queue
 import tempfile
 import threading
 import time
@@ -71,7 +72,7 @@ from ..models.apple import (
 logger = get_logger(__name__)
 
 
-def _binary_worker_init(log_queue: multiprocessing.Queue[logging.LogRecord | None], log_level: int) -> None:
+def _binary_worker_init(log_queue: multiprocessing.Queue[logging.LogRecord], log_level: int) -> None:
     os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
     root = logging.getLogger()
     root.handlers = [QueueHandler(log_queue)]
@@ -79,10 +80,14 @@ def _binary_worker_init(log_queue: multiprocessing.Queue[logging.LogRecord | Non
 
 
 class _WorkerLogRelay:
+    """Only workers ever write to the queue; the parent never does, so a worker SIGKILLed
+    mid-write cannot leave the parent blocked on the queue's shared write lock."""
+
     def __init__(self) -> None:
-        self.queue: multiprocessing.Queue[logging.LogRecord | None] = multiprocessing.Queue()
+        self.queue: multiprocessing.Queue[logging.LogRecord] = multiprocessing.Queue()
         self.level = logging.getLogger().getEffectiveLevel()
         self._request_id = current_request_id()
+        self._stop = threading.Event()
         self._thread = threading.Thread(target=self._drain, name="binary-analysis-log-relay", daemon=True)
 
     def __enter__(self) -> _WorkerLogRelay:
@@ -90,12 +95,18 @@ class _WorkerLogRelay:
         return self
 
     def __exit__(self, *exc: object) -> None:
-        self.queue.put(None)
+        self._stop.set()
         self._thread.join(timeout=2)
 
     def _drain(self) -> None:
         try:
-            while (record := self.queue.get()) is not None:
+            while True:
+                try:
+                    record = self.queue.get(timeout=0.1)
+                except queue.Empty:
+                    if self._stop.is_set():
+                        return
+                    continue
                 if self._request_id is not None:
                     record.request_id = self._request_id
                 logging.getLogger(record.name).handle(record)

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -173,8 +173,7 @@ class AppleAppAnalyzer:
 
             if workers > 1:
                 logger.debug(f"Analyzing binaries in parallel with {workers} processes")
-                artifact.get_lief_cache().clear()
-                analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path, lief_cache=None)
+                analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path)
                 executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
                 try:
                     results = list(executor.map(partial(_run_and_time, analyze), binaries))
@@ -183,11 +182,10 @@ class AppleAppAnalyzer:
                     executor.kill_workers()
                     raise
             else:
-                lief_cache = artifact.get_lief_cache()
                 results = []
                 for binary_info in binaries:
                     start = time.monotonic()
-                    result = self._analyze_binary(binary_info, app_bundle_path, lief_cache)
+                    result = self._analyze_binary(binary_info, app_bundle_path)
                     results.append((result, time.monotonic() - start))
                     gc.collect()
 
@@ -502,7 +500,6 @@ class AppleAppAnalyzer:
         self,
         binary_info: BinaryInfo,
         app_bundle_path: Path,
-        lief_cache: dict[Path, lief.MachO.FatBinary] | None = None,
         skip_swift_metadata: bool = False,
     ) -> MachOBinaryAnalysis | None:
         binary_path = binary_info.path
@@ -515,18 +512,13 @@ class AppleAppAnalyzer:
 
         logger.debug(f"Analyzing binary: {binary_path}")
 
-        # Only binaries with dSYMs are pre-cached. Pop from cache to free memory immediately.
-        # Binaries without dSYMs will be parsed on-demand here.
-        fat_binary = lief_cache.pop(binary_path, None) if lief_cache else None
-        if fat_binary is None:
-            logger.debug(f"Binary not in LIEF cache, parsing now: {binary_path.name}")
-            with open(binary_path, "rb") as f:
-                config = lief.MachO.ParserConfig()
-                config.parse_dyld_exports = False
-                config.parse_dyld_bindings = False
-                config.parse_dyld_rebases = False
+        with open(binary_path, "rb") as f:
+            config = lief.MachO.ParserConfig()
+            config.parse_dyld_exports = False
+            config.parse_dyld_bindings = False
+            config.parse_dyld_rebases = False
 
-                fat_binary = lief.MachO.parse(f, config)  # type: ignore
+            fat_binary = lief.MachO.parse(f, config)  # type: ignore
 
         if fat_binary is None or fat_binary.size == 0:
             raise RuntimeError(f"Failed to parse binary with LIEF: {binary_path}")

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -4,17 +4,13 @@ from __future__ import annotations
 
 import gc
 import logging
-import multiprocessing
 import os
-import queue
 import tempfile
-import threading
 import time
 
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from functools import partial
-from logging.handlers import QueueHandler
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Tuple
 
@@ -28,6 +24,7 @@ from launchpad.artifacts.apple.zipped_xcarchive import BinaryInfo, ZippedXCArchi
 from launchpad.artifacts.artifact import AppleArtifact
 from launchpad.parsers.apple.dwarf_relocations_parser import DwarfRelocationsParser
 from launchpad.parsers.apple.macho_parser import MachOParser, get_cpu_type_name
+from launchpad.sentry_sdk_init import SentryConfig, get_sentry_config, initialize_sentry_sdk
 from launchpad.size.constants import APPLE_FILESYSTEM_BLOCK_SIZE
 from launchpad.size.hermes.reporter import HermesReport
 from launchpad.size.hermes.utils import make_hermes_reports
@@ -51,11 +48,11 @@ from launchpad.size.treemap.treemap_builder import TreemapBuilder
 from launchpad.size.utils.apple_bundle_size import calculate_bundle_sizes
 from launchpad.size.utils.file_analysis import analyze_apple_files
 from launchpad.size.utils.insight_path_map import build_insight_path_map
-from launchpad.tracing import current_request_id
+from launchpad.tracing import bind_request_id, current_request_id
 from launchpad.utils.apple.apple_strip import AppleStrip
 from launchpad.utils.apple.code_signature_validator import CodeSignatureValidator
 from launchpad.utils.file_utils import get_file_size, to_nearest_block_size
-from launchpad.utils.logging import get_logger
+from launchpad.utils.logging import get_logger, setup_logging
 from launchpad.utils.metadata_extractor import extract_metadata_from_zip
 
 from ..models.apple import (
@@ -73,60 +70,45 @@ from ..models.apple import (
 logger = get_logger(__name__)
 
 
-def _binary_worker_init(log_queue: multiprocessing.Queue[logging.LogRecord], log_level: int) -> None:
+class _WorkerContext(NamedTuple):
+    verbose: bool
+    request_id: str | None
+    sentry_config: SentryConfig | None
+    trace_headers: dict[str, str]
+
+    @classmethod
+    def capture(cls) -> _WorkerContext:
+        sentry_active = sentry_sdk.get_client().is_active() and os.getenv("LAUNCHPAD_ENV") is not None
+        headers = {"sentry-trace": sentry_sdk.get_traceparent(), "baggage": sentry_sdk.get_baggage()}
+        return cls(
+            verbose=logging.getLogger().getEffectiveLevel() <= logging.DEBUG,
+            request_id=current_request_id(),
+            sentry_config=get_sentry_config() if sentry_active else None,
+            trace_headers={k: v for k, v in headers.items() if v},
+        )
+
+
+def _binary_worker_init(context: _WorkerContext) -> None:
     os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
-    root = logging.getLogger()
-    root.handlers = [QueueHandler(log_queue)]
-    root.setLevel(log_level)
+    setup_logging(verbose=context.verbose)
+    if context.request_id is not None:
+        bind_request_id(context.request_id)
+    if context.sentry_config is not None:
+        initialize_sentry_sdk(context.sentry_config)
+        sentry_sdk.continue_trace(context.trace_headers)
+
+
+def _analyze_and_flush(analyze: Any, binary_info: BinaryInfo) -> _TimedBinary:
+    try:
+        return analyze(binary_info)
+    finally:
+        sentry_sdk.flush(timeout=2)
 
 
 class _TimedBinary(NamedTuple):
     binary: MachOBinaryAnalysis | None
     started_at: float
     finished_at: float
-
-
-class _WorkerLogRelay:
-    """Only workers ever write to the queue; the parent never does, so a worker SIGKILLed
-    mid-write cannot leave the parent blocked on the queue's shared write lock."""
-
-    def __init__(self) -> None:
-        self.queue: multiprocessing.Queue[logging.LogRecord] = multiprocessing.Queue()
-        self.level = logging.getLogger().getEffectiveLevel()
-        self._request_id = current_request_id()
-        self._stop = threading.Event()
-        self._thread = threading.Thread(target=self._drain, name="binary-analysis-log-relay", daemon=True)
-
-    def __enter__(self) -> _WorkerLogRelay:
-        self._thread.start()
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        self._stop.set()
-        self._thread.join(timeout=2)
-        if self._thread.is_alive():
-            logger.warning("Worker log relay did not stop; a worker was likely killed mid-write")
-
-    def _drain(self) -> None:
-        while True:
-            try:
-                record = self.queue.get(timeout=0.1)
-            except queue.Empty:
-                if self._stop.is_set():
-                    return
-                continue
-            except Exception:
-                logger.warning("Dropped an undecodable worker log record", exc_info=True)
-                continue
-            try:
-                target = logging.getLogger(record.name)
-                if not target.isEnabledFor(record.levelno):
-                    continue
-                if self._request_id is not None:
-                    record.request_id = self._request_id
-                target.handle(record)
-            except Exception:
-                logger.warning("Failed to relay a worker log record", exc_info=True)
 
 
 class AppleAppAnalyzer:
@@ -228,18 +210,17 @@ class AppleAppAnalyzer:
             )
             if workers > 0:
                 logger.debug(f"Analyzing binaries with {workers} processes")
-                with _WorkerLogRelay() as relay:
-                    executor = ProcessPoolExecutor(
-                        max_workers=workers,
-                        initializer=_binary_worker_init,
-                        initargs=(relay.queue, relay.level),
-                    )
-                    try:
-                        results = list(executor.map(analyze, binaries))
-                        executor.shutdown(wait=True)
-                    except BaseException:
-                        executor.kill_workers()
-                        raise
+                executor = ProcessPoolExecutor(
+                    max_workers=workers,
+                    initializer=_binary_worker_init,
+                    initargs=(_WorkerContext.capture(),),
+                )
+                try:
+                    results = list(executor.map(partial(_analyze_and_flush, analyze), binaries))
+                    executor.shutdown(wait=True)
+                except BaseException:
+                    executor.kill_workers()
+                    raise
             else:
                 logger.debug("Analyzing binaries in-process")
                 results = []

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -70,6 +70,9 @@ logger = get_logger(__name__)
 
 
 def _binary_worker_init() -> None:
+    # Each binary already runs in its own worker; keep per-binary demangling serial so
+    # the outer pool doesn't multiply into dozens of concurrent cwl-demangle subprocesses.
+    os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
     if not sys.platform.startswith("linux"):
         return
     try:
@@ -191,6 +194,9 @@ class AppleAppAnalyzer:
 
             if workers > 1:
                 logger.debug(f"Analyzing binaries in parallel with {workers} processes")
+                # Workers re-parse from disk (lief_cache=None), so the parent's cached LIEF
+                # trees are dead weight; drop them so they don't stay resident all run.
+                artifact.get_lief_cache().clear()
                 analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path, lief_cache=None)
                 executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
                 try:
@@ -490,7 +496,9 @@ class AppleAppAnalyzer:
                 configured = 0
             if configured >= 1:
                 return min(configured, num_binaries)
-        return min(8, os.cpu_count() or 1, num_binaries)
+        # Match the worker pod's whole-core CPU request; os.cpu_count() reads node cores
+        # (no CPU limit set), which would oversubscribe. Override via the env var above.
+        return min(4, num_binaries)
 
     def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:
         logger.info(

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -16,12 +16,13 @@ from datetime import datetime
 from functools import partial
 from logging.handlers import QueueHandler
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, NamedTuple, Tuple
 
 import lief
 import sentry_sdk
 
 from cryptography import x509
+from sentry_sdk.utils import qualname_from_function
 
 from launchpad.artifacts.apple.zipped_xcarchive import BinaryInfo, ZippedXCArchive
 from launchpad.artifacts.artifact import AppleArtifact
@@ -77,6 +78,12 @@ def _binary_worker_init(log_queue: multiprocessing.Queue[logging.LogRecord], log
     root = logging.getLogger()
     root.handlers = [QueueHandler(log_queue)]
     root.setLevel(log_level)
+
+
+class _TimedBinary(NamedTuple):
+    binary: MachOBinaryAnalysis | None
+    started_at: float
+    finished_at: float
 
 
 class _WorkerLogRelay:
@@ -232,10 +239,12 @@ class AppleAppAnalyzer:
                     results.append(analyze(binary_info))
                     gc.collect()
 
-            for binary_info, binary in zip(binaries, results):
-                if binary is not None:
-                    binary_analysis.append(binary)
-                    binary_analysis_map[str(binary_info.path.relative_to(app_bundle_path))] = binary
+            for binary_info, timed in zip(binaries, results):
+                if workers > 0:
+                    self._record_binary_span(binary_info, timed)
+                if timed.binary is not None:
+                    binary_analysis.append(timed.binary)
+                    binary_analysis_map[str(binary_info.path.relative_to(app_bundle_path))] = timed.binary
 
             hermes_reports = make_hermes_reports(app_bundle_path)
 
@@ -511,15 +520,24 @@ class AppleAppAnalyzer:
             configured = 4
         return min(configured, num_binaries)
 
-    def _analyze_binary_logged(
-        self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path
-    ) -> MachOBinaryAnalysis | None:
+    def _analyze_binary_logged(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> _TimedBinary:
         self._log_binary_started(binary_info, app_bundle_path, extract_dir)
-        start = time.monotonic()
+        started_at = time.time()
         binary = self._analyze_binary(binary_info, app_bundle_path)
+        finished_at = time.time()
         if binary is not None:
-            self._log_binary_completed(binary_info, binary, time.monotonic() - start)
-        return binary
+            self._log_binary_completed(binary_info, binary, finished_at - started_at)
+        return _TimedBinary(binary, started_at, finished_at)
+
+    # Pool workers have no Sentry client, so rebuild the span @sentry_sdk.trace would have made.
+    def _record_binary_span(self, binary_info: BinaryInfo, timed: _TimedBinary) -> None:
+        span = sentry_sdk.start_span(
+            op="function",
+            name=qualname_from_function(self._analyze_binary),
+            start_timestamp=timed.started_at,
+        )
+        span.set_data("binary_name", binary_info.name)
+        span.finish(end_timestamp=timed.finished_at)
 
     def _log_binary_started(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> None:
         logger.info(

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -531,11 +531,12 @@ class AppleAppAnalyzer:
     def _analyze_binary_logged(self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: Path) -> _TimedBinary:
         self._log_binary_started(binary_info, app_bundle_path, extract_dir)
         started_at = time.time()
+        start = time.monotonic()
         binary = self._analyze_binary(binary_info, app_bundle_path)
-        finished_at = time.time()
+        elapsed_s = time.monotonic() - start
         if binary is not None:
-            self._log_binary_completed(binary_info, binary, finished_at - started_at)
-        return _TimedBinary(binary, started_at, finished_at)
+            self._log_binary_completed(binary_info, binary, elapsed_s)
+        return _TimedBinary(binary, started_at, started_at + elapsed_s)
 
     # Pool workers have no Sentry client, so rebuild the span @sentry_sdk.trace would have made.
     def _record_binary_span(self, binary_info: BinaryInfo, timed: _TimedBinary) -> None:

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -85,6 +85,13 @@ def _force_kill_pool(executor: ProcessPoolExecutor) -> None:
         logger.debug("executor.shutdown during force-kill raised", exc_info=True)
 
 
+def _run_and_time(analyze: Any, binary_info: BinaryInfo) -> Tuple[Any, float]:
+    # Time each binary inside the worker that runs it, so per-binary duration survives even
+    # though the parent emits the completed logs in a batch after all results return.
+    start = time.monotonic()
+    return analyze(binary_info), time.monotonic() - start
+
+
 class AppleAppAnalyzer:
     """Analyzer for Apple app bundles (.xcarchive directories)."""
 
@@ -189,7 +196,7 @@ class AppleAppAnalyzer:
                 analyze = partial(self._analyze_binary, app_bundle_path=app_bundle_path, lief_cache=None)
                 executor = ProcessPoolExecutor(max_workers=workers, initializer=_binary_worker_init)
                 try:
-                    results = list(executor.map(analyze, binaries))
+                    results = list(executor.map(partial(_run_and_time, analyze), binaries))
                     executor.shutdown(wait=True)
                 except BaseException:
                     _force_kill_pool(executor)
@@ -198,14 +205,16 @@ class AppleAppAnalyzer:
                 lief_cache = artifact.get_lief_cache()
                 results = []
                 for binary_info in binaries:
-                    results.append(self._analyze_binary(binary_info, app_bundle_path, lief_cache))
+                    start = time.monotonic()
+                    result = self._analyze_binary(binary_info, app_bundle_path, lief_cache)
+                    results.append((result, time.monotonic() - start))
                     gc.collect()
 
-            for binary_info, binary in zip(binaries, results):
+            for binary_info, (binary, elapsed) in zip(binaries, results):
                 if binary is not None:
                     binary_analysis.append(binary)
                     binary_analysis_map[str(binary_info.path.relative_to(app_bundle_path))] = binary
-                    self._log_binary_completed(binary_info, binary)
+                    self._log_binary_completed(binary_info, binary, elapsed)
 
             hermes_reports = make_hermes_reports(app_bundle_path)
 
@@ -502,12 +511,13 @@ class AppleAppAnalyzer:
         if binary_info.dsym_path:
             logger.debug(f"Found dSYM file for {binary_info.name} at {binary_info.dsym_path.relative_to(extract_dir)}")
 
-    def _log_binary_completed(self, binary_info: BinaryInfo, binary: MachOBinaryAnalysis) -> None:
+    def _log_binary_completed(self, binary_info: BinaryInfo, binary: MachOBinaryAnalysis, elapsed_s: float) -> None:
         logger.info(
             "size.apple.binary_analysis_completed",
             extra={
                 "event": "size.binary_analysis_completed",
                 "binary_name": binary_info.name,
+                "elapsed_s": round(elapsed_s, 3),
                 "symbol_count": (len(binary.symbol_info.symbol_sizes) if binary.symbol_info else 0),
                 "swift_types_count": (len(binary.symbol_info.swift_type_groups) if binary.symbol_info else 0),
                 "objc_types_count": (len(binary.symbol_info.objc_type_groups) if binary.symbol_info else 0),

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -76,6 +76,8 @@ def _binary_worker_init() -> None:
         libc = ctypes.CDLL(None, use_errno=True)
         libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
         libc.prctl.restype = ctypes.c_int
+        # Have the kernel SIGKILL this worker if the parent dies, so a worker wedged
+        # in a non-returning LIEF call can't orphan when parent-side cleanup never runs.
         PR_SET_PDEATHSIG = 1
         libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
     except Exception:

--- a/src/launchpad/tracing.py
+++ b/src/launchpad/tracing.py
@@ -21,6 +21,10 @@ def current_request_id() -> str | None:
     return _request_id.get(None)
 
 
+def bind_request_id(request_id: str) -> None:
+    _request_id.set(request_id)
+
+
 class RequestLogFilter:
     """Logging filter that adds request_id to log records.."""
 

--- a/src/launchpad/tracing.py
+++ b/src/launchpad/tracing.py
@@ -17,6 +17,10 @@ def request_context():
         _request_id.reset(token)
 
 
+def current_request_id() -> str | None:
+    return _request_id.get(None)
+
+
 class RequestLogFilter:
     """Logging filter that adds request_id to log records.."""
 

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -99,7 +99,7 @@ class TestAppleAppSizes:
     def test_binary_worker_count(self) -> None:
         analyzer = AppleAppAnalyzer()
         assert analyzer._binary_analysis_worker_count(1) == 1
-        assert analyzer._binary_analysis_worker_count(0) == 1
+        assert analyzer._binary_analysis_worker_count(0) == 0
         assert analyzer._binary_analysis_worker_count(100) == 4
         assert analyzer._binary_analysis_worker_count(2) == 2
 
@@ -110,24 +110,26 @@ class TestAppleAppSizes:
         assert analyzer._binary_analysis_worker_count(2) == 2  # capped at num binaries
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "1")
         assert analyzer._binary_analysis_worker_count(100) == 1
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "0")
+        assert analyzer._binary_analysis_worker_count(100) == 0
 
-    def test_binary_analysis_output_independent_of_worker_count(
+    def test_parallel_binary_analysis_matches_in_process(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "1")
-        one_worker = AppleAppAnalyzer(skip_treemap=False).analyze(
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "0")
+        in_process = AppleAppAnalyzer(skip_treemap=False).analyze(
             cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
         )
 
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "4")
-        four_workers = AppleAppAnalyzer(skip_treemap=False).analyze(
+        parallel = AppleAppAnalyzer(skip_treemap=False).analyze(
             cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
         )
 
-        assert one_worker.install_size == four_workers.install_size
-        assert one_worker.download_size == four_workers.download_size
-        assert one_worker.treemap is not None and four_workers.treemap is not None
-        assert one_worker.treemap.model_dump_json() == four_workers.treemap.model_dump_json()
+        assert in_process.install_size == parallel.install_size
+        assert in_process.download_size == parallel.download_size
+        assert in_process.treemap is not None and parallel.treemap is not None
+        assert in_process.treemap.model_dump_json() == parallel.treemap.model_dump_json()
 
     def test_parallel_binary_analysis_under_forkserver(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -183,6 +183,19 @@ class TestAppleAppSizes:
         assert results.treemap is not None
         assert results.install_size > 0
 
+    def test_binary_completed_log_includes_elapsed(self) -> None:
+        """Per-binary duration must survive parallelization via an elapsed_s log field."""
+        from unittest.mock import Mock, patch
+
+        binary_info = Mock()
+        binary_info.name = "Foo"
+        binary = Mock(symbol_info=None)
+
+        with patch.object(apple.logger, "info") as info:
+            AppleAppAnalyzer()._log_binary_completed(binary_info, binary, 1.23456)
+
+        assert info.call_args.kwargs["extra"]["elapsed_s"] == 1.235
+
     def test_apple_app_sizes(self, hackernews_xcarchive: Path) -> None:
         """Test that treemap structure matches reference report."""
 

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -1,11 +1,13 @@
 import functools
+import gzip
+import http.server
+import io
 import json
 import logging
 import multiprocessing as mp
 import os
 import plistlib
 import threading
-import time
 
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -27,6 +29,46 @@ from launchpad.size.models.common import ComponentType
 from launchpad.tracing import current_request_id, request_context
 
 
+class _SentryIngestStub:
+    """Minimal local stand-in for Sentry's envelope endpoint."""
+
+    def __init__(self) -> None:
+        self.envelopes: list[Envelope] = []
+        stub = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                body = self.rfile.read(int(self.headers["Content-Length"]))
+                if self.headers.get("Content-Encoding") == "gzip":
+                    body = gzip.decompress(body)
+                stub.envelopes.append(Envelope.deserialize_from(io.BytesIO(body)))
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *_args: object) -> None:
+                pass
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.dsn = f"http://key@127.0.0.1:{self._server.server_port}/1"
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> _SentryIngestStub:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._server.shutdown()
+
+    def log_items(self) -> list[dict[str, Any]]:
+        return [
+            log
+            for envelope in self.envelopes
+            for item in envelope.items
+            if item.headers.get("type") == "log"
+            for log in json.loads(item.get_bytes())["items"]
+        ]
+
+
 class _CapturingTransport(sentry_sdk.transport.Transport):
     def __init__(self) -> None:
         super().__init__()
@@ -41,12 +83,6 @@ class _CapturingTransport(sentry_sdk.transport.Transport):
 def _log_suppressed_and_allowed(_: int) -> None:
     logging.getLogger("lief").info("noisy third-party")
     logging.getLogger("launchpad.size.analyzers.apple").info("allowed")
-
-
-def _log_forever(i: int) -> None:
-    log = logging.getLogger("launchpad.size.analyzers.apple")
-    while True:
-        log.info("tick %d", i)
 
 
 @pytest.fixture
@@ -179,15 +215,15 @@ class TestAppleAppSizes:
         assert results.treemap is not None
         assert results.install_size > 0
 
-    def test_worker_logs_relay_to_parent_with_request_id(
-        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    def test_worker_logs_reach_stdout_with_request_id(
+        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
     ) -> None:
-        """Per-binary logs are emitted inside pool workers, which have no logging config of
-        their own; they must reach the parent's handlers stamped with the parent's request id."""
-        ctx = mp.get_context("forkserver")
+        """Pool workers configure their own logging and write to the inherited stdout, so their
+        per-binary lines must carry the parent's request id. Uses spawn rather than forkserver
+        because the forkserver inherits stdout once at startup, before capfd redirects it."""
+        ctx = mp.get_context("spawn")
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
-        caplog.set_level(logging.INFO)
 
         with request_context():
             request_id = current_request_id()
@@ -195,11 +231,50 @@ class TestAppleAppSizes:
                 cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
             )
 
-        completed = [r for r in caplog.records if r.getMessage() == "size.apple.binary_analysis_completed"]
+        lines = [json.loads(line) for line in capfd.readouterr().out.splitlines() if line.startswith("{")]
+        completed = [d for d in lines if d["message"] == "size.apple.binary_analysis_completed"]
         assert completed
-        assert all(r.process != os.getpid() for r in completed)
-        assert all(getattr(r, "request_id", None) == request_id for r in completed)
-        assert all(isinstance(getattr(r, "elapsed_s", None), float) for r in completed)
+        assert all(d["request_id"] == request_id for d in completed)
+        assert all(isinstance(d["elapsed_s"], float) for d in completed)
+
+    def test_worker_logging_applies_third_party_suppression(self, capfd: pytest.CaptureFixture[str]) -> None:
+        ctx = mp.get_context("spawn")
+        context = apple._WorkerContext(verbose=False, request_id=None, sentry_config=None, trace_headers={})
+        with ProcessPoolExecutor(
+            max_workers=1, mp_context=ctx, initializer=apple._binary_worker_init, initargs=(context,)
+        ) as executor:
+            executor.submit(_log_suppressed_and_allowed, 0).result()
+
+        out = capfd.readouterr().out
+        assert "allowed" in out
+        assert "noisy third-party" not in out
+
+    def test_worker_logs_are_sent_to_sentry_under_parent_trace(
+        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Workers run their own Sentry client; their log records must arrive at the ingest
+        endpoint carrying the parent's trace id."""
+        ctx = mp.get_context("forkserver")
+        monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
+        with _SentryIngestStub() as stub:
+            monkeypatch.setenv("LAUNCHPAD_ENV", "integration")
+            monkeypatch.setenv("SENTRY_DSN", stub.dsn)
+            monkeypatch.setenv("SENTRY_REGION", "test")
+            sentry_sdk.init(dsn=stub.dsn, traces_sample_rate=1.0, enable_logs=True)
+            try:
+                with sentry_sdk.start_transaction(name="test") as transaction:
+                    AppleAppAnalyzer(skip_treemap=False).analyze(
+                        cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
+                    )
+                sentry_sdk.flush()
+            finally:
+                sentry_sdk.get_global_scope().set_client(None)
+
+        worker_logs = [item for item in stub.log_items() if item["body"] == "size.apple.binary_analysis_completed"]
+        assert worker_logs
+        assert all(item["trace_id"] == transaction.trace_id for item in worker_logs)
+        assert all(item["attributes"]["process.pid"]["value"] != os.getpid() for item in worker_logs)
 
     def test_parallel_binary_spans_reattach_to_parent_transaction(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
@@ -232,50 +307,6 @@ class TestAppleAppSizes:
         assert any(
             a is not b and a["start_timestamp"] < b["start_timestamp"] < a["timestamp"] for a in spans for b in spans
         )
-
-    def test_worker_log_relay_honors_parent_logger_levels(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Logger.handle skips level checks, so relayed records must be gated on the parent's
-        per-logger levels or setup_logging's third-party suppression would not apply to workers."""
-        caplog.set_level(logging.INFO)
-        logging.getLogger("lief").setLevel(logging.WARNING)
-        ctx = mp.get_context("forkserver")
-        with apple._WorkerLogRelay() as relay:
-            with ProcessPoolExecutor(
-                max_workers=1,
-                mp_context=ctx,
-                initializer=apple._binary_worker_init,
-                initargs=(relay.queue, relay.level),
-            ) as executor:
-                executor.submit(_log_suppressed_and_allowed, 0).result()
-
-        messages = [r.getMessage() for r in caplog.records]
-        assert "allowed" in messages
-        assert "noisy third-party" not in messages
-
-    def test_worker_log_relay_exits_cleanly_after_killing_workers(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Simulates the deadline path: workers SIGKILLed mid-log must not leave the parent
-        blocked on the shared log queue or with a feeder thread that would hang interpreter exit."""
-        caplog.set_level(logging.INFO)
-        ctx = mp.get_context("forkserver")
-        started = time.monotonic()
-        with apple._WorkerLogRelay() as relay:
-            executor = ProcessPoolExecutor(
-                max_workers=2,
-                mp_context=ctx,
-                initializer=apple._binary_worker_init,
-                initargs=(relay.queue, relay.level),
-            )
-            for i in range(2):
-                executor.submit(_log_forever, i)
-            deadline = time.monotonic() + 10
-            while not any(r.getMessage().startswith("tick") for r in caplog.records) and time.monotonic() < deadline:
-                time.sleep(0.05)
-            assert any(r.getMessage().startswith("tick") for r in caplog.records)
-            executor.kill_workers()
-
-        assert time.monotonic() - started < 15
-        assert not relay._thread.is_alive()
-        assert not any(t.name == "QueueFeederThread" for t in threading.enumerate())
 
     def test_binary_completed_log_includes_elapsed(self) -> None:
         """Per-binary duration must survive parallelization via an elapsed_s log field."""

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -3,6 +3,8 @@ import logging
 import multiprocessing as mp
 import os
 import plistlib
+import threading
+import time
 
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -18,6 +20,12 @@ from launchpad.size.analyzers import apple
 from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.common import ComponentType
 from launchpad.tracing import current_request_id, request_context
+
+
+def _log_forever(i: int) -> None:
+    log = logging.getLogger("launchpad.size.analyzers.apple")
+    while True:
+        log.info("tick %d", i)
 
 
 @pytest.fixture
@@ -171,6 +179,31 @@ class TestAppleAppSizes:
         assert all(r.process != os.getpid() for r in completed)
         assert all(getattr(r, "request_id", None) == request_id for r in completed)
         assert all(isinstance(getattr(r, "elapsed_s", None), float) for r in completed)
+
+    def test_worker_log_relay_exits_cleanly_after_killing_workers(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Simulates the deadline path: workers SIGKILLed mid-log must not leave the parent
+        blocked on the shared log queue or with a feeder thread that would hang interpreter exit."""
+        caplog.set_level(logging.INFO)
+        ctx = mp.get_context("forkserver")
+        started = time.monotonic()
+        with apple._WorkerLogRelay() as relay:
+            executor = ProcessPoolExecutor(
+                max_workers=2,
+                mp_context=ctx,
+                initializer=apple._binary_worker_init,
+                initargs=(relay.queue, relay.level),
+            )
+            for i in range(2):
+                executor.submit(_log_forever, i)
+            deadline = time.monotonic() + 10
+            while not any(r.getMessage().startswith("tick") for r in caplog.records) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert any(r.getMessage().startswith("tick") for r in caplog.records)
+            executor.kill_workers()
+
+        assert time.monotonic() - started < 15
+        assert not relay._thread.is_alive()
+        assert not any(t.name == "QueueFeederThread" for t in threading.enumerate())
 
     def test_binary_completed_log_includes_elapsed(self) -> None:
         """Per-binary duration must survive parallelization via an elapsed_s log field."""

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -38,6 +38,11 @@ class _CapturingTransport(sentry_sdk.transport.Transport):
                 self.transactions.append(json.loads(item.get_bytes()))
 
 
+def _log_suppressed_and_allowed(_: int) -> None:
+    logging.getLogger("lief").info("noisy third-party")
+    logging.getLogger("launchpad.size.analyzers.apple").info("allowed")
+
+
 def _log_forever(i: int) -> None:
     log = logging.getLogger("launchpad.size.analyzers.apple")
     while True:
@@ -227,6 +232,25 @@ class TestAppleAppSizes:
         assert any(
             a is not b and a["start_timestamp"] < b["start_timestamp"] < a["timestamp"] for a in spans for b in spans
         )
+
+    def test_worker_log_relay_honors_parent_logger_levels(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Logger.handle skips level checks, so relayed records must be gated on the parent's
+        per-logger levels or setup_logging's third-party suppression would not apply to workers."""
+        caplog.set_level(logging.INFO)
+        logging.getLogger("lief").setLevel(logging.WARNING)
+        ctx = mp.get_context("forkserver")
+        with apple._WorkerLogRelay() as relay:
+            with ProcessPoolExecutor(
+                max_workers=1,
+                mp_context=ctx,
+                initializer=apple._binary_worker_init,
+                initargs=(relay.queue, relay.level),
+            ) as executor:
+                executor.submit(_log_suppressed_and_allowed, 0).result()
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert "allowed" in messages
+        assert "noisy third-party" not in messages
 
     def test_worker_log_relay_exits_cleanly_after_killing_workers(self, caplog: pytest.LogCaptureFixture) -> None:
         """Simulates the deadline path: workers SIGKILLed mid-log must not leave the parent

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -1,5 +1,9 @@
+import multiprocessing as mp
 import plistlib
+import signal
+import time
 
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Callable, cast
 from unittest.mock import patch
@@ -9,8 +13,15 @@ import pytest
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import AppleArtifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
-from launchpad.size.analyzers.apple import AppleAppAnalyzer
+from launchpad.size.analyzers.apple import AppleAppAnalyzer, _force_kill_pool
 from launchpad.size.models.common import ComponentType
+
+
+def _sigterm_ignoring_busy_loop(*_args: object) -> None:
+    """Models a worker wedged in a native call: SIGTERM is ignored, spins forever."""
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    while True:
+        pass
 
 
 @pytest.fixture
@@ -91,6 +102,66 @@ class TestAppleAppSizes:
         assert args[0] == "size.apple.insight_completed"
         assert kwargs["extra"]["insight"] == "dummy"
         assert "elapsed_s" in kwargs["extra"]
+
+    def test_binary_worker_count(self) -> None:
+        analyzer = AppleAppAnalyzer()
+        assert analyzer._binary_analysis_worker_count(1) == 1
+        assert analyzer._binary_analysis_worker_count(0) == 1
+        assert analyzer._binary_analysis_worker_count(100) >= 1
+        assert analyzer._binary_analysis_worker_count(100) <= 8
+
+    def test_binary_worker_count_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        analyzer = AppleAppAnalyzer()
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "3")
+        assert analyzer._binary_analysis_worker_count(100) == 3
+        assert analyzer._binary_analysis_worker_count(2) == 2  # capped at num binaries
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "1")
+        assert analyzer._binary_analysis_worker_count(100) == 1
+
+    def test_parallel_binary_analysis_matches_serial(
+        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Toggling the worker count must not change analysis output."""
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "1")
+        serial = AppleAppAnalyzer(skip_treemap=False).analyze(
+            cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
+        )
+
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "4")
+        parallel = AppleAppAnalyzer(skip_treemap=False).analyze(
+            cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
+        )
+
+        assert serial.install_size == parallel.install_size
+        assert serial.download_size == parallel.download_size
+        assert serial.treemap is not None and parallel.treemap is not None
+        assert serial.treemap.model_dump_json() == parallel.treemap.model_dump_json()
+
+    def test_force_kill_pool_kills_sigterm_ignoring_worker(self) -> None:
+        """Cleanup must SIGKILL workers that ignore SIGTERM (e.g. wedged in LIEF)."""
+        ctx = mp.get_context("fork")
+        executor = ProcessPoolExecutor(max_workers=2, mp_context=ctx)
+        try:
+            executor.submit(_sigterm_ignoring_busy_loop)
+            executor.submit(_sigterm_ignoring_busy_loop)
+
+            deadline = time.monotonic() + 10
+            while len(getattr(executor, "_processes", {})) < 2 and time.monotonic() < deadline:
+                time.sleep(0.05)
+            procs = list(executor._processes.values())
+            assert len(procs) == 2 and all(p.is_alive() for p in procs)
+
+            _force_kill_pool(executor)
+
+            for p in procs:
+                p.join(timeout=5)
+                assert not p.is_alive()
+                assert p.exitcode == -signal.SIGKILL
+        finally:
+            for p in list((getattr(executor, "_processes", None) or {}).values()):
+                if p.is_alive():
+                    p.kill()
+            executor.shutdown(wait=False, cancel_futures=True)
 
     def test_apple_app_sizes(self, hackernews_xcarchive: Path) -> None:
         """Test that treemap structure matches reference report."""

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -1,3 +1,4 @@
+import functools
 import multiprocessing as mp
 import plistlib
 import signal
@@ -13,6 +14,7 @@ import pytest
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import AppleArtifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
+from launchpad.size.analyzers import apple
 from launchpad.size.analyzers.apple import AppleAppAnalyzer, _force_kill_pool
 from launchpad.size.models.common import ComponentType
 
@@ -107,8 +109,8 @@ class TestAppleAppSizes:
         analyzer = AppleAppAnalyzer()
         assert analyzer._binary_analysis_worker_count(1) == 1
         assert analyzer._binary_analysis_worker_count(0) == 1
-        assert analyzer._binary_analysis_worker_count(100) >= 1
-        assert analyzer._binary_analysis_worker_count(100) <= 8
+        assert analyzer._binary_analysis_worker_count(100) == 4
+        assert analyzer._binary_analysis_worker_count(2) == 2
 
     def test_binary_worker_count_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         analyzer = AppleAppAnalyzer()
@@ -153,8 +155,10 @@ class TestAppleAppSizes:
 
             _force_kill_pool(executor)
 
+            deadline = time.monotonic() + 15
             for p in procs:
-                p.join(timeout=5)
+                while p.is_alive() and time.monotonic() < deadline:
+                    p.join(timeout=0.2)
                 assert not p.is_alive()
                 assert p.exitcode == -signal.SIGKILL
         finally:
@@ -162,6 +166,22 @@ class TestAppleAppSizes:
                 if p.is_alive():
                     p.kill()
             executor.shutdown(wait=False, cancel_futures=True)
+
+    def test_parallel_binary_analysis_under_forkserver(
+        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Prod uses the forkserver start method, which pickles the analyzer and binaries;
+        the fork default in tests would mask a pickling regression, so exercise it here."""
+        ctx = mp.get_context("forkserver")
+        monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
+
+        results = AppleAppAnalyzer(skip_treemap=False).analyze(
+            cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
+        )
+
+        assert results.treemap is not None
+        assert results.install_size > 0
 
     def test_apple_app_sizes(self, hackernews_xcarchive: Path) -> None:
         """Test that treemap structure matches reference report."""

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import logging
 import multiprocessing as mp
 import os
@@ -8,10 +9,14 @@ import time
 
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from typing import Callable, cast
+from typing import Any, Callable, cast
 from unittest.mock import patch
 
 import pytest
+import sentry_sdk
+import sentry_sdk.transport
+
+from sentry_sdk.envelope import Envelope
 
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import AppleArtifact
@@ -20,6 +25,17 @@ from launchpad.size.analyzers import apple
 from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.common import ComponentType
 from launchpad.tracing import current_request_id, request_context
+
+
+class _CapturingTransport(sentry_sdk.transport.Transport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.transactions: list[dict[str, Any]] = []
+
+    def capture_envelope(self, envelope: Envelope) -> None:
+        for item in envelope.items:
+            if item.headers.get("type") == "transaction":
+                self.transactions.append(json.loads(item.get_bytes()))
 
 
 def _log_forever(i: int) -> None:
@@ -179,6 +195,38 @@ class TestAppleAppSizes:
         assert all(r.process != os.getpid() for r in completed)
         assert all(getattr(r, "request_id", None) == request_id for r in completed)
         assert all(isinstance(getattr(r, "elapsed_s", None), float) for r in completed)
+
+    def test_parallel_binary_spans_reattach_to_parent_transaction(
+        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Workers can't report spans, so the parent rebuilds one per binary from worker
+        timestamps; they must land on the task transaction and reflect real concurrency."""
+        ctx = mp.get_context("forkserver")
+        monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
+        transport = _CapturingTransport()
+        sentry_sdk.init(dsn="https://key@example.invalid/1", transport=transport, traces_sample_rate=1.0)
+        try:
+            with sentry_sdk.start_transaction(name="test"):
+                artifact = cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
+                binary_count = len(artifact.get_all_binary_paths())
+                AppleAppAnalyzer(skip_treemap=False).analyze(artifact)
+            sentry_sdk.flush()
+        finally:
+            sentry_sdk.get_global_scope().set_client(None)
+
+        spans = [
+            s
+            for t in transport.transactions
+            for s in t["spans"]
+            if s["op"] == "function" and s["description"].endswith("AppleAppAnalyzer._analyze_binary")
+        ]
+        assert len(spans) == binary_count
+        assert {s["data"]["binary_name"] for s in spans} == {b.name for b in artifact.get_all_binary_paths()}
+        assert all(s["timestamp"] > s["start_timestamp"] for s in spans)
+        assert any(
+            a is not b and a["start_timestamp"] < b["start_timestamp"] < a["timestamp"] for a in spans for b in spans
+        )
 
     def test_worker_log_relay_exits_cleanly_after_killing_workers(self, caplog: pytest.LogCaptureFixture) -> None:
         """Simulates the deadline path: workers SIGKILLed mid-log must not leave the parent

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -59,6 +59,9 @@ class _SentryIngestStub:
     def __exit__(self, *_exc: object) -> None:
         self._server.shutdown()
 
+    def transaction_count(self) -> int:
+        return sum(1 for e in self.envelopes for item in e.items if item.headers.get("type") == "transaction")
+
     def log_items(self) -> list[dict[str, Any]]:
         return [
             log
@@ -164,22 +167,18 @@ class TestAppleAppSizes:
         assert kwargs["extra"]["insight"] == "dummy"
         assert "elapsed_s" in kwargs["extra"]
 
-    def test_binary_worker_count(self) -> None:
+    def test_binary_worker_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
         analyzer = AppleAppAnalyzer()
-        assert analyzer._binary_analysis_worker_count(1) == 1
-        assert analyzer._binary_analysis_worker_count(0) == 0
         assert analyzer._binary_analysis_worker_count(100) == 4
         assert analyzer._binary_analysis_worker_count(2) == 2
-
-    def test_binary_worker_count_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        analyzer = AppleAppAnalyzer()
+        assert analyzer._binary_analysis_worker_count(0) == 0
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "3")
         assert analyzer._binary_analysis_worker_count(100) == 3
-        assert analyzer._binary_analysis_worker_count(2) == 2  # capped at num binaries
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "1")
-        assert analyzer._binary_analysis_worker_count(100) == 1
+        assert analyzer._binary_analysis_worker_count(2) == 2
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "0")
         assert analyzer._binary_analysis_worker_count(100) == 0
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "nope")
+        assert analyzer._binary_analysis_worker_count(100) == 4
 
     def test_parallel_binary_analysis_matches_in_process(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
@@ -199,28 +198,11 @@ class TestAppleAppSizes:
         assert in_process.treemap is not None and parallel.treemap is not None
         assert in_process.treemap.model_dump_json() == parallel.treemap.model_dump_json()
 
-    def test_parallel_binary_analysis_under_forkserver(
-        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Prod uses the forkserver start method, which pickles the analyzer and binaries;
-        the fork default in tests would mask a pickling regression, so exercise it here."""
-        ctx = mp.get_context("forkserver")
-        monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
-
-        results = AppleAppAnalyzer(skip_treemap=False).analyze(
-            cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
-        )
-
-        assert results.treemap is not None
-        assert results.install_size > 0
-
     def test_worker_logs_reach_stdout_with_request_id(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
     ) -> None:
-        """Pool workers configure their own logging and write to the inherited stdout, so their
-        per-binary lines must carry the parent's request id. Uses spawn rather than forkserver
-        because the forkserver inherits stdout once at startup, before capfd redirects it."""
+        """Uses spawn rather than forkserver: the forkserver inherits stdout once at startup,
+        before capfd redirects it, so forkserver workers would write past the capture."""
         ctx = mp.get_context("spawn")
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
@@ -275,6 +257,7 @@ class TestAppleAppSizes:
         assert worker_logs
         assert all(item["trace_id"] == transaction.trace_id for item in worker_logs)
         assert all(item["attributes"]["process.pid"]["value"] != os.getpid() for item in worker_logs)
+        assert stub.transaction_count() == 1
 
     def test_parallel_binary_spans_reattach_to_parent_transaction(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
@@ -284,6 +267,7 @@ class TestAppleAppSizes:
         ctx = mp.get_context("forkserver")
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
+        monkeypatch.setenv("LAUNCHPAD_ENV", "test")
         transport = _CapturingTransport()
         sentry_sdk.init(dsn="https://key@example.invalid/1", transport=transport, traces_sample_rate=1.0)
         try:
@@ -307,19 +291,6 @@ class TestAppleAppSizes:
         assert any(
             a is not b and a["start_timestamp"] < b["start_timestamp"] < a["timestamp"] for a in spans for b in spans
         )
-
-    def test_binary_completed_log_includes_elapsed(self) -> None:
-        """Per-binary duration must survive parallelization via an elapsed_s log field."""
-        from unittest.mock import Mock, patch
-
-        binary_info = Mock()
-        binary_info.name = "Foo"
-        binary = Mock(symbol_info=None)
-
-        with patch.object(apple.logger, "info") as info:
-            AppleAppAnalyzer()._log_binary_completed(binary_info, binary, 1.23456)
-
-        assert info.call_args.kwargs["extra"]["elapsed_s"] == 1.235
 
     def test_apple_app_sizes(self, hackernews_xcarchive: Path) -> None:
         """Test that treemap structure matches reference report."""

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -1,8 +1,6 @@
 import functools
 import multiprocessing as mp
 import plistlib
-import signal
-import time
 
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -15,15 +13,8 @@ from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
 from launchpad.artifacts.artifact import AppleArtifact
 from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.size.analyzers import apple
-from launchpad.size.analyzers.apple import AppleAppAnalyzer, _force_kill_pool
+from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.common import ComponentType
-
-
-def _sigterm_ignoring_busy_loop(*_args: object) -> None:
-    """Models a worker wedged in a native call: SIGTERM is ignored, spins forever."""
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    while True:
-        pass
 
 
 @pytest.fixture
@@ -138,34 +129,6 @@ class TestAppleAppSizes:
         assert serial.download_size == parallel.download_size
         assert serial.treemap is not None and parallel.treemap is not None
         assert serial.treemap.model_dump_json() == parallel.treemap.model_dump_json()
-
-    def test_force_kill_pool_kills_sigterm_ignoring_worker(self) -> None:
-        """Cleanup must SIGKILL workers that ignore SIGTERM (e.g. wedged in LIEF)."""
-        ctx = mp.get_context("fork")
-        executor = ProcessPoolExecutor(max_workers=2, mp_context=ctx)
-        try:
-            executor.submit(_sigterm_ignoring_busy_loop)
-            executor.submit(_sigterm_ignoring_busy_loop)
-
-            deadline = time.monotonic() + 10
-            while len(getattr(executor, "_processes", {})) < 2 and time.monotonic() < deadline:
-                time.sleep(0.05)
-            procs = list(executor._processes.values())
-            assert len(procs) == 2 and all(p.is_alive() for p in procs)
-
-            _force_kill_pool(executor)
-
-            deadline = time.monotonic() + 15
-            for p in procs:
-                while p.is_alive() and time.monotonic() < deadline:
-                    p.join(timeout=0.2)
-                assert not p.is_alive()
-                assert p.exitcode == -signal.SIGKILL
-        finally:
-            for p in list((getattr(executor, "_processes", None) or {}).values()):
-                if p.is_alive():
-                    p.kill()
-            executor.shutdown(wait=False, cancel_futures=True)
 
     def test_parallel_binary_analysis_under_forkserver(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -1,5 +1,7 @@
 import functools
+import logging
 import multiprocessing as mp
+import os
 import plistlib
 
 from concurrent.futures import ProcessPoolExecutor
@@ -15,6 +17,7 @@ from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.size.analyzers import apple
 from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.common import ComponentType
+from launchpad.tracing import current_request_id, request_context
 
 
 @pytest.fixture
@@ -146,6 +149,28 @@ class TestAppleAppSizes:
 
         assert results.treemap is not None
         assert results.install_size > 0
+
+    def test_worker_logs_relay_to_parent_with_request_id(
+        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Per-binary logs are emitted inside pool workers, which have no logging config of
+        their own; they must reach the parent's handlers stamped with the parent's request id."""
+        ctx = mp.get_context("forkserver")
+        monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
+        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
+        caplog.set_level(logging.INFO)
+
+        with request_context():
+            request_id = current_request_id()
+            AppleAppAnalyzer(skip_treemap=False).analyze(
+                cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
+            )
+
+        completed = [r for r in caplog.records if r.getMessage() == "size.apple.binary_analysis_completed"]
+        assert completed
+        assert all(r.process != os.getpid() for r in completed)
+        assert all(getattr(r, "request_id", None) == request_id for r in completed)
+        assert all(isinstance(getattr(r, "elapsed_s", None), float) for r in completed)
 
     def test_binary_completed_log_includes_elapsed(self) -> None:
         """Per-binary duration must survive parallelization via an elapsed_s log field."""

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -111,24 +111,23 @@ class TestAppleAppSizes:
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "1")
         assert analyzer._binary_analysis_worker_count(100) == 1
 
-    def test_parallel_binary_analysis_matches_serial(
+    def test_binary_analysis_output_independent_of_worker_count(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Toggling the worker count must not change analysis output."""
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "1")
-        serial = AppleAppAnalyzer(skip_treemap=False).analyze(
+        one_worker = AppleAppAnalyzer(skip_treemap=False).analyze(
             cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
         )
 
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "4")
-        parallel = AppleAppAnalyzer(skip_treemap=False).analyze(
+        four_workers = AppleAppAnalyzer(skip_treemap=False).analyze(
             cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
         )
 
-        assert serial.install_size == parallel.install_size
-        assert serial.download_size == parallel.download_size
-        assert serial.treemap is not None and parallel.treemap is not None
-        assert serial.treemap.model_dump_json() == parallel.treemap.model_dump_json()
+        assert one_worker.install_size == four_workers.install_size
+        assert one_worker.download_size == four_workers.download_size
+        assert one_worker.treemap is not None and four_workers.treemap is not None
+        assert one_worker.treemap.model_dump_json() == four_workers.treemap.model_dump_json()
 
     def test_parallel_binary_analysis_under_forkserver(
         self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
The per-binary Mach-O analysis loop ran serially and dominated wall-clock time on a large anonymized iOS app (hundreds of binaries) — a major contributor to hitting the 15-minute deadline.

The work is CPU-bound Python (LIEF, symbol sizing, demangling), so this parallelizes it with a `ProcessPoolExecutor` to get past the GIL (threads were tried first and regressed). Workers parse from disk and results stay in input order, so `binary_analysis` and the treemap are unchanged. Worker count is a fixed `4` to match the pods' CPU request — prod sets no CPU limit, so `os.cpu_count()` would read node cores and oversubscribe — overridable via `LAUNCHPAD_BINARY_ANALYSIS_WORKERS`, where `0` runs in-process with no pool at all (the rollback switch). Demangling runs serial inside workers to cap subprocess fan-out, and the LIEF pre-parse cache is removed since workers couldn't use it anyway.

Workers start with a bare interpreter, so each configures its own logging and initializes its own Sentry client with the parent's config, continuing the parent's trace from propagated headers. Per-binary started/completed logs (with `elapsed_s`) fire inside the worker at the moment of the work and reach both stdout and Sentry Logs under the build's trace. Workers also return start/end timestamps and the parent rebuilds the per-binary span from them, so the trace waterfall shows real overlap.

Timeout safety was the main review concern, since a worker wedged in native LIEF ignores `SIGTERM`. **We traced how the taskbroker enforces the deadline**: it's an in-process `SIGALRM` raising `ProcessingDeadlineExceeded` inside the task process — there's no external kill. Because the main process is idle in `executor.map` when it fires, our `except` calls `executor.kill_workers()` (new in 3.14), which `SIGKILL`s the wedged workers directly (verified under `forkserver`, prod's start method). If the main process is hard-killed instead (e.g. OOM), it's the container's PID 1, so the runtime tears down the whole cgroup and takes the workers with it. **Either way, no orphaned binary-analysis subprocesses.**

Benchmark — large anonymized app, 8 workers on a 10-core dev box (shipped default is 4, so real-world gain is a bit smaller):

| Metric | Serial | This PR |
|---|---|---|
| Binary-analysis phase | ~255s | ~44s (~5.8×) |
| Total wall clock | ~461s | ~250s (~1.8×) |

Verified with in-process-vs-parallel equivalence, worker-count, worker-logging (stdout with request id, third-party suppression, and delivery to a local Sentry ingest stub under the parent's trace), and rebuilt-span tests.
