### PR TITLE
feat(size): Log per-insight timing in Apple analyzer

### DIFF
--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -446,7 +446,13 @@ class AppleAppAnalyzer:
         self, insight_class: type, insights_input: InsightsInput, insight_name: str
     ) -> Any:
         with sentry_sdk.start_span(op="insight", description=f"apple.insights.{insight_name}"):
-            return insight_class().generate(insights_input)
+            started = time.monotonic()
+            result = insight_class().generate(insights_input)
+            logger.info(
+                "size.apple.insight_completed",
+                extra={"insight": insight_name, "elapsed_s": round(time.monotonic() - started, 3)},
+            )
+            return result
 
     @sentry_sdk.trace
     def _analyze_binary(

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -2,6 +2,7 @@ import plistlib
 
 from pathlib import Path
 from typing import Callable, cast
+from unittest.mock import patch
 
 import pytest
 
@@ -72,6 +73,24 @@ def create_app_clip() -> Callable[[ZippedXCArchive, str, str, dict[str, int]], P
 
 class TestAppleAppSizes:
     """Test Apple app sizes functionality."""
+
+    def test_generate_insight_logs_timing(self) -> None:
+        """Each insight logs its wall-clock duration so slow phases are visible."""
+
+        class _DummyInsight:
+            def generate(self, _input: object) -> str:
+                return "ok"
+
+        analyzer = AppleAppAnalyzer()
+        with patch("launchpad.size.analyzers.apple.logger") as mock_logger:
+            result = analyzer._generate_insight_with_tracing(_DummyInsight, cast(object, None), "dummy")
+
+        assert result == "ok"
+        mock_logger.info.assert_called_once()
+        args, kwargs = mock_logger.info.call_args
+        assert args[0] == "size.apple.insight_completed"
+        assert kwargs["extra"]["insight"] == "dummy"
+        assert "elapsed_s" in kwargs["extra"]
 
     def test_apple_app_sizes(self, hackernews_xcarchive: Path) -> None:
         """Test that treemap structure matches reference report."""


### PR DESCRIPTION
Insight generation logged nothing per-insight. On a large anonymized iOS app that timed out, `size.apple.generate_insights` was the last log before silence — a slow insight was indistinguishable from a hang.

This logs each insight's duration on completion: `size.apple.insight_completed` with `insight` and `elapsed_s`.

It's observability-only, so there's no material speedup and none measured (460.7s vs 439.8s, within noise). What it buys is attribution: it immediately isolated the culprit — `image_optimization` was 129.06s of 129.3s insights (99.8%), while the other 11 summed to ~0.27s.

Tested with a unit test asserting the completion log fires with the insight name + `elapsed_s`, plus `make check`.
