### PR TITLE
feat(worker): Tag processing duration with platform (ios/android/timeout/failed)

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -129,6 +129,7 @@ class ArtifactProcessor:
             return
 
         artifact_type = "unknown"
+        platform = "unknown"
         with contextlib.ExitStack() as stack:
             stack.enter_context(request_context())
             processing_start = time.monotonic()
@@ -142,6 +143,7 @@ class ArtifactProcessor:
             try:
                 artifact_type = artifact_processor.process_artifact(organization_id, project_id, artifact_id)
             except ProcessingDeadlineExceeded:
+                platform = "timeout"
                 statsd.increment("artifact.processing.failed")
                 statsd.increment("artifact.processing.timeout")
                 duration = time.time() - start_time
@@ -157,12 +159,14 @@ class ArtifactProcessor:
                 )
                 raise
             except Exception:
+                platform = "failed"
                 statsd.increment("artifact.processing.failed")
                 duration = time.time() - start_time
                 logger.exception(
                     f"Processing failed for artifact {artifact_id} (project: {project_id}, org: {organization_id}) in {duration:.2f}s"
                 )
             else:
+                platform = {"xcarchive": "ios", "aab": "android", "apk": "android"}.get(artifact_type, "unknown")
                 statsd.increment("artifact.processing.completed")
                 duration = time.time() - start_time
                 logger.info(
@@ -173,6 +177,7 @@ class ArtifactProcessor:
                     f"project_id:{project_id}",
                     f"organization_id:{organization_id}",
                     f"artifact_type:{artifact_type}",
+                    f"platform:{platform}",
                 ]
                 if organization_slug:
                     duration_tags.append(f"organization_slug:{organization_slug}")

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from objectstore_client import Client as ObjectstoreClient
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig, _parse_build_number
 from launchpad.artifacts.android.aab import AAB
@@ -455,6 +456,79 @@ class TestArtifactProcessorMessageHandling:
             c[1] for c in fake_statsd.calls if c[0] == "timing" and c[1]["metric"] == "artifact.processing.duration"
         )
         assert not any(tag.startswith("organization_slug:") for tag in timing["tags"])
+
+    @staticmethod
+    def _duration_tags(fake_statsd):
+        timing = next(
+            c[1] for c in fake_statsd.calls if c[0] == "timing" and c[1]["metric"] == "artifact.processing.duration"
+        )
+        return timing["tags"]
+
+    @staticmethod
+    def _service_config():
+        return ServiceConfig(
+            sentry_base_url="http://test.sentry.io",
+            projects_to_skip=[],
+            objectstore_config=ObjectstoreConfig(objectstore_url="http://test.objectstore.io"),
+        )
+
+    @pytest.mark.parametrize(
+        "artifact_type,expected_platform",
+        [("xcarchive", "ios"), ("aab", "android"), ("apk", "android"), ("unknown", "unknown")],
+    )
+    @patch("launchpad.artifact_processor.SentryClient")
+    @patch.object(ArtifactProcessor, "process_artifact")
+    def test_process_message_platform_on_success(
+        self, mock_process, mock_sentry_client, artifact_type, expected_platform
+    ):
+        """Successful builds map artifact_type to a platform tag (aab/apk both -> android)."""
+        mock_process.return_value = artifact_type
+        fake_statsd = FakeStatsd()
+
+        ArtifactProcessor.process_message(
+            artifact_id="a",
+            project_id="p",
+            organization_id="o",
+            service_config=self._service_config(),
+            statsd=fake_statsd,
+        )
+
+        assert f"platform:{expected_platform}" in self._duration_tags(fake_statsd)
+
+    @patch("launchpad.artifact_processor.SentryClient")
+    @patch.object(ArtifactProcessor, "process_artifact")
+    def test_process_message_platform_timeout(self, mock_process, mock_sentry_client):
+        """Builds that exceed the processing deadline are tagged platform:timeout."""
+        mock_process.side_effect = ProcessingDeadlineExceeded()
+        fake_statsd = FakeStatsd()
+
+        with pytest.raises(ProcessingDeadlineExceeded):
+            ArtifactProcessor.process_message(
+                artifact_id="a",
+                project_id="p",
+                organization_id="o",
+                service_config=self._service_config(),
+                statsd=fake_statsd,
+            )
+
+        assert "platform:timeout" in self._duration_tags(fake_statsd)
+
+    @patch("launchpad.artifact_processor.SentryClient")
+    @patch.object(ArtifactProcessor, "process_artifact")
+    def test_process_message_platform_failed(self, mock_process, mock_sentry_client):
+        """Builds that fail before type detection are tagged platform:failed."""
+        mock_process.side_effect = RuntimeError("boom")
+        fake_statsd = FakeStatsd()
+
+        ArtifactProcessor.process_message(
+            artifact_id="a",
+            project_id="p",
+            organization_id="o",
+            service_config=self._service_config(),
+            statsd=fake_statsd,
+        )
+
+        assert "platform:failed" in self._duration_tags(fake_statsd)
 
 
 class TestParseBuildNumber:


### PR DESCRIPTION
The per-org processing-time widgets on the Datadog Preprod dashboard need to show the platform per org in the legend, org-first and readable. Datadog sorts group-by legend tags alphabetically by tag key and drops query aliases when a group-by is present, so the existing `artifact_type` tag can only ever render as `aab, 24547` (platform-first, raw `aab`/`apk`/`xcarchive`, and `unknown` for every failure). There's no dashboard-side way around that.

This adds a `platform` tag to `artifact.processing.duration`, derived from the build outcome:

- `xcarchive` -> `ios`
- `aab` / `apk` -> `android` (merged)
- deadline exceeded -> `timeout`
- any other failure -> `failed`

Because `platform` sorts after `organization_id`/`organization_slug` alphabetically, grouping by `{organization_id, platform}` renders the legend org-first (`24547, ios`), with friendly merged names. It also splits the old `unknown` bucket into `timeout` vs `failed` — and timed-out builds (which burn the full ~15-min deadline) are the biggest lag contributors, so surfacing them as their own category is the whole point of the culprit-detection view.

`artifact_type` is left unchanged for anything that relies on the raw type. The tag is emitted on every path via the existing `finally` block. Covered by parametrized unit tests for the success mapping plus timeout and failed cases; `make check` and `make test-unit` pass.