### PR TITLE
perf(demangle): Raise chunk size to 5000 and split chunks on timeout

### DIFF
--- a/sentry-options/schemas/launchpad/schema.json
+++ b/sentry-options/schemas/launchpad/schema.json
@@ -14,6 +14,11 @@
       "type": "integer",
       "default": 4,
       "description": "Number of worker processes for Apple per-binary analysis. 0 runs binaries in-process, one at a time."
+    },
+    "size.demangle.chunk_size": {
+      "type": "integer",
+      "default": 5000,
+      "description": "Number of Swift symbols per cwl-demangle invocation. Larger chunks mean fewer process spawns; a chunk that times out is retried in smaller pieces."
     }
   }
 }

--- a/src/launchpad/utils/apple/cwl_demangle.py
+++ b/src/launchpad/utils/apple/cwl_demangle.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
+from launchpad.options import get_option
 from launchpad.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -18,8 +19,7 @@ logger = get_logger(__name__)
 # Default timeout for cwl-demangle subprocess (in seconds)
 DEFAULT_DEMANGLE_TIMEOUT = int(os.environ.get("LAUNCHPAD_DEMANGLE_TIMEOUT", "10"))
 
-# Default chunk size for batching symbols
-DEFAULT_CHUNK_SIZE = int(os.environ.get("LAUNCHPAD_DEMANGLE_CHUNK_SIZE", "5000"))
+DEFAULT_CHUNK_SIZE = 5000
 
 SPLIT_FACTOR = 10
 
@@ -89,8 +89,7 @@ class CwlDemangler:
         names = self.queue.copy()
         self.queue.clear()
 
-        # Process in chunks to avoid potential issues with large inputs
-        chunk_size = DEFAULT_CHUNK_SIZE
+        chunk_size = get_option("size.demangle.chunk_size", DEFAULT_CHUNK_SIZE)
         total_chunks = (len(names) + chunk_size - 1) // chunk_size
 
         chunks: List[Tuple[List[str], int]] = []

--- a/src/launchpad/utils/apple/cwl_demangle.py
+++ b/src/launchpad/utils/apple/cwl_demangle.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -18,7 +19,14 @@ logger = get_logger(__name__)
 DEFAULT_DEMANGLE_TIMEOUT = int(os.environ.get("LAUNCHPAD_DEMANGLE_TIMEOUT", "10"))
 
 # Default chunk size for batching symbols
-DEFAULT_CHUNK_SIZE = int(os.environ.get("LAUNCHPAD_DEMANGLE_CHUNK_SIZE", "500"))
+DEFAULT_CHUNK_SIZE = int(os.environ.get("LAUNCHPAD_DEMANGLE_CHUNK_SIZE", "5000"))
+
+SPLIT_FACTOR = 10
+
+
+# The timeout default was tuned for 500-symbol chunks; larger chunks scale it proportionally.
+def chunk_timeout(num_symbols: int) -> float:
+    return DEFAULT_DEMANGLE_TIMEOUT * max(1, num_symbols / 500)
 
 
 @dataclass
@@ -128,6 +136,21 @@ class CwlDemangler:
 
         return results
 
+    def _demangle_after_timeout(self, chunk: List[str], chunk_idx: int, elapsed: float) -> Dict[str, CwlDemangleResult]:
+        if len(chunk) == 1:
+            logger.exception("cwl-demangle subprocess timed out", extra={"chunk_idx": chunk_idx, "elapsed": elapsed})
+            return {}
+
+        logger.warning(
+            "cwl-demangle chunk timed out, retrying in smaller pieces",
+            extra={"chunk_idx": chunk_idx, "chunk_len": len(chunk), "elapsed": elapsed},
+        )
+        piece = math.ceil(len(chunk) / SPLIT_FACTOR)
+        results: Dict[str, CwlDemangleResult] = {}
+        for i in range(0, len(chunk), piece):
+            results.update(self._demangle_chunk(chunk[i : i + piece], chunk_idx))
+        return results
+
     def _demangle_chunk(self, chunk: List[str], chunk_idx: int) -> Dict[str, CwlDemangleResult]:
         if not chunk:
             return {}
@@ -164,14 +187,10 @@ class CwlDemangler:
 
             try:
                 result = subprocess.run(
-                    command_parts, capture_output=True, text=True, check=True, timeout=DEFAULT_DEMANGLE_TIMEOUT
+                    command_parts, capture_output=True, text=True, check=True, timeout=chunk_timeout(len(chunk))
                 )
             except subprocess.TimeoutExpired:
-                elapsed = time.time() - start_time
-                logger.exception(
-                    "cwl-demangle subprocess timed out", extra={"chunk_idx": chunk_idx, "elapsed": elapsed}
-                )
-                return {}
+                return self._demangle_after_timeout(chunk, chunk_idx, time.time() - start_time)
             except subprocess.CalledProcessError:
                 elapsed = time.time() - start_time
                 logger.exception("cwl-demangle subprocess failed", extra={"chunk_idx": chunk_idx, "elapsed": elapsed})

--- a/tests/integration/test_cwl_demangle.py
+++ b/tests/integration/test_cwl_demangle.py
@@ -1,7 +1,10 @@
 import os
+import subprocess
 
+from pathlib import Path
 from unittest import mock
 
+from launchpad.utils.apple import cwl_demangle
 from launchpad.utils.apple.cwl_demangle import CwlDemangler, CwlDemangleResult
 
 
@@ -114,6 +117,31 @@ class TestCwlDemangler:
             result = demangler.demangle_all()
             # Should succeed with custom timeout
             assert len(result) == 100
+
+    def test_chunk_timeout_scales_with_chunk_length(self):
+        assert cwl_demangle.chunk_timeout(1) == 10
+        assert cwl_demangle.chunk_timeout(500) == 10
+        assert cwl_demangle.chunk_timeout(5000) == 100
+
+    def test_timed_out_chunk_is_split_so_only_the_slow_symbol_is_dropped(self):
+        symbols = self._generate_symbols(50)
+        slow = "_$s4Slow6SymbolC"
+        real_run = subprocess.run
+
+        def run_with_simulated_hang(cmd, **kwargs):
+            names = Path(cmd[cmd.index("--input") + 1]).read_text().splitlines()
+            if slow in names:
+                raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+            return real_run(cmd, **kwargs)
+
+        demangler = CwlDemangler()
+        for symbol in [*symbols[:25], slow, *symbols[25:]]:
+            demangler.add_name(symbol)
+        with mock.patch.object(cwl_demangle.subprocess, "run", side_effect=run_with_simulated_hang):
+            result = demangler.demangle_all()
+
+        assert slow not in result
+        assert set(result) == set(symbols)
 
     def _generate_symbols(self, count: int) -> list[str]:
         """Generate valid Swift mangled symbols."""

--- a/tests/integration/test_cwl_demangle.py
+++ b/tests/integration/test_cwl_demangle.py
@@ -4,6 +4,8 @@ import subprocess
 from pathlib import Path
 from unittest import mock
 
+from sentry_options.testing import override_options
+
 from launchpad.utils.apple import cwl_demangle
 from launchpad.utils.apple.cwl_demangle import CwlDemangler, CwlDemangleResult
 
@@ -142,6 +144,20 @@ class TestCwlDemangler:
 
         assert slow not in result
         assert set(result) == set(symbols)
+
+    def test_chunk_size_comes_from_sentry_option(self):
+        demangler = CwlDemangler()
+        for symbol in self._generate_symbols(10):
+            demangler.add_name(symbol)
+        seen: list[int] = []
+        with (
+            override_options("launchpad", {"size.demangle.chunk_size": 3}),
+            mock.patch.object(
+                demangler, "_demangle_chunk", side_effect=lambda chunk, _idx: seen.append(len(chunk)) or {}
+            ),
+        ):
+            demangler.demangle_all()
+        assert seen == [3, 3, 3, 1]
 
     def _generate_symbols(self, count: int) -> list[str]:
         """Generate valid Swift mangled symbols."""


### PR DESCRIPTION
The demangler spawns `cwl-demangle` once per chunk of 500 symbols. #483 measured 5000 as faster; #540 cut it to 500 so a 10s timeout, added after a build with pathological SwiftUI symbols made single chunks run for minutes, would drop fewer symbols. That hang was fixed in the demangler itself twelve days later (getsentry/CwlDemangle v1.1.0, #547). On v1.1.0 a 1.6M-symbol binary has no outliers left: worst symbol 0.92s, worst 5000-symbol chunk 3.3s. The small chunks now only cost ~3,200 process spawns per large binary.

This raises the chunk size to 5000, makes the timeout proportional to chunk length with the 10s floor (500 symbols keep today's budget, 5000 get 100s), and on timeout retries the chunk in ten pieces down to single symbols, so a bad symbol loses only itself instead of 499 neighbours. The chunk size is a sentry-option, `size.demangle.chunk_size`, read per batch like the worker count in #672; the env var is gone. `LAUNCHPAD_DEMANGLE_TIMEOUT` is unchanged.

Measured on the 1.6M-symbol binary, cwl-demangle v1.1.0, 4 threads, two runs each:

| | chunk 500 | chunk 5000 |
|---|---|---|
| demangler alone | 60.1s / 59.2s | 38.7s / 38.4s |
| full build | 168s / 159s | 112s / 107s |
| main binary | 112s | 63s |
| results, timeouts | 1,416,994, 0 | 1,416,994, 0 |

Treemap JSON and install sizes are byte-identical. A 295-binary app with small binaries is neutral (46s binary phase either way). The gain is spawn count: the subprocess is 96% of the loop and the same 50,000 symbols take 9.3s as one invocation vs 12.0s as 100. A process pool was evaluated and rejected; threads already release the GIL and returning 1.4M results would cost ~7.5s of pickling.

Tests: timeout scaling, a simulated hanging symbol in a 51-symbol batch that loses only itself, and chunking under `override_options`. The paired automator PR is getsentry/sentry-options-automator#9641.
