### PR TITLE
perf(size): Remove per-binary full GC

### DIFF
--- a/src/launchpad/size/analyzers/apple.py
+++ b/src/launchpad/size/analyzers/apple.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import gc
 import logging
 import os
 import tempfile
@@ -518,7 +517,6 @@ class AppleAppAnalyzer:
         start = time.monotonic()
         binary = self._analyze_binary(binary_info, app_bundle_path)
         elapsed_s = time.monotonic() - start
-        gc.collect()
         if binary is not None:
             self._log_binary_completed(binary_info, binary, elapsed_s)
         return _TimedBinary(binary, started_at, started_at + elapsed_s)


### PR DESCRIPTION
The explicit python gc collection appears to scale poorly when processing apps with many binaries. I tested against an app with ~300 binaries, and the gc.collect() duration kept increasing over time taking up meaningful amounts of CPU time. This was particularly noticeable prior to allowing concurrent binary processing, as the garbage collection pauses in some cases could end up taking nearly half the overall binary analysis time. Even after the concurrent binary analysis processing change, this change still appeared to reduce overall wall time a bit and reduce CPU use without causing a meaningful regression in peak memory use.

The theory about the mechanism is that the heap keeps growing as we process lots of binaries (which is unavoidable to some extent though we're not currently trying very hard to mitigate that I don't think), and the gc scans therefore take longer over time.