### PR TITLE
feat(worker): Tag processing duration metric with organization_slug

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -102,6 +102,7 @@ class ArtifactProcessor:
         artifact_id: str,
         project_id: str,
         organization_id: str,
+        organization_slug: str | None = None,
         service_config=None,
         artifact_processor=None,
         statsd=None,
@@ -168,14 +169,17 @@ class ArtifactProcessor:
                     f"Processing complete for artifact {artifact_id} (project: {project_id}, org: {organization_id}) in {duration:.2f}s"
                 )
             finally:
+                duration_tags = [
+                    f"project_id:{project_id}",
+                    f"organization_id:{organization_id}",
+                    f"artifact_type:{artifact_type}",
+                ]
+                if organization_slug:
+                    duration_tags.append(f"organization_slug:{organization_slug}")
                 statsd.timing(
                     "artifact.processing.duration",
                     time.monotonic() - processing_start,
-                    tags=[
-                        f"project_id:{project_id}",
-                        f"organization_id:{organization_id}",
-                        f"artifact_type:{artifact_type}",
-                    ],
+                    tags=duration_tags,
                 )
 
     def process_artifact(

--- a/src/launchpad/worker/tasks.py
+++ b/src/launchpad/worker/tasks.py
@@ -9,9 +9,14 @@ default = app.taskregistry.create_namespace("default", processing_deadline_durat
 
 
 @default.register(name="process_artifact")
-def process_artifact(artifact_id: str, project_id: str, organization_id: str) -> None:
+def process_artifact(
+    artifact_id: str, project_id: str, organization_id: str, organization_slug: str | None = None
+) -> None:
     setup_logging()
     logger.info(f"Processing artifact {artifact_id}")
-    logger.info(f"Params: artifact_id={artifact_id}, project_id={project_id}, organization_id={organization_id}")
-    ArtifactProcessor.process_message(artifact_id, project_id, organization_id)
+    logger.info(
+        f"Params: artifact_id={artifact_id}, project_id={project_id}, "
+        f"organization_id={organization_id}, organization_slug={organization_slug}"
+    )
+    ArtifactProcessor.process_message(artifact_id, project_id, organization_id, organization_slug=organization_slug)
     logger.info(f"Processed artifact {artifact_id}")

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -404,6 +404,58 @@ class TestArtifactProcessorMessageHandling:
             {"metric": "artifact.processing.completed", "value": 1, "tags": None},
         ) in calls
 
+    @patch("launchpad.artifact_processor.SentryClient")
+    @patch.object(ArtifactProcessor, "process_artifact")
+    def test_process_message_duration_includes_org_slug(self, mock_process, mock_sentry_client):
+        """The processing duration metric is tagged with organization_slug when provided."""
+        mock_process.return_value = "xcarchive"
+        fake_statsd = FakeStatsd()
+        service_config = ServiceConfig(
+            sentry_base_url="http://test.sentry.io",
+            projects_to_skip=[],
+            objectstore_config=ObjectstoreConfig(objectstore_url="http://test.objectstore.io"),
+        )
+
+        ArtifactProcessor.process_message(
+            artifact_id="slug-test-123",
+            project_id="test-project",
+            organization_id="test-org-123",
+            organization_slug="acme-inc",
+            service_config=service_config,
+            statsd=fake_statsd,
+        )
+
+        timing = next(
+            c[1] for c in fake_statsd.calls if c[0] == "timing" and c[1]["metric"] == "artifact.processing.duration"
+        )
+        assert "organization_slug:acme-inc" in timing["tags"]
+        assert "organization_id:test-org-123" in timing["tags"]
+
+    @patch("launchpad.artifact_processor.SentryClient")
+    @patch.object(ArtifactProcessor, "process_artifact")
+    def test_process_message_duration_omits_slug_when_absent(self, mock_process, mock_sentry_client):
+        """No organization_slug tag is emitted when the slug is not provided (rollout compatibility)."""
+        mock_process.return_value = "xcarchive"
+        fake_statsd = FakeStatsd()
+        service_config = ServiceConfig(
+            sentry_base_url="http://test.sentry.io",
+            projects_to_skip=[],
+            objectstore_config=ObjectstoreConfig(objectstore_url="http://test.objectstore.io"),
+        )
+
+        ArtifactProcessor.process_message(
+            artifact_id="no-slug-123",
+            project_id="test-project",
+            organization_id="test-org-123",
+            service_config=service_config,
+            statsd=fake_statsd,
+        )
+
+        timing = next(
+            c[1] for c in fake_statsd.calls if c[0] == "timing" and c[1]["metric"] == "artifact.processing.duration"
+        )
+        assert not any(tag.startswith("organization_slug:") for tag in timing["tags"])
+
 
 class TestParseBuildNumber:
     @pytest.mark.parametrize(


### PR DESCRIPTION
The per-org processing-time views on the Datadog Preprod dashboard group `launchpad.artifact.processing.duration` by the numeric `organization_id`, which is hard to read when trying to spot which customer is uploading large / slow-to-process builds. The worker only receives the numeric id today and has no way to resolve a slug, so the readable name never makes it onto the metric.

This threads an optional `organization_slug` through the `process_artifact` task and `ArtifactProcessor.process_message`, and appends an `organization_slug` tag to the duration metric when a slug is present. It's an added tag, not a replacement — `organization_id` stays for anything that references it.

The argument defaults to `None` and the tag is only emitted when a slug is actually provided, so this side can deploy first: in-flight tasks enqueued before the sender change ship the slug remain valid, and the tag simply starts appearing once the Sentry sender (separate PR) begins passing it.

Tested with two new unit tests covering the tag being present when a slug is passed and absent when it isn't. `make check` and `make test-unit` pass.