### PR TITLE
fix(size): Keep demangle parallelism inside binary analysis workers

### DIFF
--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -91,7 +91,6 @@ class _WorkerContext(NamedTuple):
 
 
 def _binary_worker_init(context: _WorkerContext) -> None:
-    os.environ["LAUNCHPAD_NO_PARALLEL_DEMANGLE"] = "true"
     setup_logging(verbose=context.verbose)
     if context.request_id is not None:
         bind_request_id(context.request_id)


### PR DESCRIPTION
Follow-up to #663. After the parallel binary analysis rolled out to EU, a re-upload of a customer iOS build hit the 900s task deadline. The 4-worker pool phase itself finished cleanly (18 binaries started, 17 completed within four seconds), but the main app binary, which has 1.6M Swift symbols, never completed: its demangle ran for 14 minutes until taskbroker killed the task. The same binary demangled in about 333s under the old serial analyzer, where the whole build took 387s.

The cause is the worker initializer setting `LAUNCHPAD_NO_PARALLEL_DEMANGLE=true`. That was added during review to bound subprocess count, so four workers could not each fan out to four `cwl-demangle` threads. But it turned the heaviest binary, which is the critical path, from four demangle threads into one, and 3200 sequential chunks do not fit under the deadline. Parallelism across binaries does not help when one binary dominates.

This drops the override so each worker keeps the same four demangle threads the serial path had. Worst case is sixteen concurrent `cwl-demangle` subprocesses on a 4-CPU pod while several heavy binaries overlap. Throughput is CPU-bound either way, so the phase does not get slower, and each subprocess handles a 500-symbol chunk and exits, so memory stays bounded. The remaining thing to watch is the 10s per-chunk timeout under contention, since timed-out chunks are silently dropped rather than failing the build; if those show up on large apps the fix is a longer chunk timeout, not restoring the cap.

Existing worker and parallel-vs-in-process integration tests pass; there was no test asserting the env var. To verify after deploy: re-upload the customer build and check its trace for completion and for any demangle timeout errors.
