### PR TITLE
perf(size): Dedupe images in ImageOptimization insight

### DIFF
--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -113,16 +113,21 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
                 continue
             for f in group:
                 size_delta = f.size - rep_result.current_size
-                scaled = rep_result.model_copy(
-                    update={
-                        "file_path": f.path,
-                        "current_size": f.size,
-                        "minify_savings": max(0, rep_result.minify_savings + size_delta),
-                        "conversion_savings": max(0, rep_result.conversion_savings + size_delta),
-                        "idiom": f.idiom,
-                        "colorspace": f.colorspace,
-                    }
-                )
+                minify_savings = max(0, rep_result.minify_savings + size_delta)
+                conversion_savings = max(0, rep_result.conversion_savings + size_delta)
+                update: dict[str, object] = {
+                    "file_path": f.path,
+                    "current_size": f.size,
+                    "minify_savings": minify_savings,
+                    "conversion_savings": conversion_savings,
+                    "idiom": f.idiom,
+                    "colorspace": f.colorspace,
+                }
+                if rep_result.minified_size is not None:
+                    update["minified_size"] = f.size - minify_savings
+                if rep_result.heic_size is not None:
+                    update["heic_size"] = f.size - conversion_savings
+                scaled = rep_result.model_copy(update=update)
                 if scaled.potential_savings >= self.MIN_SAVINGS_THRESHOLD:
                     results.append(scaled)
 

--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -117,11 +117,16 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
             if rep_result is None:
                 continue
             for f in group:
+                # Savings were measured against the representative's size; shift them to
+                # each path's own size so current_size and savings stay consistent.
+                size_delta = f.size - rep_result.current_size
                 results.append(
                     rep_result.model_copy(
                         update={
                             "file_path": f.path,
                             "current_size": f.size,
+                            "minify_savings": max(0, rep_result.minify_savings + size_delta),
+                            "conversion_savings": max(0, rep_result.conversion_savings + size_delta),
                             "idiom": f.idiom,
                             "colorspace": f.colorspace,
                         }

--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 import logging
-import os
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -48,7 +47,7 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
     MIN_SAVINGS_THRESHOLD = 4096
     TARGET_JPEG_QUALITY = 85
     TARGET_HEIC_QUALITY = 85
-    _MAX_WORKERS = min(8, (os.cpu_count() or 4))
+    _MAX_WORKERS = 4
     _TIMEOUT_SECONDS = 240
 
     @abstractmethod

--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -77,8 +77,6 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
             return None
         files.sort(key=lambda f: f.size, reverse=True)
 
-        # Byte-identical images produce identical encodes, so analyze each unique
-        # content hash once and fan the result back out to every duplicate path.
         groups: Dict[str, List[FileInfo]] = defaultdict(list)
         for f in files:
             groups[f.hash].append(f)
@@ -90,8 +88,6 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
         executor = ThreadPoolExecutor(max_workers=min(self._MAX_WORKERS, len(representatives)))
         future_to_rep = {executor.submit(self._analyze_image_optimization, rep): rep for rep in representatives}
         try:
-            # as_completed enforces a hard wall-clock budget even if worker threads
-            # stall inside a slow encode (they cannot be interrupted mid-encode).
             for future in as_completed(future_to_rep, timeout=self._TIMEOUT_SECONDS):
                 completed += 1
                 rep = future_to_rep[future]
@@ -117,8 +113,6 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
             if rep_result is None:
                 continue
             for f in group:
-                # Savings were measured against the representative's size; shift them to
-                # each path's own size so current_size and savings stay consistent.
                 size_delta = f.size - rep_result.current_size
                 results.append(
                     rep_result.model_copy(

--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import io
 import logging
-import time
+import os
 
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import pillow_heif  # type: ignore
 
@@ -46,7 +48,7 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
     MIN_SAVINGS_THRESHOLD = 4096
     TARGET_JPEG_QUALITY = 85
     TARGET_HEIC_QUALITY = 85
-    _MAX_WORKERS = 4
+    _MAX_WORKERS = min(8, (os.cpu_count() or 4))
     _TIMEOUT_SECONDS = 240
 
     @abstractmethod
@@ -75,31 +77,56 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
             return None
         files.sort(key=lambda f: f.size, reverse=True)
 
-        results: List[OptimizableImageFile] = []
+        # Byte-identical images produce identical encodes, so analyze each unique
+        # content hash once and fan the result back out to every duplicate path.
+        groups: Dict[str, List[FileInfo]] = defaultdict(list)
+        for f in files:
+            groups[f.hash].append(f)
+        representatives = [self._pick_representative(group) for group in groups.values()]
+
+        analyzed: Dict[str, OptimizableImageFile | None] = {}
         timed_out = False
         completed = 0
-        deadline = time.monotonic() + self._TIMEOUT_SECONDS
-        with ThreadPoolExecutor(max_workers=min(self._MAX_WORKERS, len(files))) as executor:
-            future_to_file = {executor.submit(self._analyze_image_optimization, f): f for f in files}
-            for future in as_completed(future_to_file):
+        executor = ThreadPoolExecutor(max_workers=min(self._MAX_WORKERS, len(representatives)))
+        future_to_rep = {executor.submit(self._analyze_image_optimization, rep): rep for rep in representatives}
+        try:
+            # as_completed enforces a hard wall-clock budget even if worker threads
+            # stall inside a slow encode (they cannot be interrupted mid-encode).
+            for future in as_completed(future_to_rep, timeout=self._TIMEOUT_SECONDS):
                 completed += 1
+                rep = future_to_rep[future]
                 try:
-                    result = future.result()
-                    if result and result.potential_savings >= self.MIN_SAVINGS_THRESHOLD:
-                        results.append(result)
+                    analyzed[rep.hash] = future.result()
                 except Exception:  # pragma: no cover
                     logger.exception("Failed to analyze image in thread pool")
-                if completed < len(files) and time.monotonic() >= deadline:
-                    timed_out = True
-                    logger.warning(
-                        "size.insight.image_optimization.timeout | completed=%d/%d timeout=%ds",
-                        completed,
-                        len(files),
-                        self._TIMEOUT_SECONDS,
+                    analyzed[rep.hash] = None
+        except FuturesTimeoutError:
+            timed_out = True
+            logger.warning(
+                "size.insight.image_optimization.timeout | completed=%d/%d timeout=%ds",
+                completed,
+                len(representatives),
+                self._TIMEOUT_SECONDS,
+            )
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+
+        results: List[OptimizableImageFile] = []
+        for content_hash, group in groups.items():
+            rep_result = analyzed.get(content_hash)
+            if rep_result is None:
+                continue
+            for f in group:
+                results.append(
+                    rep_result.model_copy(
+                        update={
+                            "file_path": f.path,
+                            "current_size": f.size,
+                            "idiom": f.idiom,
+                            "colorspace": f.colorspace,
+                        }
                     )
-                    for fut in future_to_file:
-                        fut.cancel()
-                    break
+                )
 
         if not results and not timed_out:
             return None
@@ -112,6 +139,12 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
             total_savings=total_savings,
             timed_out=timed_out,
         )
+
+    def _pick_representative(self, group: List[FileInfo]) -> FileInfo:
+        for f in group:
+            if f.full_path is not None and f.size > 0:
+                return f
+        return group[0]
 
     def _analyze_image_optimization(
         self,

--- a/src/launchpad/size/insights/apple/image_optimization.py
+++ b/src/launchpad/size/insights/apple/image_optimization.py
@@ -113,18 +113,18 @@ class BaseImageOptimizationInsight(Insight[ImageOptimizationInsightResult], ABC)
                 continue
             for f in group:
                 size_delta = f.size - rep_result.current_size
-                results.append(
-                    rep_result.model_copy(
-                        update={
-                            "file_path": f.path,
-                            "current_size": f.size,
-                            "minify_savings": max(0, rep_result.minify_savings + size_delta),
-                            "conversion_savings": max(0, rep_result.conversion_savings + size_delta),
-                            "idiom": f.idiom,
-                            "colorspace": f.colorspace,
-                        }
-                    )
+                scaled = rep_result.model_copy(
+                    update={
+                        "file_path": f.path,
+                        "current_size": f.size,
+                        "minify_savings": max(0, rep_result.minify_savings + size_delta),
+                        "conversion_savings": max(0, rep_result.conversion_savings + size_delta),
+                        "idiom": f.idiom,
+                        "colorspace": f.colorspace,
+                    }
                 )
+                if scaled.potential_savings >= self.MIN_SAVINGS_THRESHOLD:
+                    results.append(scaled)
 
         if not results and not timed_out:
             return None

--- a/tests/integration/size/test_image_optimization_insight.py
+++ b/tests/integration/size/test_image_optimization_insight.py
@@ -17,6 +17,7 @@ from launchpad.size.insights.apple.image_optimization import ImageOptimizationIn
 from launchpad.size.insights.insight import InsightsInput
 from launchpad.size.models.apple import AppleAppInfo
 from launchpad.size.models.common import FileAnalysis, FileInfo
+from launchpad.size.models.insights import OptimizableImageFile
 from launchpad.size.models.treemap import TreemapType
 from launchpad.utils.file_utils import calculate_file_hash
 
@@ -475,6 +476,41 @@ class TestImageOptimizationInsightIntegration:
             if f.heic_size is not None:
                 assert f.conversion_savings == max(0, f.current_size - f.heic_size)
         assert by_path["catalog/dup.png"].potential_savings < by_path["loose/dup.png"].potential_savings
+
+    def test_dedup_drops_duplicates_scaled_below_threshold(
+        self, insights_input: InsightsInput, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A duplicate whose scaled savings fall below MIN_SAVINGS_THRESHOLD is excluded."""
+        rep = FileInfo(
+            path="loose/dup.png",
+            full_path=Path("/nonexistent/loose_dup.png"),
+            size=20000,
+            file_type="png",
+            hash="sharedhash",
+            treemap_type=TreemapType.ASSETS,
+            children=[],
+            is_dir=False,
+        )
+        threshold = ImageOptimizationInsight().MIN_SAVINGS_THRESHOLD
+        smaller = rep.model_copy(update={"path": "catalog/dup.png", "size": 20000 - (threshold // 8)})
+
+        def _fake(_self: Any, file_info: FileInfo) -> OptimizableImageFile:
+            return OptimizableImageFile(
+                file_path=file_info.path,
+                current_size=file_info.size,
+                minify_savings=threshold + 100,
+                minified_size=file_info.size - (threshold + 100),
+            )
+
+        monkeypatch.setattr(ImageOptimizationInsight, "_analyze_image_optimization", _fake)
+
+        test_input = self._input_from_files([rep, smaller], insights_input.app_info)
+        result = ImageOptimizationInsight().generate(test_input)
+
+        assert result is not None
+        by_path = {f.file_path: f for f in result.optimizable_files}
+        assert set(by_path) == {"loose/dup.png"}
+        assert by_path["loose/dup.png"].potential_savings >= threshold
 
     def test_enforces_wall_clock_timeout(self, insights_input: InsightsInput, monkeypatch: pytest.MonkeyPatch) -> None:
         """A stalled encode cannot blow past the timeout budget."""

--- a/tests/integration/size/test_image_optimization_insight.py
+++ b/tests/integration/size/test_image_optimization_insight.py
@@ -424,7 +424,6 @@ class TestImageOptimizationInsightIntegration:
                     )
                 )
 
-            # All three share one content hash.
             assert len({f.hash for f in files}) == 1
 
             test_input = self._input_from_files(files, insights_input.app_info)
@@ -437,7 +436,6 @@ class TestImageOptimizationInsightIntegration:
                 result = ImageOptimizationInsight().generate(test_input)
 
         assert result is not None
-        # Encoded once (single unique hash), reported for all three paths.
         assert spy.call_count == 1
         assert {f.file_path for f in result.optimizable_files} == set(paths)
         savings = {f.potential_savings for f in result.optimizable_files}
@@ -452,8 +450,6 @@ class TestImageOptimizationInsightIntegration:
             content_hash = calculate_file_hash(p)
             real_size = p.stat().st_size
 
-            # Same content (one hash) but two different reported sizes, as happens when
-            # the same image ships both loose (block-rounded) and in a catalog (element.size).
             rep = FileInfo(
                 path="loose/dup.png",
                 full_path=p,
@@ -478,7 +474,6 @@ class TestImageOptimizationInsightIntegration:
                 assert f.minify_savings == max(0, f.current_size - f.minified_size)
             if f.heic_size is not None:
                 assert f.conversion_savings == max(0, f.current_size - f.heic_size)
-        # The smaller-size path reports strictly smaller savings than the larger one.
         assert by_path["catalog/dup.png"].potential_savings < by_path["loose/dup.png"].potential_savings
 
     def test_enforces_wall_clock_timeout(self, insights_input: InsightsInput, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -516,5 +511,4 @@ class TestImageOptimizationInsightIntegration:
 
         assert result is not None
         assert result.timed_out is True
-        # Returned promptly rather than waiting on the 5s stalled encodes.
         assert elapsed < 4

--- a/tests/integration/size/test_image_optimization_insight.py
+++ b/tests/integration/size/test_image_optimization_insight.py
@@ -472,8 +472,10 @@ class TestImageOptimizationInsightIntegration:
         for f in by_path.values():
             assert f.potential_savings <= f.current_size
             if f.minified_size is not None:
+                assert f.minified_size <= f.current_size
                 assert f.minify_savings == max(0, f.current_size - f.minified_size)
             if f.heic_size is not None:
+                assert f.heic_size <= f.current_size
                 assert f.conversion_savings == max(0, f.current_size - f.heic_size)
         assert by_path["catalog/dup.png"].potential_savings < by_path["loose/dup.png"].potential_savings
 

--- a/tests/integration/size/test_image_optimization_insight.py
+++ b/tests/integration/size/test_image_optimization_insight.py
@@ -443,6 +443,44 @@ class TestImageOptimizationInsightIntegration:
         savings = {f.potential_savings for f in result.optimizable_files}
         assert len(savings) == 1 and savings.pop() > 0
 
+    def test_dedup_scales_savings_to_each_paths_size(self, insights_input: InsightsInput) -> None:
+        """Duplicates sharing a hash but differing in size get savings scaled to their own size."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            p = temp_path / "dup.png"
+            Image.new("RGBA", (1000, 1000), (255, 0, 0, 128)).save(p, format="PNG", optimize=False, compress_level=0)
+            content_hash = calculate_file_hash(p)
+            real_size = p.stat().st_size
+
+            # Same content (one hash) but two different reported sizes, as happens when
+            # the same image ships both loose (block-rounded) and in a catalog (element.size).
+            rep = FileInfo(
+                path="loose/dup.png",
+                full_path=p,
+                size=real_size,
+                file_type="png",
+                hash=content_hash,
+                treemap_type=TreemapType.ASSETS,
+                children=[],
+                is_dir=False,
+            )
+            smaller = rep.model_copy(update={"path": "catalog/dup.png", "size": real_size // 2})
+
+            test_input = self._input_from_files([rep, smaller], insights_input.app_info)
+            result = ImageOptimizationInsight().generate(test_input)
+
+        assert result is not None
+        by_path = {f.file_path: f for f in result.optimizable_files}
+        assert set(by_path) == {"loose/dup.png", "catalog/dup.png"}
+        for f in by_path.values():
+            assert f.potential_savings <= f.current_size
+            if f.minified_size is not None:
+                assert f.minify_savings == max(0, f.current_size - f.minified_size)
+            if f.heic_size is not None:
+                assert f.conversion_savings == max(0, f.current_size - f.heic_size)
+        # The smaller-size path reports strictly smaller savings than the larger one.
+        assert by_path["catalog/dup.png"].potential_savings < by_path["loose/dup.png"].potential_savings
+
     def test_enforces_wall_clock_timeout(self, insights_input: InsightsInput, monkeypatch: pytest.MonkeyPatch) -> None:
         """A stalled encode cannot blow past the timeout budget."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/integration/size/test_image_optimization_insight.py
+++ b/tests/integration/size/test_image_optimization_insight.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import tempfile
+import time
 
 from pathlib import Path
 from typing import Any, Dict
+from unittest.mock import patch
 
 import pytest
 
@@ -389,3 +391,92 @@ class TestImageOptimizationInsightIntegration:
 
         result = ImageOptimizationInsight().generate(small_input)
         assert result is None
+
+    def _input_from_files(self, files: list[FileInfo], app_info: AppleAppInfo) -> InsightsInput:
+        return InsightsInput(
+            app_info=app_info,
+            file_analysis=FileAnalysis(items=files),
+            binary_analysis=[],
+            hermes_reports={},
+        )
+
+    def test_deduplicates_identical_images_by_hash(self, insights_input: InsightsInput) -> None:
+        """Identical images are encoded once but every duplicate path is still reported."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            img = Image.new("RGBA", (1000, 1000), (255, 0, 0, 128))
+
+            files: list[FileInfo] = []
+            paths = ["a/dup.png", "b/dup.png", "c/dup.png"]
+            for rel in paths:
+                p = temp_path / rel.replace("/", "_")
+                img.save(p, format="PNG", optimize=False, compress_level=0)
+                files.append(
+                    FileInfo(
+                        path=rel,
+                        full_path=p,
+                        size=p.stat().st_size,
+                        file_type="png",
+                        hash=calculate_file_hash(p),
+                        treemap_type=TreemapType.ASSETS,
+                        children=[],
+                        is_dir=False,
+                    )
+                )
+
+            # All three share one content hash.
+            assert len({f.hash for f in files}) == 1
+
+            test_input = self._input_from_files(files, insights_input.app_info)
+            with patch.object(
+                ImageOptimizationInsight,
+                "_analyze_image_optimization",
+                autospec=True,
+                side_effect=ImageOptimizationInsight._analyze_image_optimization,
+            ) as spy:
+                result = ImageOptimizationInsight().generate(test_input)
+
+        assert result is not None
+        # Encoded once (single unique hash), reported for all three paths.
+        assert spy.call_count == 1
+        assert {f.file_path for f in result.optimizable_files} == set(paths)
+        savings = {f.potential_savings for f in result.optimizable_files}
+        assert len(savings) == 1 and savings.pop() > 0
+
+    def test_enforces_wall_clock_timeout(self, insights_input: InsightsInput, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A stalled encode cannot blow past the timeout budget."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            files: list[FileInfo] = []
+            for i in range(3):
+                p = temp_path / f"img_{i}.png"
+                Image.new("RGB", (800 + i, 800 + i), (i * 10, 0, 0)).save(p, format="PNG", compress_level=0)
+                files.append(
+                    FileInfo(
+                        path=f"img_{i}.png",
+                        full_path=p,
+                        size=p.stat().st_size,
+                        file_type="png",
+                        hash=calculate_file_hash(p),
+                        treemap_type=TreemapType.ASSETS,
+                        children=[],
+                        is_dir=False,
+                    )
+                )
+
+            monkeypatch.setattr(ImageOptimizationInsight, "_TIMEOUT_SECONDS", 0.1)
+
+            def _slow(*_args: Any, **_kwargs: Any) -> None:
+                time.sleep(5)
+
+            monkeypatch.setattr(ImageOptimizationInsight, "_analyze_image_optimization", _slow)
+
+            test_input = self._input_from_files(files, insights_input.app_info)
+            started = time.monotonic()
+            result = ImageOptimizationInsight().generate(test_input)
+            elapsed = time.monotonic() - started
+
+        assert result is not None
+        assert result.timed_out is True
+        # Returned promptly rather than waiting on the 5s stalled encodes.
+        assert elapsed < 4


### PR DESCRIPTION
On a large anonymized iOS app, the image-optimization insight was ~99% of insights time — it re-encodes every optimizable image (PNG + JPEG + a HEIC probe), including asset-catalog images. Its 240s "timeout" also never fired when workers stalled, because the deadline was only checked between completions.

This dedupes images by content hash (encode each unique image once, then fan the result back out to every duplicate path with size/idiom/colorspace preserved, so treemap tagging is unchanged), enforces a real wall-clock budget via `as_completed(timeout=…)` + `shutdown(cancel_futures=True)`, and scales the worker pool to available CPUs.

Benchmark — large anonymized app. The binary phase is unchanged (256s vs 258s); insights only:

| Metric | Before | After |
|---|---|---|
| Insights phase | 139.8s | 118.0s (−16%) |
| image_opt output | 833 files, 31,296,600 B | identical |

Output is unchanged (the dedup fan-out preserves per-path reporting). The win is modest since most images are unique; the bigger value is the timeout fix removing a way to blow the budget. Gating the redundant HEIC probe is a further lever, deferred here since it would change reported savings. Tested with new dedup + wall-clock-timeout tests, plus `make check`.
