### PR TITLE
feat(size): Log the binary analysis pool size at INFO

### DIFF
--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -213,7 +213,7 @@ class AppleAppAnalyzer:
                 extract_dir=artifact.get_extract_dir(),
             )
             if workers > 0:
-                logger.debug(f"Analyzing binaries with {workers} processes")
+                logger.info("size.apple.binary_analysis_workers", extra={"workers": workers})
                 executor = ProcessPoolExecutor(
                     max_workers=workers,
                     initializer=_binary_worker_init,

--- a/tests/integration/size/test_apple_app_sizes.py
+++ b/tests/integration/size/test_apple_app_sizes.py
@@ -190,12 +190,17 @@ class TestAppleAppSizes:
         assert in_process.treemap.model_dump_json() == parallel.treemap.model_dump_json()
 
     def test_worker_logs_reach_stdout_with_request_id(
-        self, hackernews_xcarchive: Path, monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+        self,
+        hackernews_xcarchive: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capfd: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Uses spawn rather than forkserver: the forkserver inherits stdout once at startup,
         before capfd redirects it, so forkserver workers would write past the capture."""
         ctx = mp.get_context("spawn")
         monkeypatch.setattr(apple, "ProcessPoolExecutor", functools.partial(ProcessPoolExecutor, mp_context=ctx))
+        caplog.set_level(logging.INFO, logger=apple.logger.name)
 
         with request_context():
             request_id = current_request_id()
@@ -208,6 +213,8 @@ class TestAppleAppSizes:
         assert completed
         assert all(d["request_id"] == request_id for d in completed)
         assert all(isinstance(d["elapsed_s"], float) for d in completed)
+        pool = [r for r in caplog.records if r.getMessage() == "size.apple.binary_analysis_workers"]
+        assert [r.workers for r in pool] == [2]
 
     def test_worker_logging_applies_third_party_suppression(self, capfd: pytest.CaptureFixture[str]) -> None:
         ctx = mp.get_context("spawn")


### PR DESCRIPTION
Follow-up to #672. With the Apple binary-analysis worker count now driven by the `size.binary_analysis.workers` option, there was no way to confirm from a build's logs which value it actually ran with: the only line that mentioned the count was at DEBUG, which Sentry Logs doesn't ingest.

This emits `size.apple.binary_analysis_workers` at INFO with a structured `workers` field when the pool is created. A region override, such as the `de` value in getsentry/sentry-options-automator#9610, can then be verified by filtering the build's logs on that message and reading the field, and the same line shows the default elsewhere.

The existing worker-stdout integration test now also asserts the line is emitted once with the configured count.
