### PR TITLE
feat(size): Drive binary analysis worker count from sentry-options

### DIFF
--- a/sentry-options/schemas/launchpad/schema.json
+++ b/sentry-options/schemas/launchpad/schema.json
@@ -5,8 +5,15 @@
     "projects.skip": {
       "type": "array",
       "default": [],
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Project IDs whose artifacts are skipped during processing. Unioned with the PROJECT_IDS_TO_SKIP environment variable so values set here take effect without a redeploy."
+    },
+    "size.binary_analysis.workers": {
+      "type": "integer",
+      "default": 4,
+      "description": "Number of worker processes for Apple per-binary analysis. 0 runs binaries in-process, one at a time."
     }
   }
 }

--- a/src/launchpad/artifact_processor.py
+++ b/src/launchpad/artifact_processor.py
@@ -278,7 +278,7 @@ class ArtifactProcessor:
         if isinstance(artifact, AndroidArtifact):
             return AndroidAnalyzer()
         elif isinstance(artifact, AppleArtifact):
-            return AppleAppAnalyzer()
+            return AppleAppAnalyzer(binary_analysis_workers=get_option("size.binary_analysis.workers", 4))
         else:
             raise ValueError(f"Unknown artifact kind {artifact}")
 

--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -124,6 +124,7 @@ class AppleAppAnalyzer:
         skip_treemap: bool = False,
         skip_image_analysis: bool = False,
         skip_insights: bool = False,
+        binary_analysis_workers: int = _DEFAULT_BINARY_ANALYSIS_WORKERS,
     ) -> None:
         """Initialize the Apple analyzer.
 
@@ -135,8 +136,10 @@ class AppleAppAnalyzer:
             skip_treemap: Skip treemap generation for hierarchical size analysis
             skip_image_analysis: Skip image analysis for faster processing
             skip_insights: Skip insights generation for faster analysis
+            binary_analysis_workers: Processes for per-binary analysis; 0 runs binaries in-process
         """
         self.working_dir = working_dir
+        self.binary_analysis_workers = binary_analysis_workers
         self.skip_swift_metadata = skip_swift_metadata
         self.skip_symbols = skip_symbols
         self.skip_component_analysis = skip_component_analysis
@@ -501,11 +504,7 @@ class AppleAppAnalyzer:
             return result
 
     def _binary_analysis_worker_count(self, num_binaries: int) -> int:
-        try:
-            configured = int(os.getenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", _DEFAULT_BINARY_ANALYSIS_WORKERS))
-        except ValueError:
-            configured = _DEFAULT_BINARY_ANALYSIS_WORKERS
-        return min(configured, num_binaries)
+        return min(self.binary_analysis_workers, num_binaries)
 
     def _analyze_binary_logged(
         self, binary_info: BinaryInfo, app_bundle_path: Path, extract_dir: SafeDirectory

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -167,29 +167,20 @@ class TestAppleAppSizes:
         assert kwargs["extra"]["insight"] == "dummy"
         assert "elapsed_s" in kwargs["extra"]
 
-    def test_binary_worker_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        analyzer = AppleAppAnalyzer()
-        assert analyzer._binary_analysis_worker_count(100) == 4
-        assert analyzer._binary_analysis_worker_count(2) == 2
-        assert analyzer._binary_analysis_worker_count(0) == 0
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "3")
-        assert analyzer._binary_analysis_worker_count(100) == 3
-        assert analyzer._binary_analysis_worker_count(2) == 2
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "0")
-        assert analyzer._binary_analysis_worker_count(100) == 0
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "nope")
-        assert analyzer._binary_analysis_worker_count(100) == 4
+    def test_binary_worker_count(self) -> None:
+        assert AppleAppAnalyzer()._binary_analysis_worker_count(100) == 4
+        assert AppleAppAnalyzer()._binary_analysis_worker_count(2) == 2
+        assert AppleAppAnalyzer()._binary_analysis_worker_count(0) == 0
+        assert AppleAppAnalyzer(binary_analysis_workers=3)._binary_analysis_worker_count(100) == 3
+        assert AppleAppAnalyzer(binary_analysis_workers=3)._binary_analysis_worker_count(2) == 2
+        assert AppleAppAnalyzer(binary_analysis_workers=0)._binary_analysis_worker_count(100) == 0
 
-    def test_parallel_binary_analysis_matches_in_process(
-        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "0")
-        in_process = AppleAppAnalyzer(skip_treemap=False).analyze(
+    def test_parallel_binary_analysis_matches_in_process(self, hackernews_xcarchive: Path) -> None:
+        in_process = AppleAppAnalyzer(skip_treemap=False, binary_analysis_workers=0).analyze(
             cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
         )
 
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "4")
-        parallel = AppleAppAnalyzer(skip_treemap=False).analyze(
+        parallel = AppleAppAnalyzer(skip_treemap=False, binary_analysis_workers=4).analyze(
             cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
         )
 
@@ -205,11 +196,10 @@ class TestAppleAppSizes:
         before capfd redirects it, so forkserver workers would write past the capture."""
         ctx = mp.get_context("spawn")
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
 
         with request_context():
             request_id = current_request_id()
-            AppleAppAnalyzer(skip_treemap=False).analyze(
+            AppleAppAnalyzer(skip_treemap=False, binary_analysis_workers=2).analyze(
                 cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
             )
 
@@ -238,7 +228,6 @@ class TestAppleAppSizes:
         endpoint carrying the parent's trace id."""
         ctx = mp.get_context("forkserver")
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
         with _SentryIngestStub() as stub:
             monkeypatch.setenv("LAUNCHPAD_ENV", "integration")
             monkeypatch.setenv("SENTRY_DSN", stub.dsn)
@@ -246,7 +235,7 @@ class TestAppleAppSizes:
             sentry_sdk.init(dsn=stub.dsn, traces_sample_rate=1.0, enable_logs=True)
             try:
                 with sentry_sdk.start_transaction(name="test") as transaction:
-                    AppleAppAnalyzer(skip_treemap=False).analyze(
+                    AppleAppAnalyzer(skip_treemap=False, binary_analysis_workers=2).analyze(
                         cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
                     )
                 sentry_sdk.flush()
@@ -266,7 +255,6 @@ class TestAppleAppSizes:
         timestamps; they must land on the task transaction and reflect real concurrency."""
         ctx = mp.get_context("forkserver")
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
-        monkeypatch.setenv("LAUNCHPAD_BINARY_ANALYSIS_WORKERS", "2")
         monkeypatch.setenv("LAUNCHPAD_ENV", "test")
         transport = _CapturingTransport()
         sentry_sdk.init(dsn="https://key@example.invalid/1", transport=transport, traces_sample_rate=1.0)
@@ -274,7 +262,7 @@ class TestAppleAppSizes:
             with sentry_sdk.start_transaction(name="test"):
                 artifact = cast(AppleArtifact, ArtifactFactory.from_path(hackernews_xcarchive))
                 binary_count = len(artifact.get_all_binary_paths())
-                AppleAppAnalyzer(skip_treemap=False).analyze(artifact)
+                AppleAppAnalyzer(skip_treemap=False, binary_analysis_workers=2).analyze(artifact)
             sentry_sdk.flush()
         finally:
             sentry_sdk.get_global_scope().set_client(None)

--- a/tests/unit/artifacts/test_artifact_processor.py
+++ b/tests/unit/artifacts/test_artifact_processor.py
@@ -10,7 +10,7 @@ from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 from launchpad.artifact_processor import ArtifactProcessor, ServiceConfig, _parse_build_number, get_service_config
 from launchpad.artifacts.android.aab import AAB
 from launchpad.artifacts.apple.zipped_xcarchive import ZippedXCArchive
-from launchpad.artifacts.artifact import Artifact
+from launchpad.artifacts.artifact import AppleArtifact, Artifact
 from launchpad.constants import (
     InstallableAppErrorCode,
     ProcessingErrorCode,
@@ -644,3 +644,16 @@ class TestGetServiceConfigProjectsToSkip:
         monkeypatch.setenv("PROJECT_IDS_TO_SKIP", "shared,env-only")
         with override_options("launchpad", {"projects.skip": ["shared", "opt-only"]}):
             assert get_service_config().projects_to_skip == ["shared", "env-only", "opt-only"]
+
+
+class TestCreateAnalyzerBinaryAnalysisWorkers:
+    def test_apple_analyzer_uses_schema_default(self):
+        processor = ArtifactProcessor(Mock(), Mock(), Mock())
+        analyzer = processor._create_analyzer(Mock(spec=AppleArtifact))
+        assert analyzer.binary_analysis_workers == 4
+
+    def test_apple_analyzer_uses_option_value(self):
+        processor = ArtifactProcessor(Mock(), Mock(), Mock())
+        with override_options("launchpad", {"size.binary_analysis.workers": 0}):
+            analyzer = processor._create_analyzer(Mock(spec=AppleArtifact))
+        assert analyzer.binary_analysis_workers == 0


### PR DESCRIPTION
Follow-up to #663 and #671. The choice between the process pool and the old in-process path for Apple per-binary analysis was controlled by a deploy-time env var. Changing it meant an ops PR and a rollout, which is the wrong shape for a rollout lever: the point of the switch is to flip a region back to serial quickly if the parallel path misbehaves, or to trim workers for a region with smaller pods, without redeploying.

This moves the knob to a sentry-option, `size.binary_analysis.workers`, using the wiring from #668. It's an integer with a schema default of 4; 0 selects the in-process path. The processor reads the option when it builds the analyzer and passes it as a constructor argument alongside the existing `skip_*` flags, so the size package stays free of the options client, the CLI keeps the default of four, and each task picks up the current value. The env var and its parsing are removed rather than kept as a second knob.

The paired getsentry/sentry-options-automator#9609 sets the value explicitly to 4 in launchpad's default values, so a later change, or a region override such as 0 for a serial baseline or 2 for a memory-constrained region, is a one-line edit there. That PR validates against this schema, so it merges after this one.

Tests: unit tests on the analyzer factory for the schema default and an overridden value via `override_options`, following the `projects.skip` tests; the worker-count and in-process-versus-parallel equivalence integration tests now set the count through the constructor, as do the worker-logging tests.
