### PR TITLE
ci(options): Validate sentry-options schema changes on PRs

### DIFF
--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -1,0 +1,39 @@
+name: Validate Sentry Options Schema
+
+on:
+  pull_request:
+    paths:
+      - 'sentry-options/schemas/**'
+      - 'uv.lock'
+      - '.github/workflows/validate-sentry-options.yml'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  cli-version:
+    name: Determine sentry-options CLI version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: uv.lock
+          sparse-checkout-cone-mode: false
+      - name: Parse sentry-options version from uv.lock
+        id: version
+        run: |
+          echo -n "version=" >> "$GITHUB_OUTPUT"
+          yq -p toml -oy '.package[] | select(.name == "sentry-options") | .version' uv.lock >> "$GITHUB_OUTPUT"
+
+  validate-schema:
+    needs: cli-version
+    name: Validate Schema Evolution
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@2cc89b0011942ca3593f5c20e89de2baa414ed41 # 1.2.9
+    secrets: inherit
+    with:
+      schemas-path: sentry-options/schemas
+      cli-version: ${{ needs.cli-version.outputs.version }}

--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cli-version:
     name: Determine sentry-options CLI version


### PR DESCRIPTION
Adds the sentry-options schema-validation workflow from the [onboarding guide](https://github.com/getsentry/sentry-options/blob/main/docs/setup.md#2-add-workflows) — the piece that was missing after the initial integration (#668).

It runs on PRs that touch `sentry-options/schemas/**` (or `uv.lock`) and calls the reusable `getsentry/sentry-options/.github/workflows/validate-schema.yml` to check two things: that the schema is well-formed, and — the important part — that a change doesn't violate the schema-evolution rules, like changing an option's type or default or making another backward-incompatible edit. Those are the changes that would break already-deployed readers of an option, and the existing test suite can't catch them: `init()` only validates that a schema is well-formed, with no visibility into the previous version.

Follows seer's two-job pattern: a first job parses the pinned `sentry-options` version out of `uv.lock` so validation runs the exact same CLI version the service depends on (1.2.9 today), and the reusable workflow is SHA-pinned to the matching release. The workflow validates its own PR (no schema change here, so it passes cleanly), which confirms the wiring.