### PR TITLE
feat(logging): Stamp the artifact id onto every log record

### DIFF
--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -47,7 +47,7 @@ from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.android import AndroidAppInfo
 from launchpad.size.models.apple import AppleAppInfo
 from launchpad.size.models.common import BaseAppInfo
-from launchpad.tracing import request_context
+from launchpad.tracing import log_context, request_context
 from launchpad.utils.file_utils import IdPrefix, id_from_bytes
 from launchpad.utils.logging import get_logger
 from launchpad.utils.objectstore import ObjectstoreConfig, create_objectstore_client
@@ -137,6 +137,9 @@ class ArtifactProcessor:
         platform = "unknown"
         with contextlib.ExitStack() as stack:
             stack.enter_context(request_context())
+            stack.enter_context(
+                log_context(artifact_id=artifact_id, project_id=project_id, organization_id=organization_id)
+            )
             processing_start = time.monotonic()
             scope = stack.enter_context(sentry_sdk.new_scope())
             scope.set_tag("launchpad.project_id", project_id)

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -47,7 +47,7 @@ from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.android import AndroidAppInfo
 from launchpad.size.models.apple import AppleAppInfo
 from launchpad.size.models.common import BaseAppInfo
-from launchpad.tracing import log_context, request_context
+from launchpad.tracing import request_context
 from launchpad.utils.file_utils import IdPrefix, id_from_bytes
 from launchpad.utils.logging import get_logger
 from launchpad.utils.objectstore import ObjectstoreConfig, create_objectstore_client
@@ -136,9 +136,8 @@ class ArtifactProcessor:
         artifact_type = "unknown"
         platform = "unknown"
         with contextlib.ExitStack() as stack:
-            stack.enter_context(request_context())
             stack.enter_context(
-                log_context(artifact_id=artifact_id, project_id=project_id, organization_id=organization_id)
+                request_context(artifact_id=artifact_id, project_id=project_id, organization_id=organization_id)
             )
             processing_start = time.monotonic()
             scope = stack.enter_context(sentry_sdk.new_scope())

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -136,9 +136,7 @@ class ArtifactProcessor:
         artifact_type = "unknown"
         platform = "unknown"
         with contextlib.ExitStack() as stack:
-            stack.enter_context(
-                request_context(artifact_id=artifact_id, project_id=project_id, organization_id=organization_id)
-            )
+            stack.enter_context(request_context(artifact_id=artifact_id))
             processing_start = time.monotonic()
             scope = stack.enter_context(sentry_sdk.new_scope())
             scope.set_tag("launchpad.project_id", project_id)

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -49,7 +49,7 @@ from launchpad.size.treemap.treemap_builder import TreemapBuilder
 from launchpad.size.utils.apple_bundle_size import calculate_bundle_sizes
 from launchpad.size.utils.file_analysis import analyze_apple_files
 from launchpad.size.utils.insight_path_map import build_insight_path_map
-from launchpad.tracing import bind_request_id, current_request_id
+from launchpad.tracing import bind_log_fields, bind_request_id, current_log_fields, current_request_id
 from launchpad.utils.apple.apple_strip import AppleStrip
 from launchpad.utils.apple.code_signature_validator import CodeSignatureValidator
 from launchpad.utils.file_utils import get_file_size, to_nearest_block_size
@@ -76,6 +76,7 @@ _DEFAULT_BINARY_ANALYSIS_WORKERS = 4
 class _WorkerContext(NamedTuple):
     verbose: bool
     request_id: str | None
+    log_fields: dict[str, str]
     sentry_config: SentryConfig | None
     trace_headers: dict[str, str]
 
@@ -85,6 +86,7 @@ class _WorkerContext(NamedTuple):
         return cls(
             verbose=logging.getLogger().getEffectiveLevel() <= logging.DEBUG,
             request_id=current_request_id(),
+            log_fields=current_log_fields(),
             sentry_config=get_sentry_config() if sentry_sdk.get_client().is_active() else None,
             trace_headers={k: v for k, v in headers.items() if v},
         )
@@ -95,6 +97,8 @@ def _binary_worker_init(context: _WorkerContext) -> None:
     setup_logging(verbose=context.verbose)
     if context.request_id is not None:
         bind_request_id(context.request_id)
+    if context.log_fields:
+        bind_log_fields(context.log_fields)
     if context.sentry_config is not None:
         initialize_sentry_sdk(context.sentry_config)
         sentry_sdk.continue_trace(context.trace_headers)

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -49,7 +49,7 @@ from launchpad.size.treemap.treemap_builder import TreemapBuilder
 from launchpad.size.utils.apple_bundle_size import calculate_bundle_sizes
 from launchpad.size.utils.file_analysis import analyze_apple_files
 from launchpad.size.utils.insight_path_map import build_insight_path_map
-from launchpad.tracing import bind_log_fields, bind_request_id, current_log_fields, current_request_id
+from launchpad.tracing import bind_artifact_id, bind_request_id, current_artifact_id, current_request_id
 from launchpad.utils.apple.apple_strip import AppleStrip
 from launchpad.utils.apple.code_signature_validator import CodeSignatureValidator
 from launchpad.utils.file_utils import get_file_size, to_nearest_block_size
@@ -76,7 +76,7 @@ _DEFAULT_BINARY_ANALYSIS_WORKERS = 4
 class _WorkerContext(NamedTuple):
     verbose: bool
     request_id: str | None
-    log_fields: dict[str, str]
+    artifact_id: str | None
     sentry_config: SentryConfig | None
     trace_headers: dict[str, str]
 
@@ -86,7 +86,7 @@ class _WorkerContext(NamedTuple):
         return cls(
             verbose=logging.getLogger().getEffectiveLevel() <= logging.DEBUG,
             request_id=current_request_id(),
-            log_fields=current_log_fields(),
+            artifact_id=current_artifact_id(),
             sentry_config=get_sentry_config() if sentry_sdk.get_client().is_active() else None,
             trace_headers={k: v for k, v in headers.items() if v},
         )
@@ -97,8 +97,8 @@ def _binary_worker_init(context: _WorkerContext) -> None:
     setup_logging(verbose=context.verbose)
     if context.request_id is not None:
         bind_request_id(context.request_id)
-    if context.log_fields:
-        bind_log_fields(context.log_fields)
+    if context.artifact_id is not None:
+        bind_artifact_id(context.artifact_id)
     if context.sentry_config is not None:
         initialize_sentry_sdk(context.sentry_config)
         sentry_sdk.continue_trace(context.trace_headers)

--- a/src/launchpad/tracing.py
+++ b/src/launchpad/tracing.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 
 _request_id: ContextVar[str | None] = ContextVar("request_id")
+_log_fields: ContextVar[dict[str, str]] = ContextVar("log_fields")
 
 
 @contextmanager
@@ -25,13 +26,32 @@ def bind_request_id(request_id: str) -> None:
     _request_id.set(request_id)
 
 
+@contextmanager
+def log_context(**fields: str):
+    """Attach structured fields (e.g. artifact_id) to every log record emitted within the block."""
+    token = _log_fields.set({**_log_fields.get({}), **fields})
+    try:
+        yield
+    finally:
+        _log_fields.reset(token)
+
+
+def current_log_fields() -> dict[str, str]:
+    return _log_fields.get({})
+
+
+def bind_log_fields(fields: dict[str, str]) -> None:
+    _log_fields.set(fields)
+
+
 class RequestLogFilter:
-    """Logging filter that adds request_id to log records.."""
+    """Logging filter that adds request_id and log_context fields to log records."""
 
     def filter(self, record) -> bool:
+        for key, value in _log_fields.get({}).items():
+            setattr(record, key, value)
         try:
-            request_id = _request_id.get()
-            record.request_id = request_id
+            record.request_id = _request_id.get()
         except LookupError:
             pass
         return True

--- a/src/launchpad/tracing.py
+++ b/src/launchpad/tracing.py
@@ -8,14 +8,15 @@ _log_fields: ContextVar[dict[str, str]] = ContextVar("log_fields")
 
 
 @contextmanager
-def request_context():
-    """Create a request context with a unique request_id."""
-    request_id = str(uuid.uuid4())
-    token = _request_id.set(request_id)
+def request_context(**fields: str):
+    """Create a request context with a unique request_id and stamp the given fields onto every log record."""
+    request_token = _request_id.set(str(uuid.uuid4()))
+    fields_token = _log_fields.set(fields)
     try:
         yield
     finally:
-        _request_id.reset(token)
+        _log_fields.reset(fields_token)
+        _request_id.reset(request_token)
 
 
 def current_request_id() -> str | None:
@@ -24,16 +25,6 @@ def current_request_id() -> str | None:
 
 def bind_request_id(request_id: str) -> None:
     _request_id.set(request_id)
-
-
-@contextmanager
-def log_context(**fields: str):
-    """Attach structured fields (e.g. artifact_id) to every log record emitted within the block."""
-    token = _log_fields.set({**_log_fields.get({}), **fields})
-    try:
-        yield
-    finally:
-        _log_fields.reset(token)
 
 
 def current_log_fields() -> dict[str, str]:
@@ -45,7 +36,7 @@ def bind_log_fields(fields: dict[str, str]) -> None:
 
 
 class RequestLogFilter:
-    """Logging filter that adds request_id and log_context fields to log records."""
+    """Logging filter that adds request_id and request_context fields to log records."""
 
     def filter(self, record) -> bool:
         for key, value in _log_fields.get({}).items():

--- a/src/launchpad/tracing.py
+++ b/src/launchpad/tracing.py
@@ -4,18 +4,18 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 
 _request_id: ContextVar[str | None] = ContextVar("request_id")
-_log_fields: ContextVar[dict[str, str]] = ContextVar("log_fields")
+_artifact_id: ContextVar[str | None] = ContextVar("artifact_id")
 
 
 @contextmanager
-def request_context(**fields: str):
-    """Create a request context with a unique request_id and stamp the given fields onto every log record."""
+def request_context(artifact_id: str | None = None):
+    """Create a request context with a unique request_id and stamp the artifact_id onto every log record."""
     request_token = _request_id.set(str(uuid.uuid4()))
-    fields_token = _log_fields.set(fields)
+    artifact_token = _artifact_id.set(artifact_id)
     try:
         yield
     finally:
-        _log_fields.reset(fields_token)
+        _artifact_id.reset(artifact_token)
         _request_id.reset(request_token)
 
 
@@ -27,22 +27,23 @@ def bind_request_id(request_id: str) -> None:
     _request_id.set(request_id)
 
 
-def current_log_fields() -> dict[str, str]:
-    return _log_fields.get({})
+def current_artifact_id() -> str | None:
+    return _artifact_id.get(None)
 
 
-def bind_log_fields(fields: dict[str, str]) -> None:
-    _log_fields.set(fields)
+def bind_artifact_id(artifact_id: str) -> None:
+    _artifact_id.set(artifact_id)
 
 
 class RequestLogFilter:
-    """Logging filter that adds request_id and request_context fields to log records."""
+    """Logging filter that adds request_id and artifact_id to log records."""
 
     def filter(self, record) -> bool:
-        for key, value in _log_fields.get({}).items():
-            setattr(record, key, value)
         try:
             record.request_id = _request_id.get()
         except LookupError:
             pass
+        artifact_id = _artifact_id.get(None)
+        if artifact_id is not None:
+            record.artifact_id = artifact_id
         return True

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -26,7 +26,7 @@ from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.size.analyzers import apple
 from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.common import ComponentType
-from launchpad.tracing import current_request_id, request_context
+from launchpad.tracing import current_request_id, log_context, request_context
 
 
 class _SentryIngestStub:
@@ -207,7 +207,7 @@ class TestAppleAppSizes:
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
 
-        with request_context():
+        with request_context(), log_context(artifact_id="42"):
             request_id = current_request_id()
             AppleAppAnalyzer(skip_treemap=False).analyze(
                 cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
@@ -217,11 +217,14 @@ class TestAppleAppSizes:
         completed = [d for d in lines if d["message"] == "size.apple.binary_analysis_completed"]
         assert completed
         assert all(d["request_id"] == request_id for d in completed)
+        assert all(d["artifact_id"] == "42" for d in completed)
         assert all(isinstance(d["elapsed_s"], float) for d in completed)
 
     def test_worker_logging_applies_third_party_suppression(self, capfd: pytest.CaptureFixture[str]) -> None:
         ctx = mp.get_context("spawn")
-        context = apple._WorkerContext(verbose=False, request_id=None, sentry_config=None, trace_headers={})
+        context = apple._WorkerContext(
+            verbose=False, request_id=None, log_fields={}, sentry_config=None, trace_headers={}
+        )
         with ProcessPoolExecutor(
             max_workers=1, mp_context=ctx, initializer=apple._binary_worker_init, initargs=(context,)
         ) as executor:

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -223,7 +223,7 @@ class TestAppleAppSizes:
     def test_worker_logging_applies_third_party_suppression(self, capfd: pytest.CaptureFixture[str]) -> None:
         ctx = mp.get_context("spawn")
         context = apple._WorkerContext(
-            verbose=False, request_id=None, log_fields={}, sentry_config=None, trace_headers={}
+            verbose=False, request_id=None, artifact_id=None, sentry_config=None, trace_headers={}
         )
         with ProcessPoolExecutor(
             max_workers=1, mp_context=ctx, initializer=apple._binary_worker_init, initargs=(context,)

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -26,7 +26,7 @@ from launchpad.artifacts.artifact_factory import ArtifactFactory
 from launchpad.size.analyzers import apple
 from launchpad.size.analyzers.apple import AppleAppAnalyzer
 from launchpad.size.models.common import ComponentType
-from launchpad.tracing import current_request_id, log_context, request_context
+from launchpad.tracing import current_request_id, request_context
 
 
 class _SentryIngestStub:
@@ -207,7 +207,7 @@ class TestAppleAppSizes:
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
         monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
 
-        with request_context(), log_context(artifact_id="42"):
+        with request_context(artifact_id="42"):
             request_id = current_request_id()
             AppleAppAnalyzer(skip_treemap=False).analyze(
                 cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -1,3 +1,5 @@
+import logging
+
 from datetime import datetime
 from unittest.mock import Mock, patch
 
@@ -18,6 +20,7 @@ from launchpad.constants import (
 )
 from launchpad.sentry_client import SentryClient, SentryClientError
 from launchpad.size.models.android import AndroidAppInfo
+from launchpad.tracing import RequestLogFilter
 from launchpad.utils.objectstore import ObjectstoreConfig
 from launchpad.utils.statsd import FakeStatsd
 
@@ -242,8 +245,10 @@ class TestArtifactProcessorMessageHandling:
 
     @patch("launchpad.artifact_processor.SentryClient")
     @patch.object(ArtifactProcessor, "process_artifact")
-    def test_process_message_ios(self, mock_process, mock_sentry_client):
+    def test_process_message_ios(self, mock_process, mock_sentry_client, caplog):
         """Test processing iOS artifact messages."""
+        caplog.set_level(logging.INFO)
+        caplog.handler.addFilter(RequestLogFilter())
         fake_statsd = FakeStatsd()
         service_config = ServiceConfig(
             sentry_base_url="http://test.sentry.io",
@@ -263,6 +268,13 @@ class TestArtifactProcessorMessageHandling:
             "test-org-123",
             "test-project-ios",
             "ios-test-123",
+        )
+
+        started = next(r for r in caplog.records if r.getMessage().startswith("Processing artifact"))
+        assert (started.artifact_id, started.project_id, started.organization_id) == (
+            "ios-test-123",
+            "test-project-ios",
+            "test-org-123",
         )
 
         # Verify metrics were recorded

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -271,11 +271,8 @@ class TestArtifactProcessorMessageHandling:
         )
 
         started = next(r for r in caplog.records if r.getMessage().startswith("Processing artifact"))
-        assert (started.artifact_id, started.project_id, started.organization_id) == (
-            "ios-test-123",
-            "test-project-ios",
-            "test-org-123",
-        )
+        assert started.artifact_id == "ios-test-123"
+        assert not hasattr(started, "project_id")
 
         # Verify metrics were recorded
         calls = fake_statsd.calls

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,38 @@
+import logging
+
+from launchpad.tracing import RequestLogFilter, current_request_id, log_context, request_context
+
+
+def _filtered_record() -> logging.LogRecord:
+    record = logging.LogRecord("t", logging.INFO, __file__, 1, "msg", None, None)
+    RequestLogFilter().filter(record)
+    return record
+
+
+def test_log_context_fields_are_stamped_onto_records() -> None:
+    with log_context(artifact_id="123", project_id="p"):
+        record = _filtered_record()
+    assert record.artifact_id == "123"
+    assert record.project_id == "p"
+
+
+def test_log_context_fields_are_absent_outside_the_block() -> None:
+    with log_context(artifact_id="123"):
+        pass
+    assert not hasattr(_filtered_record(), "artifact_id")
+
+
+def test_nested_log_context_merges_fields() -> None:
+    with log_context(artifact_id="123"):
+        with log_context(project_id="p"):
+            record = _filtered_record()
+        outer = _filtered_record()
+    assert (record.artifact_id, record.project_id) == ("123", "p")
+    assert outer.artifact_id == "123" and not hasattr(outer, "project_id")
+
+
+def test_request_id_is_still_stamped_alongside_fields() -> None:
+    with request_context(), log_context(artifact_id="123"):
+        record = _filtered_record()
+        assert record.request_id == current_request_id()
+    assert record.artifact_id == "123"

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -9,12 +9,11 @@ def _filtered_record() -> logging.LogRecord:
     return record
 
 
-def test_request_context_stamps_request_id_and_fields_onto_records() -> None:
-    with request_context(artifact_id="123", project_id="p"):
+def test_request_context_stamps_request_id_and_artifact_id_onto_records() -> None:
+    with request_context(artifact_id="123"):
         record = _filtered_record()
         assert record.request_id == current_request_id()
     assert record.artifact_id == "123"
-    assert record.project_id == "p"
 
 
 def test_request_context_fields_are_absent_outside_the_block() -> None:
@@ -25,7 +24,7 @@ def test_request_context_fields_are_absent_outside_the_block() -> None:
     assert not hasattr(record, "request_id")
 
 
-def test_request_context_without_fields_only_stamps_request_id() -> None:
+def test_request_context_without_artifact_id_only_stamps_request_id() -> None:
     with request_context():
         record = _filtered_record()
     assert record.request_id

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,6 +1,6 @@
 import logging
 
-from launchpad.tracing import RequestLogFilter, current_request_id, log_context, request_context
+from launchpad.tracing import RequestLogFilter, current_request_id, request_context
 
 
 def _filtered_record() -> logging.LogRecord:
@@ -9,30 +9,24 @@ def _filtered_record() -> logging.LogRecord:
     return record
 
 
-def test_log_context_fields_are_stamped_onto_records() -> None:
-    with log_context(artifact_id="123", project_id="p"):
+def test_request_context_stamps_request_id_and_fields_onto_records() -> None:
+    with request_context(artifact_id="123", project_id="p"):
         record = _filtered_record()
+        assert record.request_id == current_request_id()
     assert record.artifact_id == "123"
     assert record.project_id == "p"
 
 
-def test_log_context_fields_are_absent_outside_the_block() -> None:
-    with log_context(artifact_id="123"):
+def test_request_context_fields_are_absent_outside_the_block() -> None:
+    with request_context(artifact_id="123"):
         pass
-    assert not hasattr(_filtered_record(), "artifact_id")
+    record = _filtered_record()
+    assert not hasattr(record, "artifact_id")
+    assert not hasattr(record, "request_id")
 
 
-def test_nested_log_context_merges_fields() -> None:
-    with log_context(artifact_id="123"):
-        with log_context(project_id="p"):
-            record = _filtered_record()
-        outer = _filtered_record()
-    assert (record.artifact_id, record.project_id) == ("123", "p")
-    assert outer.artifact_id == "123" and not hasattr(outer, "project_id")
-
-
-def test_request_id_is_still_stamped_alongside_fields() -> None:
-    with request_context(), log_context(artifact_id="123"):
+def test_request_context_without_fields_only_stamps_request_id() -> None:
+    with request_context():
         record = _filtered_record()
-        assert record.request_id == current_request_id()
-    assert record.artifact_id == "123"
+    assert record.request_id
+    assert not hasattr(record, "artifact_id")


### PR DESCRIPTION
Stacked on #663.

Finding a build's logs today means locating the "Processing artifact <id> (project: ..., org: ...)" line, reading its `request_id`, and filtering on that. The artifact id itself is only in message text, never a structured field.

This extends `request_context()` in `tracing.py` to take `**fields`, stored in a contextvar alongside the request id and reset together with it. The existing `RequestLogFilter` copies whatever fields are set onto each record, the same way it already stamps `request_id`. `process_message` enters it with `artifact_id`, so every line for the rest of the task carries it. Project and org ids stay in the processing log line and on the Sentry scope tags, since the artifact id alone is enough to find a whole build. The binary-analysis worker relay from #663 captures the same fields at creation and stamps them onto relayed worker records, so the per-binary lines carry them too.

Since Sentry's logging integration forwards every non-standard record attribute as a log attribute, `artifact_id:758251` in the Sentry Logs search returns the whole build, parent and workers, and the same field is present in the JSON lines GCP and Datadog ingest.

Covered by unit tests for the contextvar and filter (stamping, scoping, coexistence with `request_id`), an assertion on the `process_message` log line, and the existing forkserver relay test now also checking `artifact_id` on worker records.
